### PR TITLE
Add MCP server for agents

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: dokimos-dev/dokimos-server
 
 jobs:
   build-and-push:
@@ -25,6 +24,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      matrix:
+        include:
+          - image: dokimos-dev/dokimos-server
+            dockerfile: dokimos-server/Dockerfile
+          - image: dokimos-dev/dokimos-mcp-server
+            dockerfile: dokimos-mcp-server/Dockerfile
 
     steps:
       - name: Checkout repository
@@ -47,7 +54,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'release' || github.event.inputs.tag == 'latest' || github.event.inputs.latest == 'true' }}
             type=semver,pattern={{version}}
@@ -58,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: dokimos-server/Dockerfile
+          file: ${{ matrix.dockerfile }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ dokimos/
 ├── dokimos-koog/           # Koog AI agent integration (Kotlin)
 ├── dokimos-kotlin/         # Kotlin DSL for experiment builders
 ├── dokimos-server-client/  # HTTP client for the experiment server
-├── dokimos-mcp-server/     # MCP server exposing evaluation tools over stdio (Claude Desktop, etc.)
+├── dokimos-mcp-server/     # MCP server exposing evaluation tools over stdio to any MCP client
 ├── dokimos-server/         # REST API + React web UI (Spring Boot + PostgreSQL)
 │   └── frontend/           # React + Vite + Tailwind CSS frontend
 ├── dokimos-examples/       # Runnable examples for all frameworks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ dokimos/
 ├── dokimos-koog/           # Koog AI agent integration (Kotlin)
 ├── dokimos-kotlin/         # Kotlin DSL for experiment builders
 ├── dokimos-server-client/  # HTTP client for the experiment server
+├── dokimos-mcp-server/     # MCP server exposing evaluation tools over stdio (Claude Desktop, etc.)
 ├── dokimos-server/         # REST API + React web UI (Spring Boot + PostgreSQL)
 │   └── frontend/           # React + Vite + Tailwind CSS frontend
 ├── dokimos-examples/       # Runnable examples for all frameworks
@@ -123,6 +124,13 @@ When working on the core framework, understand these central types in `dokimos-c
 
 - Uses async batching: background thread batches HTTP calls every 500ms or 10 items.
 - Implements exponential backoff retries (3 attempts).
+
+### dokimos-mcp-server
+
+- Exposes four tools over MCP stdio: `run_evaluation`, `list_experiments`, `compare_runs`, `get_failing_queries`.
+- Not published to Maven Central. Packaged as a shaded executable JAR via the shade plugin.
+- **Stdout is reserved for the JSON-RPC stream.** All logging goes to stderr, and `logback.xml` registers a `NopStatusListener` so logback's own status output never reaches stdout (the shaded JAR loses logback's version metadata, which would otherwise trigger a status dump to stdout).
+- `run_evaluation` requires `OPENAI_API_KEY`. Runs are persisted to `~/.dokimos/mcp-results.json` via `JsonResultStore`.
 
 ### dokimos-examples
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Build custom evaluators by extending `BaseEvaluator`, or use `LLMJudgeEvaluator`
 | `dokimos-koog`          | Koog integration using `AIAgent` as judge.                           |
 | `dokimos-server`        | Optional API and web UI for tracking experiments over time           |
 | `dokimos-server-client` | Client library for reporting to the Dokimos server                   |
+| `dokimos-mcp-server`    | MCP server exposing evaluation tools to LLM agents (Claude Desktop)  |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Build custom evaluators by extending `BaseEvaluator`, or use `LLMJudgeEvaluator`
 | `dokimos-koog`          | Koog integration using `AIAgent` as judge.                           |
 | `dokimos-server`        | Optional API and web UI for tracking experiments over time           |
 | `dokimos-server-client` | Client library for reporting to the Dokimos server                   |
-| `dokimos-mcp-server`    | MCP server exposing evaluation tools to LLM agents (Claude Desktop)  |
+| `dokimos-mcp-server`    | MCP server exposing evaluation tools to any MCP client               |
 
 ## Installation
 

--- a/docs/docs/mcp-server.md
+++ b/docs/docs/mcp-server.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 7
+---
+
+# MCP Server
+
+The Dokimos MCP server exposes the evaluation framework as tools for LLM agents. Connect it to any [Model Context Protocol](https://modelcontextprotocol.io) client (Claude Desktop, Claude Code, Cursor, and others) to run evaluations, compare runs, and inspect failures from a conversation.
+
+## Run with Docker
+
+The published image needs no JDK and no build. Add this to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "dokimos": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "OPENAI_API_KEY",
+        "-v", "dokimos-mcp:/home/dokimos/.dokimos",
+        "-v", "/absolute/path/to/datasets:/data:ro",
+        "ghcr.io/dokimos-dev/dokimos-mcp-server:latest"
+      ],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+Two mounts matter:
+
+- `dokimos-mcp:/home/dokimos/.dokimos` is a named volume that persists run results across restarts, so `list_experiments` and `compare_runs` keep working.
+- `/absolute/path/to/datasets:/data:ro` makes your dataset files visible inside the container. Pass `dataset_path` as the in-container path, for example `/data/qa-pairs.json`.
+
+The `-i` flag is required, since the server speaks JSON-RPC over stdin and stdout.
+
+:::tip No Docker?
+You can also build a self-contained JAR from source and run it with `java -jar`. See the [module README](https://github.com/dokimos-dev/dokimos/tree/master/dokimos-mcp-server).
+:::
+
+## Tools
+
+### run_evaluation
+
+Runs a dataset through a model and evaluator, then returns summary metrics and a run ID.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `dataset_path` | string | yes | | Path to dataset file (`.json`, `.csv`, `.jsonl`) |
+| `model` | string | no | `gpt-4o-mini` | OpenAI model name |
+| `temperature` | number | no | `0.0` | Sampling temperature |
+| `evaluator` | string | no | `exact_match` | `exact_match` or `llm_judge` |
+| `criteria` | string | no | | Evaluation criteria (for `llm_judge`) |
+| `threshold` | number | no | `0.7` | Pass/fail score threshold |
+| `experiment_name` | string | no | `mcp-evaluation` | Name for the experiment |
+
+### list_experiments
+
+Lists past evaluation runs, with optional filtering by dataset name.
+
+### compare_runs
+
+Compares two runs side by side, reporting metric deltas and flagging regressions.
+
+### get_failing_queries
+
+Returns the examples from a run whose evaluator scores fell below a threshold, with input, expected and actual output, and per-evaluator detail.
+
+## Storage
+
+Runs persist to `~/.dokimos/mcp-results.json` (inside the container, `/home/dokimos/.dokimos`). Mount a volume there to keep history between runs.
+
+## Example session
+
+Once connected, you can drive evaluations conversationally:
+
+```
+> Run an evaluation on /data/qa-pairs.json using gpt-4o with the llm_judge evaluator
+> Show me the failing queries from that run
+> Now compare it with run abc123
+```

--- a/docs/docs/mcp-server.md
+++ b/docs/docs/mcp-server.md
@@ -50,7 +50,7 @@ Runs a dataset through a model and evaluator, then returns summary metrics and a
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `dataset_path` | string | yes | | Path to dataset file (`.json`, `.csv`, `.jsonl`) |
-| `model` | string | no | `gpt-4o-mini` | OpenAI model name |
+| `model` | string | no | `gpt-5.5` | OpenAI model name |
 | `temperature` | number | no | `0.0` | Sampling temperature |
 | `evaluator` | string | no | `exact_match` | `exact_match` or `llm_judge` |
 | `criteria` | string | no | | Evaluation criteria (for `llm_judge`) |
@@ -78,7 +78,7 @@ Runs persist to `~/.dokimos/mcp-results.json` (inside the container, `/home/doki
 Once connected, you can drive evaluations conversationally:
 
 ```
-> Run an evaluation on /data/qa-pairs.json using gpt-4o with the llm_judge evaluator
+> Run an evaluation on /data/qa-pairs.json using gpt-5.5 with the llm_judge evaluator
 > Show me the failing queries from that run
 > Now compare it with run abc123
 ```

--- a/dokimos-mcp-server/Dockerfile
+++ b/dokimos-mcp-server/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
 
-# Copy all pom.xml files so Maven can parse the multi-module structure
+# Copy every module pom.xml so Maven can parse the multi-module reactor
 COPY pom.xml ./pom.xml
 COPY dokimos-core/pom.xml ./dokimos-core/pom.xml
 COPY dokimos-junit/pom.xml ./dokimos-junit/pom.xml
@@ -11,24 +11,22 @@ COPY dokimos-spring-ai/pom.xml ./dokimos-spring-ai/pom.xml
 COPY dokimos-koog/pom.xml ./dokimos-koog/pom.xml
 COPY dokimos-kotlin/pom.xml ./dokimos-kotlin/pom.xml
 COPY dokimos-server-client/pom.xml ./dokimos-server-client/pom.xml
-COPY dokimos-server-client/src ./dokimos-server-client/src
 COPY dokimos-server/pom.xml ./dokimos-server/pom.xml
 COPY dokimos-examples/pom.xml ./dokimos-examples/pom.xml
 COPY dokimos-mcp-server/pom.xml ./dokimos-mcp-server/pom.xml
 
 # Download dependencies (cached layer)
-RUN mvn dependency:go-offline -pl dokimos-server -am -q || true
+RUN mvn dependency:go-offline -pl dokimos-mcp-server -am -q || true
 
-# Copy source code needed for the server
+# Copy source needed for the MCP server and its dependency
 COPY dokimos-core/src ./dokimos-core/src
-COPY dokimos-server/src ./dokimos-server/src
-COPY dokimos-server/frontend ./dokimos-server/frontend
+COPY dokimos-mcp-server/src ./dokimos-mcp-server/src
 
-# Build the application
-RUN mvn clean package -pl dokimos-server -am -DskipTests
+# Build the shaded executable JAR
+RUN mvn clean package -pl dokimos-mcp-server -am -DskipTests
 
-# Extract only the Spring Boot fat JAR
-RUN find dokimos-server/target -maxdepth 1 -name "dokimos-server-*.jar" \
+# Extract the shaded JAR (skip sources, javadoc, and the unshaded original)
+RUN find dokimos-mcp-server/target -maxdepth 1 -name "dokimos-mcp-server-*.jar" \
     ! -name "*-sources.jar" ! -name "*-javadoc.jar" \
     | head -1 | xargs -I{} cp {} /app/app.jar
 
@@ -37,22 +35,16 @@ FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 
-# Install curl for healthcheck
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# Create non-root user
-RUN groupadd -r dokimos && useradd -r -g dokimos dokimos
+# Run as a non-root user with a writable home for the results store
+RUN groupadd -r dokimos && useradd -r -g dokimos -m -d /home/dokimos dokimos
+ENV HOME=/home/dokimos
 
 COPY --from=builder /app/app.jar app.jar
 
-RUN chown -R dokimos:dokimos /app
+# Run results persist here; mount a volume to keep them across container runs
+RUN mkdir -p /home/dokimos/.dokimos && chown -R dokimos:dokimos /home/dokimos /app
 
 USER dokimos
 
-EXPOSE 8080
-
-HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8080/actuator/health || exit 1
-
+# The server speaks JSON-RPC over stdio. Run with: docker run -i --rm ...
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/dokimos-mcp-server/README.md
+++ b/dokimos-mcp-server/README.md
@@ -1,0 +1,157 @@
+# dokimos-mcp-server
+
+MCP server that exposes the dokimos evaluation framework as tools for LLM agents. Connect it to Claude Desktop (or any MCP client) and run evaluations, compare runs, and inspect failures from a conversation.
+
+## Prerequisites
+
+- Java 17+
+- `OPENAI_API_KEY` environment variable (required for `run_evaluation`)
+
+## Build
+
+From the repository root:
+
+```bash
+mvn package -pl dokimos-mcp-server -am -DskipTests
+```
+
+This produces a self-contained JAR at:
+
+```
+dokimos-mcp-server/target/dokimos-mcp-server-0.15.0-SNAPSHOT.jar
+```
+
+## Usage
+
+### Claude Desktop
+
+Add this to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "dokimos": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/to/dokimos-mcp-server-0.15.0-SNAPSHOT.jar"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "dokimos": {
+      "command": "java",
+      "args": ["-jar", "/absolute/path/to/dokimos-mcp-server-0.15.0-SNAPSHOT.jar"],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+### Standalone
+
+```bash
+export OPENAI_API_KEY='sk-...'
+java -jar dokimos-mcp-server/target/dokimos-mcp-server-0.15.0-SNAPSHOT.jar
+```
+
+The server communicates over stdio (JSON-RPC). It is not meant to be run interactively.
+
+## Tools
+
+### run_evaluation
+
+Run an evaluation against a dataset.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `dataset_path` | string | yes | | Path to dataset file (.json, .csv, .jsonl) |
+| `model` | string | no | gpt-4o-mini | OpenAI model name |
+| `temperature` | number | no | 0.0 | Sampling temperature |
+| `evaluator` | string | no | exact_match | `exact_match` or `llm_judge` |
+| `criteria` | string | no | | Evaluation criteria (for `llm_judge`) |
+| `threshold` | number | no | 0.7 | Pass/fail score threshold |
+| `experiment_name` | string | no | mcp-evaluation | Name for the experiment |
+
+Returns a run ID, pass rate, and per-evaluator average scores.
+
+### list_experiments
+
+List past evaluation runs.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `limit` | integer | no | 20 | Max runs to return |
+| `dataset_name` | string | no | | Filter by dataset name |
+
+### compare_runs
+
+Compare two runs side by side with metric deltas.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `run_id_a` | string | yes | Baseline run ID |
+| `run_id_b` | string | yes | Comparison run ID |
+
+Flags regressions when metrics decrease between runs.
+
+### get_failing_queries
+
+Inspect failing examples from a run.
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `run_id` | string | yes | | Run ID to inspect |
+| `threshold` | number | no | 0.5 | Score threshold for failures |
+
+Returns each failing query with its input, expected/actual output, and evaluator scores.
+
+## Storage
+
+Run results are persisted to `~/.dokimos/mcp-results.json`. This file is created automatically on first use.
+
+## Dataset Format
+
+Datasets follow the standard dokimos format. Minimal JSON example:
+
+```json
+{
+  "name": "my-dataset",
+  "description": "QA pairs for testing",
+  "examples": [
+    {"input": "What is 2+2?", "expectedOutput": "4"},
+    {"input": "Capital of France?", "expectedOutput": "Paris"}
+  ]
+}
+```
+
+CSV and JSONL formats are also supported. See the [dokimos documentation](https://dokimos.dev) for details.
+
+## Example Session
+
+Once connected to an MCP client, you can run evaluations conversationally:
+
+```
+> Run an evaluation on /data/qa-pairs.json using gpt-4o with the llm_judge evaluator
+
+[calls run_evaluation with dataset_path=/data/qa-pairs.json, model=gpt-4o, evaluator=llm_judge]
+
+> Show me the failing queries from that run
+
+[calls get_failing_queries with the run ID from the previous result]
+
+> Now compare it with run abc123
+
+[calls compare_runs with the two run IDs]
+```

--- a/dokimos-mcp-server/README.md
+++ b/dokimos-mcp-server/README.md
@@ -2,7 +2,38 @@
 
 MCP server that exposes the dokimos evaluation framework as tools for LLM agents. Connect it to Claude Desktop (or any MCP client) and run evaluations, compare runs, and inspect failures from a conversation.
 
-## Prerequisites
+## Run with Docker
+
+The published image needs no JDK and no build. Point your MCP client at it:
+
+```json
+{
+  "mcpServers": {
+    "dokimos": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "OPENAI_API_KEY",
+        "-v", "dokimos-mcp:/home/dokimos/.dokimos",
+        "-v", "/absolute/path/to/datasets:/data:ro",
+        "ghcr.io/dokimos-dev/dokimos-mcp-server:latest"
+      ],
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      }
+    }
+  }
+}
+```
+
+Two mounts matter:
+
+- `dokimos-mcp:/home/dokimos/.dokimos` is a named volume that persists run results across container restarts, so `list_experiments` and `compare_runs` keep working.
+- `/absolute/path/to/datasets:/data:ro` makes your dataset files visible inside the container. Pass `dataset_path` as the in-container path, for example `/data/qa-pairs.json`.
+
+`-i` is required: the server speaks JSON-RPC over stdin/stdout.
+
+## Prerequisites (build from source)
 
 - Java 17+
 - `OPENAI_API_KEY` environment variable (required for `run_evaluation`)

--- a/dokimos-mcp-server/README.md
+++ b/dokimos-mcp-server/README.md
@@ -108,7 +108,7 @@ Run an evaluation against a dataset.
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `dataset_path` | string | yes | | Path to dataset file (.json, .csv, .jsonl) |
-| `model` | string | no | gpt-4o-mini | OpenAI model name |
+| `model` | string | no | gpt-5.5 | OpenAI model name |
 | `temperature` | number | no | 0.0 | Sampling temperature |
 | `evaluator` | string | no | exact_match | `exact_match` or `llm_judge` |
 | `criteria` | string | no | | Evaluation criteria (for `llm_judge`) |
@@ -174,9 +174,9 @@ CSV and JSONL formats are also supported. See the [dokimos documentation](https:
 Once connected to an MCP client, you can run evaluations conversationally:
 
 ```
-> Run an evaluation on /data/qa-pairs.json using gpt-4o with the llm_judge evaluator
+> Run an evaluation on /data/qa-pairs.json using gpt-5.5 with the llm_judge evaluator
 
-[calls run_evaluation with dataset_path=/data/qa-pairs.json, model=gpt-4o, evaluator=llm_judge]
+[calls run_evaluation with dataset_path=/data/qa-pairs.json, model=gpt-5.5, evaluator=llm_judge]
 
 > Show me the failing queries from that run
 

--- a/dokimos-mcp-server/pom.xml
+++ b/dokimos-mcp-server/pom.xml
@@ -20,10 +20,11 @@
     </properties>
 
     <dependencies>
-        <!-- MCP SDK with Jackson 2 -->
+        <!-- MCP SDK with Jackson 2 (used only by this module) -->
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-json-jackson2</artifactId>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- Dokimos core evaluation framework -->

--- a/dokimos-mcp-server/pom.xml
+++ b/dokimos-mcp-server/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.dokimos</groupId>
+        <artifactId>dokimos-parent</artifactId>
+        <version>0.15.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dokimos-mcp-server</artifactId>
+    <name>Dokimos :: MCP Server</name>
+    <description>MCP server exposing dokimos evaluation tools for LLM agents</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <mcp.sdk.version>1.1.0</mcp.sdk.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP SDK with Jackson 2 -->
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
+            <version>${mcp.sdk.version}</version>
+        </dependency>
+
+        <!-- Dokimos core evaluation framework -->
+        <dependency>
+            <groupId>dev.dokimos</groupId>
+            <artifactId>dokimos-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- OpenAI for LLM task execution -->
+        <dependency>
+            <groupId>com.openai</groupId>
+            <artifactId>openai-java</artifactId>
+        </dependency>
+
+        <!-- JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.16</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>dev.dokimos.mcp.DokimosMcpServer</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/dokimos-mcp-server/pom.xml
+++ b/dokimos-mcp-server/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
-        <mcp.sdk.version>1.1.0</mcp.sdk.version>
     </properties>
 
     <dependencies>
@@ -25,7 +24,6 @@
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-json-jackson2</artifactId>
-            <version>${mcp.sdk.version}</version>
         </dependency>
 
         <!-- Dokimos core evaluation framework -->
@@ -59,7 +57,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.16</version>
         </dependency>
 
         <!-- Test -->

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
@@ -1,0 +1,182 @@
+package dev.dokimos.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.dokimos.mcp.store.JsonResultStore;
+import dev.dokimos.mcp.store.ResultStore;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MCP server that exposes dokimos evaluation tools over stdio transport.
+ *
+ * <p>Provides four tools: run_evaluation, list_experiments, compare_runs, get_failing_queries.
+ * Designed for use with Claude Desktop or any MCP client.
+ */
+public class DokimosMcpServer {
+
+    private static final Logger log = LoggerFactory.getLogger(DokimosMcpServer.class);
+
+    public static void main(String[] args) {
+        ObjectMapper json = new ObjectMapper();
+        json.registerModule(new JavaTimeModule());
+
+        ResultStore store = new JsonResultStore();
+        ToolHandlers handlers = new ToolHandlers(store, json);
+
+        JacksonMcpJsonMapper jsonMapper = new JacksonMcpJsonMapper(new ObjectMapper());
+        StdioServerTransportProvider transport = new StdioServerTransportProvider(jsonMapper);
+
+        McpSyncServer server = McpServer.sync(transport)
+                .serverInfo("dokimos-mcp-server", "0.1.0")
+                .capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+                .toolCall(runEvaluationTool(), (exchange, request) -> handlers.handleRunEvaluation(request.arguments()))
+                .toolCall(
+                        listExperimentsTool(),
+                        (exchange, request) -> handlers.handleListExperiments(request.arguments()))
+                .toolCall(compareRunsTool(), (exchange, request) -> handlers.handleCompareRuns(request.arguments()))
+                .toolCall(
+                        getFailingQueriesTool(),
+                        (exchange, request) -> handlers.handleGetFailingQueries(request.arguments()))
+                .build();
+
+        log.info("dokimos MCP server started (stdio transport)");
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Shutting down dokimos MCP server");
+            server.close();
+        }));
+
+        try {
+            Thread.currentThread().join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static Tool runEvaluationTool() {
+        return Tool.builder()
+                .name("run_evaluation")
+                .description(
+                        "Run a dokimos LLM evaluation. Loads a dataset, calls the specified model for each example, "
+                                + "evaluates the outputs, and returns summary metrics with a run ID for future reference.")
+                .inputSchema(new McpSchema.JsonSchema(
+                        "object",
+                        Map.of(
+                                "dataset_path",
+                                        Map.of(
+                                                "type",
+                                                "string",
+                                                "description",
+                                                "Path to the dataset file (JSON, CSV, or JSONL)"),
+                                "model",
+                                        Map.of(
+                                                "type",
+                                                "string",
+                                                "description",
+                                                "OpenAI model name (default: gpt-4o-mini)"),
+                                "temperature",
+                                        Map.of(
+                                                "type",
+                                                "number",
+                                                "description",
+                                                "Sampling temperature, 0.0 to 2.0 (default: 0.0)"),
+                                "evaluator",
+                                        Map.of(
+                                                "type",
+                                                "string",
+                                                "description",
+                                                "Evaluator type: exact_match or llm_judge (default: exact_match)"),
+                                "criteria",
+                                        Map.of(
+                                                "type",
+                                                "string",
+                                                "description",
+                                                "Evaluation criteria for llm_judge evaluator"),
+                                "threshold",
+                                        Map.of(
+                                                "type",
+                                                "number",
+                                                "description",
+                                                "Score threshold for pass/fail (default: 0.7)"),
+                                "experiment_name",
+                                        Map.of(
+                                                "type",
+                                                "string",
+                                                "description",
+                                                "Name for this experiment (default: mcp-evaluation)")),
+                        List.of("dataset_path"),
+                        null,
+                        null,
+                        null))
+                .build();
+    }
+
+    private static Tool listExperimentsTool() {
+        return Tool.builder()
+                .name("list_experiments")
+                .description(
+                        "List past dokimos evaluation runs. Returns run IDs, timestamps, dataset names, and summary metrics.")
+                .inputSchema(new McpSchema.JsonSchema(
+                        "object",
+                        Map.of(
+                                "limit",
+                                        Map.of(
+                                                "type",
+                                                "integer",
+                                                "description",
+                                                "Maximum number of runs to return (default: 20)"),
+                                "dataset_name", Map.of("type", "string", "description", "Filter by dataset name")),
+                        List.of(),
+                        null,
+                        null,
+                        null))
+                .build();
+    }
+
+    private static Tool compareRunsTool() {
+        return Tool.builder()
+                .name("compare_runs")
+                .description("Compare two evaluation runs side by side. Shows metric deltas and flags regressions.")
+                .inputSchema(new McpSchema.JsonSchema(
+                        "object",
+                        Map.of(
+                                "run_id_a", Map.of("type", "string", "description", "First run ID (baseline)"),
+                                "run_id_b", Map.of("type", "string", "description", "Second run ID (comparison)")),
+                        List.of("run_id_a", "run_id_b"),
+                        null,
+                        null,
+                        null))
+                .build();
+    }
+
+    private static Tool getFailingQueriesTool() {
+        return Tool.builder()
+                .name("get_failing_queries")
+                .description(
+                        "Get failing queries from an evaluation run. Returns examples where evaluator scores fell below the threshold.")
+                .inputSchema(new McpSchema.JsonSchema(
+                        "object",
+                        Map.of(
+                                "run_id", Map.of("type", "string", "description", "Run ID to inspect"),
+                                "threshold",
+                                        Map.of(
+                                                "type",
+                                                "number",
+                                                "description",
+                                                "Score threshold below which queries are failing (default: 0.5)")),
+                        List.of("run_id"),
+                        null,
+                        null,
+                        null))
+                .build();
+    }
+}

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
@@ -78,11 +78,7 @@ public class DokimosMcpServer {
                                                 "description",
                                                 "Path to the dataset file (JSON, CSV, or JSONL)"),
                                 "model",
-                                        Map.of(
-                                                "type",
-                                                "string",
-                                                "description",
-                                                "OpenAI model name (default: gpt-4o-mini)"),
+                                        Map.of("type", "string", "description", "OpenAI model name (default: gpt-5.5)"),
                                 "temperature",
                                         Map.of(
                                                 "type",

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * MCP server that exposes dokimos evaluation tools over stdio transport.
  *
  * <p>Provides four tools: run_evaluation, list_experiments, compare_runs, get_failing_queries.
- * Designed for use with Claude Desktop or any MCP client.
+ * Designed for use with any MCP client.
  */
 public class DokimosMcpServer {
 

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
@@ -1,0 +1,454 @@
+package dev.dokimos.mcp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.ChatModel;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import dev.dokimos.core.Dataset;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.Evaluator;
+import dev.dokimos.core.Example;
+import dev.dokimos.core.Experiment;
+import dev.dokimos.core.ExperimentResult;
+import dev.dokimos.core.ItemResult;
+import dev.dokimos.core.Task;
+import dev.dokimos.core.evaluators.ExactMatchEvaluator;
+import dev.dokimos.core.evaluators.LLMJudgeEvaluator;
+import dev.dokimos.mcp.store.ResultStore;
+import dev.dokimos.mcp.store.RunRecord;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements the four MCP tool handlers for the dokimos evaluation framework.
+ */
+public class ToolHandlers {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolHandlers.class);
+
+    private final ResultStore store;
+    private final ObjectMapper json;
+
+    public ToolHandlers(ResultStore store, ObjectMapper json) {
+        this.store = store;
+        this.json = json;
+    }
+
+    /**
+     * Runs an evaluation: loads a dataset, calls an LLM, evaluates results, and persists the run.
+     */
+    public McpSchema.CallToolResult handleRunEvaluation(Map<String, Object> arguments) {
+        try {
+            String datasetPath = requireString(arguments, "dataset_path");
+            String model = stringOrDefault(arguments, "model", "gpt-4o-mini");
+            double temperature = doubleOrDefault(arguments, "temperature", 0.0);
+            String evaluatorType = stringOrDefault(arguments, "evaluator", "exact_match");
+            String criteria = stringOrDefault(arguments, "criteria", null);
+            double threshold = doubleOrDefault(arguments, "threshold", 0.7);
+            String experimentName = stringOrDefault(arguments, "experiment_name", "mcp-evaluation");
+
+            Dataset dataset = loadDataset(datasetPath);
+            OpenAIClient openai = buildOpenAIClient();
+            Task task = buildTask(openai, model, temperature);
+            List<Evaluator> evaluators = buildEvaluators(evaluatorType, criteria, threshold, openai, model);
+
+            ExperimentResult result = Experiment.builder()
+                    .name(experimentName)
+                    .dataset(dataset)
+                    .task(task)
+                    .evaluators(evaluators)
+                    .build()
+                    .run();
+
+            RunRecord record = toRunRecord(result, dataset, datasetPath, model, temperature);
+            store.save(record);
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("run_id", record.id());
+            response.put("experiment_name", experimentName);
+            response.put("dataset", dataset.name());
+            response.put("model", model);
+            response.put("total_examples", result.totalCount());
+            response.put("pass_rate", result.passRate());
+            response.put("pass_count", (int) result.passCount());
+            response.put("fail_count", (int) result.failCount());
+
+            Map<String, Double> scores = new LinkedHashMap<>();
+            for (String name : result.evaluatorNames()) {
+                scores.put(name, result.averageScore(name));
+            }
+            response.put("average_scores", scores);
+
+            return textResult(response);
+        } catch (Exception e) {
+            return errorResult("run_evaluation failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Lists past evaluation runs with optional filtering.
+     */
+    public McpSchema.CallToolResult handleListExperiments(Map<String, Object> arguments) {
+        try {
+            int limit = intOrDefault(arguments, "limit", 20);
+            String datasetName = stringOrDefault(arguments, "dataset_name", null);
+
+            List<RunRecord> runs = store.list(datasetName, limit);
+
+            List<Map<String, Object>> results = new ArrayList<>();
+            for (RunRecord run : runs) {
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("run_id", run.id());
+                entry.put("timestamp", run.timestamp().toString());
+                entry.put("experiment_name", run.experimentName());
+                entry.put("dataset", run.datasetName());
+                entry.put("total_examples", run.totalCount());
+                entry.put("pass_rate", run.passRate());
+                entry.put("average_scores", run.averageScores());
+                results.add(entry);
+            }
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("count", results.size());
+            response.put("runs", results);
+
+            return textResult(response);
+        } catch (Exception e) {
+            return errorResult("list_experiments failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Compares two runs side by side, showing metric deltas and regressions.
+     */
+    public McpSchema.CallToolResult handleCompareRuns(Map<String, Object> arguments) {
+        try {
+            String idA = requireString(arguments, "run_id_a");
+            String idB = requireString(arguments, "run_id_b");
+
+            RunRecord runA = store.get(idA).orElseThrow(() -> new IllegalArgumentException("Run not found: " + idA));
+            RunRecord runB = store.get(idB).orElseThrow(() -> new IllegalArgumentException("Run not found: " + idB));
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("run_a", summarizeRun(runA));
+            response.put("run_b", summarizeRun(runB));
+
+            // Compute metric deltas
+            Map<String, Object> comparison = new LinkedHashMap<>();
+
+            double passRateDelta = runB.passRate() - runA.passRate();
+            comparison.put(
+                    "pass_rate",
+                    Map.of(
+                            "run_a", runA.passRate(),
+                            "run_b", runB.passRate(),
+                            "delta", round(passRateDelta),
+                            "status", classifyDelta(passRateDelta)));
+
+            // Per evaluator comparisons
+            Map<String, Object> evaluatorDeltas = new LinkedHashMap<>();
+            List<String> regressions = new ArrayList<>();
+
+            for (String evaluator : allEvaluatorNames(runA, runB)) {
+                double scoreA = runA.averageScores().getOrDefault(evaluator, 0.0);
+                double scoreB = runB.averageScores().getOrDefault(evaluator, 0.0);
+                double delta = scoreB - scoreA;
+                String status = classifyDelta(delta);
+
+                evaluatorDeltas.put(
+                        evaluator,
+                        Map.of(
+                                "run_a", scoreA,
+                                "run_b", scoreB,
+                                "delta", round(delta),
+                                "status", status));
+
+                if ("REGRESSION".equals(status)) {
+                    regressions.add(evaluator);
+                }
+            }
+
+            comparison.put("evaluators", evaluatorDeltas);
+            comparison.put("regressions", regressions);
+            comparison.put("has_regressions", !regressions.isEmpty());
+
+            response.put("comparison", comparison);
+
+            return textResult(response);
+        } catch (Exception e) {
+            return errorResult("compare_runs failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Returns failing queries from a run, filtered by score threshold.
+     */
+    public McpSchema.CallToolResult handleGetFailingQueries(Map<String, Object> arguments) {
+        try {
+            String runId = requireString(arguments, "run_id");
+            double threshold = doubleOrDefault(arguments, "threshold", 0.5);
+
+            RunRecord run = store.get(runId).orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
+
+            List<Map<String, Object>> failing = new ArrayList<>();
+            for (RunRecord.ItemDetail item : run.items()) {
+                boolean belowThreshold = item.evaluations().stream().anyMatch(e -> e.score() < threshold);
+
+                if (belowThreshold || !item.success()) {
+                    Map<String, Object> entry = new LinkedHashMap<>();
+                    entry.put("input", item.input());
+                    entry.put("expected_output", item.expectedOutput());
+                    entry.put("actual_output", item.actualOutput());
+                    entry.put("success", item.success());
+
+                    List<Map<String, Object>> evals = new ArrayList<>();
+                    for (RunRecord.EvalDetail eval : item.evaluations()) {
+                        Map<String, Object> evalEntry = new LinkedHashMap<>();
+                        evalEntry.put("evaluator", eval.evaluator());
+                        evalEntry.put("score", eval.score());
+                        evalEntry.put("success", eval.success());
+                        evalEntry.put("reason", eval.reason());
+                        evals.add(evalEntry);
+                    }
+                    entry.put("evaluations", evals);
+                    failing.add(entry);
+                }
+            }
+
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("run_id", runId);
+            response.put("threshold", threshold);
+            response.put("total_examples", run.totalCount());
+            response.put("failing_count", failing.size());
+            response.put("failing_queries", failing);
+
+            return textResult(response);
+        } catch (Exception e) {
+            return errorResult("get_failing_queries failed: " + e.getMessage());
+        }
+    }
+
+    // --- Internal helpers ---
+
+    private Dataset loadDataset(String datasetPath) throws IOException {
+        Path path = Path.of(datasetPath);
+        String fileName = path.getFileName().toString().toLowerCase();
+
+        if (fileName.endsWith(".json")) {
+            return Dataset.fromJson(path);
+        } else if (fileName.endsWith(".csv")) {
+            return Dataset.fromCsv(path);
+        } else if (fileName.endsWith(".jsonl")) {
+            return Dataset.fromJsonl(path);
+        }
+
+        throw new IllegalArgumentException(
+                "Unsupported dataset format: " + fileName + " (expected .json, .csv, or .jsonl)");
+    }
+
+    private OpenAIClient buildOpenAIClient() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("OPENAI_API_KEY environment variable is required for evaluations");
+        }
+        return OpenAIOkHttpClient.builder().apiKey(apiKey).build();
+    }
+
+    private Task buildTask(OpenAIClient openai, String model, double temperature) {
+        return example -> {
+            String input = example.input();
+            if (input == null || input.isBlank()) {
+                return Map.of("output", "");
+            }
+
+            ChatCompletion completion = openai.chat()
+                    .completions()
+                    .create(ChatCompletionCreateParams.builder()
+                            .model(ChatModel.of(model))
+                            .temperature(temperature)
+                            .addUserMessage(input)
+                            .build());
+
+            String output = completion.choices().get(0).message().content().orElse("");
+            return Map.of("output", output);
+        };
+    }
+
+    private List<Evaluator> buildEvaluators(
+            String type, String criteria, double threshold, OpenAIClient openai, String model) {
+        List<Evaluator> evaluators = new ArrayList<>();
+
+        switch (type.toLowerCase()) {
+            case "exact_match" -> {
+                evaluators.add(
+                        ExactMatchEvaluator.builder().threshold(threshold).build());
+            }
+            case "llm_judge" -> {
+                if (criteria == null || criteria.isBlank()) {
+                    criteria = "Is the actual output correct and complete compared to the expected output?";
+                }
+                evaluators.add(LLMJudgeEvaluator.builder()
+                        .judge(prompt -> {
+                            ChatCompletion c = openai.chat()
+                                    .completions()
+                                    .create(ChatCompletionCreateParams.builder()
+                                            .model(ChatModel.of(model))
+                                            .temperature(0.0)
+                                            .addUserMessage(prompt)
+                                            .build());
+                            return c.choices().get(0).message().content().orElse("");
+                        })
+                        .criteria(criteria)
+                        .threshold(threshold)
+                        .build());
+            }
+            default ->
+                throw new IllegalArgumentException(
+                        "Unknown evaluator: " + type + " (supported: exact_match, llm_judge)");
+        }
+
+        return evaluators;
+    }
+
+    private RunRecord toRunRecord(
+            ExperimentResult result, Dataset dataset, String datasetPath, String model, double temperature) {
+        String runId = UUID.randomUUID().toString().substring(0, 8);
+
+        Map<String, Double> averageScores = new LinkedHashMap<>();
+        for (String name : result.evaluatorNames()) {
+            averageScores.put(name, result.averageScore(name));
+        }
+
+        List<RunRecord.ItemDetail> items = new ArrayList<>();
+        for (ItemResult item : result.itemResults()) {
+            Example ex = item.example();
+
+            List<RunRecord.EvalDetail> evals = new ArrayList<>();
+            for (EvalResult eval : item.evalResults()) {
+                evals.add(new RunRecord.EvalDetail(eval.name(), eval.score(), eval.success(), eval.reason()));
+            }
+
+            items.add(new RunRecord.ItemDetail(
+                    ex.input(),
+                    ex.expectedOutput(),
+                    item.actualOutputs().getOrDefault("output", "").toString(),
+                    item.success(),
+                    evals));
+        }
+
+        Map<String, Object> modelConfig = new LinkedHashMap<>();
+        modelConfig.put("model", model);
+        modelConfig.put("temperature", temperature);
+
+        return new RunRecord(
+                runId,
+                Instant.now(),
+                result.name(),
+                dataset.name(),
+                datasetPath,
+                modelConfig,
+                result.passRate(),
+                result.totalCount(),
+                (int) result.passCount(),
+                (int) result.failCount(),
+                averageScores,
+                items);
+    }
+
+    private Map<String, Object> summarizeRun(RunRecord run) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("run_id", run.id());
+        summary.put("timestamp", run.timestamp().toString());
+        summary.put("experiment_name", run.experimentName());
+        summary.put("dataset", run.datasetName());
+        summary.put("model", run.modelConfig().getOrDefault("model", "unknown"));
+        summary.put("pass_rate", run.passRate());
+        summary.put("total_examples", run.totalCount());
+        return summary;
+    }
+
+    private List<String> allEvaluatorNames(RunRecord a, RunRecord b) {
+        List<String> names = new ArrayList<>(a.averageScores().keySet());
+        for (String name : b.averageScores().keySet()) {
+            if (!names.contains(name)) {
+                names.add(name);
+            }
+        }
+        return names;
+    }
+
+    private String classifyDelta(double delta) {
+        if (delta > 0.001) {
+            return "IMPROVED";
+        } else if (delta < -0.001) {
+            return "REGRESSION";
+        }
+        return "UNCHANGED";
+    }
+
+    private double round(double value) {
+        return Math.round(value * 10000.0) / 10000.0;
+    }
+
+    private McpSchema.CallToolResult textResult(Object content) {
+        try {
+            String text = json.writerWithDefaultPrettyPrinter().writeValueAsString(content);
+            return new McpSchema.CallToolResult(
+                    List.of(new McpSchema.TextContent(null, text, null)), false, null, null);
+        } catch (JsonProcessingException e) {
+            return errorResult("Failed to serialize response: " + e.getMessage());
+        }
+    }
+
+    private McpSchema.CallToolResult errorResult(String message) {
+        log.error(message);
+        return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(null, message, null)), true, null, null);
+    }
+
+    private static String requireString(Map<String, Object> args, String key) {
+        Object value = args.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing required parameter: " + key);
+        }
+        return value.toString();
+    }
+
+    private static String stringOrDefault(Map<String, Object> args, String key, String defaultValue) {
+        Object value = args.get(key);
+        return value != null ? value.toString() : defaultValue;
+    }
+
+    private static double doubleOrDefault(Map<String, Object> args, String key, double defaultValue) {
+        Object value = args.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Number n) {
+            return n.doubleValue();
+        }
+        return Double.parseDouble(value.toString());
+    }
+
+    private static int intOrDefault(Map<String, Object> args, String key, int defaultValue) {
+        Object value = args.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Number n) {
+            return n.intValue();
+        }
+        return Integer.parseInt(value.toString());
+    }
+}

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
@@ -240,8 +240,6 @@ public class ToolHandlers {
         }
     }
 
-    // --- Internal helpers ---
-
     private Dataset loadDataset(String datasetPath) throws IOException {
         Path path = Path.of(datasetPath);
         String fileName = path.getFileName().toString().toLowerCase();

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
@@ -52,7 +52,7 @@ public class ToolHandlers {
     public McpSchema.CallToolResult handleRunEvaluation(Map<String, Object> arguments) {
         try {
             String datasetPath = requireString(arguments, "dataset_path");
-            String model = stringOrDefault(arguments, "model", "gpt-4o-mini");
+            String model = stringOrDefault(arguments, "model", "gpt-5.5");
             double temperature = doubleOrDefault(arguments, "temperature", 0.0);
             String evaluatorType = stringOrDefault(arguments, "evaluator", "exact_match");
             String criteria = stringOrDefault(arguments, "criteria", null);

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/JsonResultStore.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/JsonResultStore.java
@@ -1,0 +1,115 @@
+package dev.dokimos.mcp.store;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stores run records as a JSON array in a local file.
+ * Default location: ~/.dokimos/mcp-results.json
+ */
+public class JsonResultStore implements ResultStore {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonResultStore.class);
+
+    private final Path filePath;
+    private final ObjectMapper mapper;
+    private final Object lock = new Object();
+
+    public JsonResultStore() {
+        this(defaultPath());
+    }
+
+    public JsonResultStore(Path filePath) {
+        this.filePath = filePath;
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new JavaTimeModule());
+        this.mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        this.mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        ensureParentDir();
+    }
+
+    private static Path defaultPath() {
+        return Path.of(System.getProperty("user.home"), ".dokimos", "mcp-results.json");
+    }
+
+    private void ensureParentDir() {
+        try {
+            Files.createDirectories(filePath.getParent());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create storage directory: " + filePath.getParent(), e);
+        }
+    }
+
+    @Override
+    public void save(RunRecord record) {
+        synchronized (lock) {
+            List<RunRecord> records = loadAll();
+            records.removeIf(r -> r.id().equals(record.id()));
+            records.add(record);
+            writeAll(records);
+        }
+    }
+
+    @Override
+    public Optional<RunRecord> get(String runId) {
+        synchronized (lock) {
+            return loadAll().stream().filter(r -> r.id().equals(runId)).findFirst();
+        }
+    }
+
+    @Override
+    public List<RunRecord> list(String datasetName, int limit) {
+        synchronized (lock) {
+            List<RunRecord> records = loadAll();
+            records.sort(Comparator.comparing(RunRecord::timestamp).reversed());
+
+            if (datasetName != null && !datasetName.isBlank()) {
+                records = records.stream()
+                        .filter(r -> datasetName.equals(r.datasetName()))
+                        .toList();
+            }
+
+            if (limit > 0 && records.size() > limit) {
+                records = records.subList(0, limit);
+            }
+
+            return records;
+        }
+    }
+
+    private List<RunRecord> loadAll() {
+        if (!Files.exists(filePath)) {
+            return new ArrayList<>();
+        }
+        try {
+            byte[] bytes = Files.readAllBytes(filePath);
+            if (bytes.length == 0) {
+                return new ArrayList<>();
+            }
+            return new ArrayList<>(mapper.readValue(bytes, new TypeReference<List<RunRecord>>() {}));
+        } catch (IOException e) {
+            log.warn("Failed to read results file, starting fresh: {}", e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    private void writeAll(List<RunRecord> records) {
+        try {
+            mapper.writeValue(filePath.toFile(), records);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write results: " + filePath, e);
+        }
+    }
+}

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/ResultStore.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/ResultStore.java
@@ -1,0 +1,29 @@
+package dev.dokimos.mcp.store;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Persistence layer for evaluation run records.
+ */
+public interface ResultStore {
+
+    /**
+     * Saves a run record. Overwrites if a record with the same ID exists.
+     */
+    void save(RunRecord record);
+
+    /**
+     * Returns a run by ID, or empty if not found.
+     */
+    Optional<RunRecord> get(String runId);
+
+    /**
+     * Lists runs, most recent first.
+     *
+     * @param datasetName optional filter by dataset name (null for all)
+     * @param limit       maximum number to return (0 for all)
+     * @return matching records
+     */
+    List<RunRecord> list(String datasetName, int limit);
+}

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/RunRecord.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/RunRecord.java
@@ -1,0 +1,58 @@
+package dev.dokimos.mcp.store;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Persistent record of a single evaluation run.
+ *
+ * @param id            unique run identifier
+ * @param timestamp     when the run completed
+ * @param experimentName name given to the experiment
+ * @param datasetName   name of the dataset used
+ * @param datasetPath   filesystem path to the dataset
+ * @param modelConfig   model name, temperature, etc.
+ * @param passRate      overall pass rate (0.0 to 1.0)
+ * @param totalCount    number of examples evaluated
+ * @param passCount     number of passing examples
+ * @param failCount     number of failing examples
+ * @param averageScores per evaluator average scores
+ * @param items         per example details
+ */
+public record RunRecord(
+        String id,
+        Instant timestamp,
+        String experimentName,
+        String datasetName,
+        String datasetPath,
+        Map<String, Object> modelConfig,
+        double passRate,
+        int totalCount,
+        int passCount,
+        int failCount,
+        Map<String, Double> averageScores,
+        List<ItemDetail> items) {
+
+    /**
+     * Detail for a single evaluated example.
+     *
+     * @param input          the input query
+     * @param expectedOutput the expected answer
+     * @param actualOutput   the model's answer
+     * @param success        whether all evaluators passed
+     * @param evaluations    per evaluator results
+     */
+    public record ItemDetail(
+            String input, String expectedOutput, String actualOutput, boolean success, List<EvalDetail> evaluations) {}
+
+    /**
+     * Single evaluator result for one example.
+     *
+     * @param evaluator evaluator name
+     * @param score     numeric score
+     * @param success   pass or fail
+     * @param reason    explanation
+     */
+    public record EvalDetail(String evaluator, double score, boolean success, String reason) {}
+}

--- a/dokimos-mcp-server/src/main/resources/logback.xml
+++ b/dokimos-mcp-server/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDERR" />
+    </root>
+</configuration>

--- a/dokimos-mcp-server/src/main/resources/logback.xml
+++ b/dokimos-mcp-server/src/main/resources/logback.xml
@@ -1,4 +1,7 @@
 <configuration>
+    <!-- Stdout is reserved for the JSON-RPC stream; silence logback's own status output. -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>
         <encoder>

--- a/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/ToolHandlersTest.java
+++ b/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/ToolHandlersTest.java
@@ -1,0 +1,212 @@
+package dev.dokimos.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.dokimos.mcp.store.JsonResultStore;
+import dev.dokimos.mcp.store.ResultStore;
+import dev.dokimos.mcp.store.RunRecord;
+import io.modelcontextprotocol.spec.McpSchema;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ToolHandlersTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ToolHandlers handlers;
+    private ResultStore store;
+    private ObjectMapper json;
+
+    @BeforeEach
+    void setUp() {
+        json = new ObjectMapper();
+        json.registerModule(new JavaTimeModule());
+        store = new JsonResultStore(tempDir.resolve("test-results.json"));
+        handlers = new ToolHandlers(store, json);
+    }
+
+    @Test
+    void listExperimentsEmpty() throws Exception {
+        McpSchema.CallToolResult result = handlers.handleListExperiments(Map.of());
+        Map<String, Object> response = parseResponse(result);
+
+        assertThat(response.get("count")).isEqualTo(0);
+        assertThat((List<?>) response.get("runs")).isEmpty();
+    }
+
+    @Test
+    void listExperimentsWithData() throws Exception {
+        store.save(sampleRecord("r1", "exp-1", "ds-alpha"));
+        store.save(sampleRecord("r2", "exp-2", "ds-beta"));
+
+        McpSchema.CallToolResult result = handlers.handleListExperiments(Map.of());
+        Map<String, Object> response = parseResponse(result);
+
+        assertThat(response.get("count")).isEqualTo(2);
+    }
+
+    @Test
+    void listExperimentsFilterByDataset() throws Exception {
+        store.save(sampleRecord("r1", "exp-1", "alpha"));
+        store.save(sampleRecord("r2", "exp-2", "beta"));
+
+        McpSchema.CallToolResult result = handlers.handleListExperiments(Map.of("dataset_name", "alpha"));
+        Map<String, Object> response = parseResponse(result);
+
+        assertThat(response.get("count")).isEqualTo(1);
+    }
+
+    @Test
+    void listExperimentsWithLimit() throws Exception {
+        store.save(sampleRecord("r1", "exp-1", "ds"));
+        store.save(sampleRecord("r2", "exp-2", "ds"));
+        store.save(sampleRecord("r3", "exp-3", "ds"));
+
+        McpSchema.CallToolResult result = handlers.handleListExperiments(Map.of("limit", 2));
+        Map<String, Object> response = parseResponse(result);
+
+        assertThat(response.get("count")).isEqualTo(2);
+    }
+
+    @Test
+    void compareRuns() throws Exception {
+        store.save(sampleRecord("run-a", "exp", "ds", 0.6, Map.of("Exact Match", 0.6)));
+        store.save(sampleRecord("run-b", "exp", "ds", 0.8, Map.of("Exact Match", 0.8)));
+
+        McpSchema.CallToolResult result = handlers.handleCompareRuns(Map.of("run_id_a", "run-a", "run_id_b", "run-b"));
+        Map<String, Object> response = parseResponse(result);
+
+        assertThat(response).containsKey("comparison");
+        Map<String, Object> comparison = asMap(response.get("comparison"));
+        assertThat(comparison.get("has_regressions")).isEqualTo(false);
+
+        Map<String, Object> passRateComp = asMap(comparison.get("pass_rate"));
+        assertThat(passRateComp.get("status")).isEqualTo("IMPROVED");
+    }
+
+    @Test
+    void compareRunsDetectsRegression() throws Exception {
+        store.save(sampleRecord("run-a", "exp", "ds", 0.9, Map.of("Exact Match", 0.9)));
+        store.save(sampleRecord("run-b", "exp", "ds", 0.5, Map.of("Exact Match", 0.5)));
+
+        McpSchema.CallToolResult result = handlers.handleCompareRuns(Map.of("run_id_a", "run-a", "run_id_b", "run-b"));
+        Map<String, Object> response = parseResponse(result);
+
+        Map<String, Object> comparison = asMap(response.get("comparison"));
+        assertThat(comparison.get("has_regressions")).isEqualTo(true);
+        assertThat((List<?>) comparison.get("regressions"))
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST)
+                .contains("Exact Match");
+    }
+
+    @Test
+    void compareRunsMissingId() {
+        McpSchema.CallToolResult result = handlers.handleCompareRuns(Map.of("run_id_a", "nope", "run_id_b", "nah"));
+
+        assertThat(result.isError()).isTrue();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).contains("Run not found");
+    }
+
+    @Test
+    void getFailingQueries() throws Exception {
+        RunRecord.EvalDetail passing = new RunRecord.EvalDetail("EM", 1.0, true, "matched");
+        RunRecord.EvalDetail failing = new RunRecord.EvalDetail("EM", 0.0, false, "no match");
+
+        RunRecord record = new RunRecord(
+                "run-fail",
+                Instant.now(),
+                "exp",
+                "ds",
+                "/ds.json",
+                Map.of(),
+                0.5,
+                2,
+                1,
+                1,
+                Map.of("EM", 0.5),
+                List.of(
+                        new RunRecord.ItemDetail("q1", "a1", "a1", true, List.of(passing)),
+                        new RunRecord.ItemDetail("q2", "a2", "wrong", false, List.of(failing))));
+        store.save(record);
+
+        McpSchema.CallToolResult result = handlers.handleGetFailingQueries(Map.of("run_id", "run-fail"));
+        Map<String, Object> response = parseResponse(result);
+
+        assertThat(response.get("failing_count")).isEqualTo(1);
+        List<?> queries = (List<?>) response.get("failing_queries");
+        assertThat(queries).hasSize(1);
+
+        Map<String, Object> failedItem = asMap(queries.get(0));
+        assertThat(failedItem.get("input")).isEqualTo("q2");
+        assertThat(failedItem.get("actual_output")).isEqualTo("wrong");
+    }
+
+    @Test
+    void getFailingQueriesMissingRun() {
+        McpSchema.CallToolResult result = handlers.handleGetFailingQueries(Map.of("run_id", "no-such-run"));
+
+        assertThat(result.isError()).isTrue();
+    }
+
+    @Test
+    void runEvaluationMissingDatasetPath() {
+        McpSchema.CallToolResult result = handlers.handleRunEvaluation(Map.of());
+
+        assertThat(result.isError()).isTrue();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).contains("dataset_path");
+    }
+
+    @Test
+    void runEvaluationBadDatasetFormat() {
+        McpSchema.CallToolResult result = handlers.handleRunEvaluation(Map.of("dataset_path", "/some/file.txt"));
+
+        assertThat(result.isError()).isTrue();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).contains("Unsupported dataset format");
+    }
+
+    private Map<String, Object> parseResponse(McpSchema.CallToolResult result) throws Exception {
+        assertThat(result.isError()).isFalse();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        return json.readValue(text, new TypeReference<>() {});
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object obj) {
+        return (Map<String, Object>) obj;
+    }
+
+    private static RunRecord sampleRecord(String id, String experiment, String dataset) {
+        return sampleRecord(id, experiment, dataset, 0.75, Map.of("Exact Match", 0.75));
+    }
+
+    private static RunRecord sampleRecord(
+            String id, String experiment, String dataset, double passRate, Map<String, Double> scores) {
+        int total = 4;
+        int pass = (int) (total * passRate);
+        return new RunRecord(
+                id,
+                Instant.now(),
+                experiment,
+                dataset,
+                "/data/" + dataset + ".json",
+                Map.of("model", "gpt-4o-mini"),
+                passRate,
+                total,
+                pass,
+                total - pass,
+                scores,
+                List.of());
+    }
+}

--- a/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/store/JsonResultStoreTest.java
+++ b/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/store/JsonResultStoreTest.java
@@ -1,0 +1,143 @@
+package dev.dokimos.mcp.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JsonResultStoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    private JsonResultStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new JsonResultStore(tempDir.resolve("test-results.json"));
+    }
+
+    @Test
+    void saveAndGet() {
+        RunRecord record = sampleRecord("run-1", "test-experiment", "dataset-a");
+
+        store.save(record);
+
+        Optional<RunRecord> loaded = store.get("run-1");
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().experimentName()).isEqualTo("test-experiment");
+        assertThat(loaded.get().datasetName()).isEqualTo("dataset-a");
+        assertThat(loaded.get().passRate()).isEqualTo(0.75);
+    }
+
+    @Test
+    void getMissing() {
+        assertThat(store.get("nonexistent")).isEmpty();
+    }
+
+    @Test
+    void saveOverwritesSameId() {
+        store.save(sampleRecord("run-1", "exp-v1", "dataset-a"));
+        store.save(sampleRecord("run-1", "exp-v2", "dataset-a"));
+
+        List<RunRecord> all = store.list(null, 0);
+        assertThat(all).hasSize(1);
+        assertThat(all.get(0).experimentName()).isEqualTo("exp-v2");
+    }
+
+    @Test
+    void listReturnsNewestFirst() {
+        store.save(sampleRecord("run-old", "exp", "ds", Instant.parse("2025-01-01T00:00:00Z")));
+        store.save(sampleRecord("run-new", "exp", "ds", Instant.parse("2025-06-01T00:00:00Z")));
+
+        List<RunRecord> all = store.list(null, 0);
+        assertThat(all).hasSize(2);
+        assertThat(all.get(0).id()).isEqualTo("run-new");
+        assertThat(all.get(1).id()).isEqualTo("run-old");
+    }
+
+    @Test
+    void listFiltersByDatasetName() {
+        store.save(sampleRecord("run-1", "exp", "alpha"));
+        store.save(sampleRecord("run-2", "exp", "beta"));
+        store.save(sampleRecord("run-3", "exp", "alpha"));
+
+        List<RunRecord> filtered = store.list("alpha", 0);
+        assertThat(filtered).hasSize(2);
+        assertThat(filtered).allMatch(r -> r.datasetName().equals("alpha"));
+    }
+
+    @Test
+    void listRespectsLimit() {
+        store.save(sampleRecord("run-1", "exp", "ds", Instant.parse("2025-01-01T00:00:00Z")));
+        store.save(sampleRecord("run-2", "exp", "ds", Instant.parse("2025-02-01T00:00:00Z")));
+        store.save(sampleRecord("run-3", "exp", "ds", Instant.parse("2025-03-01T00:00:00Z")));
+
+        List<RunRecord> limited = store.list(null, 2);
+        assertThat(limited).hasSize(2);
+        assertThat(limited.get(0).id()).isEqualTo("run-3");
+    }
+
+    @Test
+    void persistsAcrossInstances() {
+        Path file = tempDir.resolve("persist-test.json");
+        JsonResultStore store1 = new JsonResultStore(file);
+        store1.save(sampleRecord("run-1", "exp", "ds"));
+
+        JsonResultStore store2 = new JsonResultStore(file);
+        assertThat(store2.get("run-1")).isPresent();
+    }
+
+    @Test
+    void itemDetailsRoundTrip() {
+        RunRecord.EvalDetail eval = new RunRecord.EvalDetail("Exact Match", 1.0, true, "Matched");
+        RunRecord.ItemDetail item = new RunRecord.ItemDetail("What is 2+2?", "4", "4", true, List.of(eval));
+
+        RunRecord record = new RunRecord(
+                "run-items",
+                Instant.now(),
+                "exp",
+                "ds",
+                "/path/to/ds.json",
+                Map.of("model", "gpt-4o-mini"),
+                1.0,
+                1,
+                1,
+                0,
+                Map.of("Exact Match", 1.0),
+                List.of(item));
+
+        store.save(record);
+
+        RunRecord loaded = store.get("run-items").orElseThrow();
+        assertThat(loaded.items()).hasSize(1);
+        assertThat(loaded.items().get(0).input()).isEqualTo("What is 2+2?");
+        assertThat(loaded.items().get(0).evaluations().get(0).evaluator()).isEqualTo("Exact Match");
+    }
+
+    private static RunRecord sampleRecord(String id, String experiment, String dataset) {
+        return sampleRecord(id, experiment, dataset, Instant.now());
+    }
+
+    private static RunRecord sampleRecord(String id, String experiment, String dataset, Instant timestamp) {
+        return new RunRecord(
+                id,
+                timestamp,
+                experiment,
+                dataset,
+                "/data/" + dataset + ".json",
+                Map.of("model", "gpt-4o-mini", "temperature", 0.0),
+                0.75,
+                4,
+                3,
+                1,
+                Map.of("Exact Match", 0.75),
+                List.of());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
                 <version>4.11.0</version>
             </dependency>
             <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp-json-jackson2</artifactId>
+                <version>1.1.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>5.21.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
                 <version>4.11.0</version>
             </dependency>
             <dependency>
-                <groupId>io.modelcontextprotocol.sdk</groupId>
-                <artifactId>mcp-json-jackson2</artifactId>
-                <version>1.1.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>5.21.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>dokimos-server-client</module>
         <module>dokimos-server</module>
         <module>dokimos-examples</module>
+        <module>dokimos-mcp-server</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This PR adds a `dokimos-mcp-server` module that exposes the evaluation framework as MCP tools, so you can run and inspect evaluations from any MCP client (Claude Desktop, Claude Code, Cursor, etc.).

Four tools over stdio:
- `run_evaluation` runs a dataset through a model and evaluator, returns summary metrics and a run ID
- `list_experiments` lists past runs, with optional dataset filtering
- `compare_runs` diffs two runs and flags regressions
- `get_failing_queries` pulls the examples that fell below threshold
  
Runs persist to ~/.dokimos/mcp-results.json. run_evaluation needs OPENAI_API_KEY. Packaged as a shaded executable JAR; not published to Maven Central.