### PR TITLE
Trigger docs deploy on MCP server changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
       - 'dokimos-junit/**'
       - 'dokimos-langchain4j/**'
       - 'dokimos-spring-ai/**'
+      - 'dokimos-mcp-server/**'
       - 'docs/**'
       - 'pom.xml'
       - '.github/workflows/docs.yml'


### PR DESCRIPTION
Adds `dokimos-mcp-server/**` to the docs workflow `paths` filter, so changes under that module redeploy the docs site. The MCP page itself lives under `docs/` and was already covered; this catches module-local doc edits.