### PR TITLE
Release: waitUntil validated instead of published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>validated</waitUntil>
                     <waitMaxTime>1800</waitMaxTime>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Switch `central-publishing-maven-plugin` to wait until Sonatype accepts the upload (`validated`) instead of waiting for full Central visibility (`published`). The latter can take 30+ minutes on slow Sonatype days and tripped the plugin's polling timeout on the 0.15.0 release attempt; visibility happens async after validation anyway, usually within minutes.
