### PR TITLE
Point Docusaurus url at live dokimos.dev custom domain

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: "https://dokimos-dev.github.io",
+  url: "https://dokimos.dev",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",
@@ -81,7 +81,7 @@ const config: Config = {
         {
           label: "Javadoc",
           position: "left",
-          href: "https://dokimos-dev.github.io/dokimos/apidocs/",
+          href: "https://dokimos.dev/apidocs/",
         },
         {
           href: "https://github.com/dokimos-dev/dokimos",


### PR DESCRIPTION
`docusaurus.config.ts` still set `url` to `https://dokimos-dev.github.io`, which now returns 404 after the custom domain took over GitHub Pages. As a result every generated `rel=canonical`, `og:url`, and `sitemap.xml` entry pointed at the dead github.io origin instead of the live `dokimos.dev` host.

## Changes

- `url` -> `https://dokimos.dev` (`baseUrl` stays `/`, since the site is served at the domain root).
- Javadoc navbar link → `https://dokimos.dev/apidocs/`. The old link pointed at `https://dokimos-dev.github.io/dokimos/apidocs/`, which was wrong on both host and path: the aggregated Javadoc is copied into the build at `/apidocs/`, not `/dokimos/apidocs/`.