### PR TITLE
Add Velm chat widget to docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,6 +11,7 @@
         "@docusaurus/core": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
         "@mdx-js/react": "^3.0.0",
+        "@velmhq/embed-react": "^0.1.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
@@ -5309,6 +5310,20 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@velmhq/embed-react": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@velmhq/embed-react/-/embed-react-0.1.0.tgz",
+      "integrity": "sha512-s8VcmeVblcX2hVXDfZkNa+SxQRegJxj8d1BgW75Lkzzi9Dp11K9LY6rXsUtHj7MR+DAYpQPcSLSbwqRpRjGBgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.0.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/core": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.0.0",
+    "@velmhq/embed-react": "^0.1.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Velm } from "@velmhq/embed-react";
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Velm
+        agent="velm/support-dokimos-dev"
+        mode="editorial"
+        theme="auto"
+        color="#000000"
+        title="Dokimos Support"
+        greeting="Hi! Ask me anything about Dokimos."
+        suggested={[
+          "How do I write my first evaluation?",
+          "Which built-in evaluators are available?",
+          "How do I run evals in CI?",
+        ]}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Adds the Velm support widget to the docs site via a Docusaurus Root wrapper. Uses the React component in editorial mode.