### PR TITLE
Report the MCP server version from the pom

### DIFF
--- a/dokimos-mcp-server/pom.xml
+++ b/dokimos-mcp-server/pom.xml
@@ -79,6 +79,23 @@
     </dependencies>
 
     <build>
+        <resources>
+            <!-- Filter only the version file so ${project.version} is injected at build time -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>dokimos-mcp.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>dokimos-mcp.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
@@ -10,8 +10,11 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +39,7 @@ public class DokimosMcpServer {
         StdioServerTransportProvider transport = new StdioServerTransportProvider(jsonMapper);
 
         McpSyncServer server = McpServer.sync(transport)
-                .serverInfo("dokimos-mcp-server", "0.1.0")
+                .serverInfo("dokimos-mcp-server", version())
                 .capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
                 .toolCall(runEvaluationTool(), (exchange, request) -> handlers.handleRunEvaluation(request.arguments()))
                 .toolCall(
@@ -60,6 +63,22 @@ public class DokimosMcpServer {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    private static String version() {
+        try (InputStream in = DokimosMcpServer.class.getResourceAsStream("/dokimos-mcp.properties")) {
+            if (in != null) {
+                Properties props = new Properties();
+                props.load(in);
+                String version = props.getProperty("version");
+                if (version != null && !version.isBlank()) {
+                    return version;
+                }
+            }
+        } catch (IOException e) {
+            log.warn("Could not read version from dokimos-mcp.properties", e);
+        }
+        return "unknown";
     }
 
     private static Tool runEvaluationTool() {

--- a/dokimos-mcp-server/src/main/resources/dokimos-mcp.properties
+++ b/dokimos-mcp-server/src/main/resources/dokimos-mcp.properties
@@ -1,0 +1,1 @@
+version=${project.version}


### PR DESCRIPTION
The `serverInfo` version was hardcoded to `0.1.0`, which had drifted from the project version (`0.15.0-SNAPSHOT`).

Injects `project.version` into a filtered `dokimos-mcp.properties` resource and reads it at startup, so the MCP handshake always reports the real version. It survives shading because it is a bundled resource, not manifest metadata (verified: the shaded jar reports `0.15.0-SNAPSHOT`).

Once merged, the first MCP image should be published as `0.15.0` to match the module's release line.