### PR TITLE
Semantic status tokens and diff-view polish

### DIFF
--- a/dokimos-server/frontend/src/components/shared/delta-cell.tsx
+++ b/dokimos-server/frontend/src/components/shared/delta-cell.tsx
@@ -37,8 +37,8 @@ export default function DeltaCell({
       <span className="text-muted-foreground">&rarr;</span>
       <span
         className={cn("font-semibold", {
-          "text-green-600 dark:text-green-500": colored && isImproved,
-          "text-red-600 dark:text-red-500": colored && isRegressed,
+          "text-success": colored && isImproved,
+          "text-destructive": colored && isRegressed,
           "text-foreground": !colored,
         })}
       >
@@ -55,10 +55,8 @@ export default function DeltaCell({
           className={cn(
             "ml-0.5 inline-flex items-center rounded-sm px-1 py-px text-[10px] font-semibold leading-none",
             {
-              "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400":
-                isImproved,
-              "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400":
-                isRegressed,
+              "bg-success/15 text-success": isImproved,
+              "bg-destructive/15 text-destructive": isRegressed,
               "bg-muted text-muted-foreground": !isImproved && !isRegressed,
             }
           )}

--- a/dokimos-server/frontend/src/components/shared/pass-rate.tsx
+++ b/dokimos-server/frontend/src/components/shared/pass-rate.tsx
@@ -12,9 +12,9 @@ export default function PassRate({ rate }: PassRateProps) {
   const percentage = (rate * 100).toFixed(1);
 
   const colorClass = cn({
-    "text-red-500": rate < 0.5,
-    "text-yellow-500": rate >= 0.5 && rate < 0.8,
-    "text-green-500": rate >= 0.8,
+    "text-destructive": rate < 0.5,
+    "text-warning": rate >= 0.5 && rate < 0.8,
+    "text-success": rate >= 0.8,
   });
 
   return <span className={colorClass}>{percentage}%</span>;

--- a/dokimos-server/frontend/src/components/shared/score-cell.tsx
+++ b/dokimos-server/frontend/src/components/shared/score-cell.tsx
@@ -1,3 +1,4 @@
+import { Check, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface ScoreCellProps {
@@ -8,12 +9,18 @@ interface ScoreCellProps {
 export default function ScoreCell({ score, success }: ScoreCellProps) {
   return (
     <span
-      className={cn({
-        "text-green-500": success,
-        "text-red-500": !success,
-      })}
+      aria-label={`${score.toFixed(2)}, ${success ? "pass" : "fail"}`}
+      className={cn(
+        "inline-flex items-center gap-1 tabular-nums",
+        success ? "text-success" : "text-destructive"
+      )}
     >
-      {score.toFixed(2)}
+      {success ? (
+        <Check className="h-3.5 w-3.5" aria-hidden="true" />
+      ) : (
+        <X className="h-3.5 w-3.5" aria-hidden="true" />
+      )}
+      <span aria-hidden="true">{score.toFixed(2)}</span>
     </span>
   );
 }

--- a/dokimos-server/frontend/src/index.css
+++ b/dokimos-server/frontend/src/index.css
@@ -26,6 +26,8 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -61,6 +63,8 @@
   --accent: oklch(0.968 0.007 247.896);
   --accent-foreground: oklch(0.208 0.042 265.755);
   --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.54 0.15 150);
+  --warning: oklch(0.53 0.13 60);
   --border: oklch(0.929 0.013 255.508);
   --input: oklch(0.929 0.013 255.508);
   --ring: oklch(0.704 0.04 256.788);
@@ -96,6 +100,8 @@
   --accent: oklch(0.279 0.041 260.031);
   --accent-foreground: oklch(0.984 0.003 247.858);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.72 0.19 149);
+  --warning: oklch(0.77 0.16 70);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.551 0.027 264.364);

--- a/dokimos-server/frontend/src/pages/experiment-page.tsx
+++ b/dokimos-server/frontend/src/pages/experiment-page.tsx
@@ -146,13 +146,28 @@ export default function ExperimentPage() {
     );
   }
 
-  // Prepare chart data from trends
-  const chartData = (trends?.runs ?? [])
-    .filter((run) => run.passRate != null)
-    .map((run) => ({
-      date: run.startedAt ? format(new Date(run.startedAt), "MMM d") : "",
-      passRate: Math.round((run.passRate ?? 0) * 100),
-    }));
+  // Prepare chart data from trends. Runs that fall on the same calendar day get a
+  // time-qualified label so their points do not collapse onto one X-axis tick.
+  const trendRuns = (trends?.runs ?? []).filter((run) => run.passRate != null);
+  const runsPerDay = new Map<string, number>();
+  for (const run of trendRuns) {
+    if (!run.startedAt) continue;
+    const day = format(new Date(run.startedAt), "MMM d");
+    runsPerDay.set(day, (runsPerDay.get(day) ?? 0) + 1);
+  }
+  const chartData = trendRuns.flatMap((run) => {
+    if (!run.startedAt) return [];
+    const day = format(new Date(run.startedAt), "MMM d");
+    const sharesDay = (runsPerDay.get(day) ?? 0) > 1;
+    return [
+      {
+        date: sharesDay
+          ? format(new Date(run.startedAt), "MMM d, h:mm a")
+          : day,
+        passRate: Math.round((run.passRate ?? 0) * 100),
+      },
+    ];
+  });
 
   const hasEnoughDataForChart = chartData.length >= 2;
 

--- a/dokimos-server/frontend/src/pages/run-diff-page.tsx
+++ b/dokimos-server/frontend/src/pages/run-diff-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, type ReactNode } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router";
 import { format } from "date-fns";
-import { ArrowDown, ArrowUp, CheckCircle2, Info, Minus } from "lucide-react";
+import { ArrowDown, ArrowUp, CheckCircle2, Info, Layers, Minus } from "lucide-react";
 import { useDiff } from "@/lib/api/diff-controller/diff-controller";
 import {
   useListRuns,
@@ -217,6 +217,16 @@ export default function RunDiffPage() {
   const cases = view?.cases?.content ?? [];
   const evaluatorNames = deriveEvaluatorNames(cases);
 
+  const sharedCount =
+    (summary?.improvedCount ?? 0) +
+    (summary?.regressedCount ?? 0) +
+    (summary?.unchangedCount ?? 0);
+  const presenceOnlyCount =
+    (summary?.addedCount ?? 0) + (summary?.removedCount ?? 0);
+  // Summary counts are unfiltered, so this holds regardless of the active status
+  // filter: the runs produced cases but none are comparable across both sides.
+  const noSharedCases = sharedCount === 0 && presenceOnlyCount > 0;
+
   const passRateDelta = summary?.passRateDelta;
   const passRateDirection =
     passRateDelta == null || passRateDelta === 0
@@ -270,9 +280,9 @@ export default function RunDiffPage() {
                 <p className="text-sm text-muted-foreground">Pass Rate</p>
                 <p
                   className={cn("text-2xl font-bold flex items-baseline gap-1.5", {
-                    "text-green-600 dark:text-green-500":
+                    "text-success":
                       passRateDirection === "up",
-                    "text-red-600 dark:text-red-500":
+                    "text-destructive":
                       passRateDirection === "down",
                   })}
                 >
@@ -298,7 +308,7 @@ export default function RunDiffPage() {
             <Card>
               <CardContent className="pt-6">
                 <p className="text-sm text-muted-foreground">Improved</p>
-                <p className="text-2xl font-bold text-green-600 dark:text-green-500">
+                <p className="text-2xl font-bold text-success">
                   {summary?.improvedCount ?? 0}
                 </p>
               </CardContent>
@@ -306,7 +316,7 @@ export default function RunDiffPage() {
             <Card>
               <CardContent className="pt-6">
                 <p className="text-sm text-muted-foreground">Regressed</p>
-                <p className="text-2xl font-bold text-red-600 dark:text-red-500">
+                <p className="text-2xl font-bold text-destructive">
                   {summary?.regressedCount ?? 0}
                 </p>
               </CardContent>
@@ -317,9 +327,9 @@ export default function RunDiffPage() {
                 <p className="text-2xl font-bold flex items-center gap-2">
                   <span
                     className={cn("inline-block h-2.5 w-2.5 rounded-full", {
-                      "bg-green-600 dark:bg-green-500":
+                      "bg-success":
                         summary?.significant && passRateDirection === "up",
-                      "bg-red-600 dark:bg-red-500":
+                      "bg-destructive":
                         summary?.significant && passRateDirection !== "up",
                       "bg-muted-foreground": !summary?.significant,
                     })}
@@ -331,8 +341,8 @@ export default function RunDiffPage() {
           </div>
 
           {summary?.pairing === "positional" && (
-            <div className="mb-4 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
-              <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="mb-4 flex items-start gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-sm text-foreground">
+              <Info className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
               <span>
                 Item-level diff needs both runs on one dataset version. These
                 runs are paired positionally, so per-case matches may not line
@@ -341,10 +351,9 @@ export default function RunDiffPage() {
             </div>
           )}
 
-          {summary && summary.regressedCount === 0 &&
-            (view?.cases?.totalElements ?? 0) > 0 && (
-              <div className="mb-4 flex items-start gap-2 rounded-md border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-800 dark:border-green-900 dark:bg-green-950 dark:text-green-300">
-                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+          {summary && summary.regressedCount === 0 && sharedCount > 0 && (
+              <div className="mb-4 flex items-start gap-2 rounded-md border border-success/40 bg-success/10 px-3 py-2 text-sm text-foreground">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success" />
                 <span>
                   No significant regressions.
                   {(summary.improvedCount ?? 0) > 0 &&
@@ -353,38 +362,59 @@ export default function RunDiffPage() {
               </div>
             )}
 
-          <div className="flex items-center gap-2 mb-4">
-            {STATUS_FILTERS.map((filter) => (
-              <Button
-                key={filter.value}
-                variant={status === filter.value ? "default" : "outline"}
-                size="sm"
-                onClick={() => handleStatusChange(filter.value)}
-              >
-                {filter.label}
-              </Button>
-            ))}
-          </div>
-
-          {cases.length === 0 ? (
+          {noSharedCases ? (
             <Card>
-              <CardContent className="py-12 text-center">
+              <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+                <Layers className="h-8 w-8 text-muted-foreground" />
                 <p className="text-muted-foreground">
-                  No cases match this filter.
+                  These runs share no comparable cases, likely because they ran
+                  on different dataset versions.
                 </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBaselineChange("")}
+                >
+                  Choose a different baseline
+                </Button>
               </CardContent>
             </Card>
           ) : (
             <>
-              <div className="overflow-x-auto">
-                <DiffTable cases={cases} evaluatorNames={evaluatorNames} />
+              <div className="flex items-center gap-2 mb-4">
+                {STATUS_FILTERS.map((filter) => (
+                  <Button
+                    key={filter.value}
+                    variant={status === filter.value ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => handleStatusChange(filter.value)}
+                  >
+                    {filter.label}
+                  </Button>
+                ))}
               </div>
-              <Pagination
-                currentPage={view?.cases?.number ?? 0}
-                totalItems={view?.cases?.totalElements ?? 0}
-                pageSize={view?.cases?.size ?? PAGE_SIZE}
-                onPageChange={handlePageChange}
-              />
+
+              {cases.length === 0 ? (
+                <Card>
+                  <CardContent className="py-12 text-center">
+                    <p className="text-muted-foreground">
+                      No cases match this filter.
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : (
+                <>
+                  <div className="overflow-x-auto">
+                    <DiffTable cases={cases} evaluatorNames={evaluatorNames} />
+                  </div>
+                  <Pagination
+                    currentPage={view?.cases?.number ?? 0}
+                    totalItems={view?.cases?.totalElements ?? 0}
+                    pageSize={view?.cases?.size ?? PAGE_SIZE}
+                    onPageChange={handlePageChange}
+                  />
+                </>
+              )}
             </>
           )}
         </>
@@ -441,18 +471,18 @@ function DiffTable({ cases, evaluatorNames }: DiffTableProps) {
       <TableRow key={key}>
         <TableCell
           className={cn(STICKY_STATUS, "z-10 w-8 p-0", {
-            "border-l-[3px] border-l-green-500": cs === "IMPROVED",
-            "border-l-[3px] border-l-red-500": cs === "REGRESSED",
+            "border-l-[3px] border-l-success": cs === "IMPROVED",
+            "border-l-[3px] border-l-destructive": cs === "REGRESSED",
             "border-l-[3px] border-l-transparent":
               cs === "UNCHANGED" || isPresenceOnly,
           })}
         >
           <span className="sr-only">{cs}</span>
           {cs === "IMPROVED" && (
-            <ArrowUp className="mx-2 h-4 w-4 text-green-600 dark:text-green-500" />
+            <ArrowUp className="mx-2 h-4 w-4 text-success" />
           )}
           {cs === "REGRESSED" && (
-            <ArrowDown className="mx-2 h-4 w-4 text-red-600 dark:text-red-500" />
+            <ArrowDown className="mx-2 h-4 w-4 text-destructive" />
           )}
           {(cs === "UNCHANGED" || isPresenceOnly) && (
             <Minus className="mx-2 h-4 w-4 text-muted-foreground" />
@@ -475,7 +505,7 @@ function DiffTable({ cases, evaluatorNames }: DiffTableProps) {
             </span>
           )}
           {diffCase.passFlip && (
-            <span className="ml-2 inline-flex items-center rounded-sm bg-red-100 px-1 py-px text-[10px] font-semibold text-red-700 dark:bg-red-950 dark:text-red-400">
+            <span className="ml-2 inline-flex items-center rounded-sm bg-destructive/15 px-1 py-px text-[10px] font-semibold text-destructive">
               flip
             </span>
           )}

--- a/dokimos-server/frontend/src/pages/run-page.tsx
+++ b/dokimos-server/frontend/src/pages/run-page.tsx
@@ -208,7 +208,7 @@ export default function RunPage() {
         <Card>
           <CardContent className="pt-6">
             <p className="text-sm text-muted-foreground">Passed</p>
-            <p className="text-2xl font-bold text-green-500">
+            <p className="text-2xl font-bold text-success">
               {run.passedItems}
             </p>
           </CardContent>
@@ -363,8 +363,8 @@ export default function RunPage() {
                                               <span
                                                 className={
                                                   evalResult.success
-                                                    ? "text-green-500"
-                                                    : "text-red-500"
+                                                    ? "text-success"
+                                                    : "text-destructive"
                                                 }
                                               >
                                                 {evalResult.success


### PR DESCRIPTION
Finishes the run-diff view and brings the existing pages onto a shared status palette.

- Adds semantic status color tokens (`--success`, `--warning`) to the theme, light and dark, both at WCAG AA contrast for text. `ScoreCell`, `DeltaCell`, `PassRate`, and the diff page now consume them instead of hardcoded `text-green-*`/`text-red-*`.
- `ScoreCell` conveys pass/fail by glyph plus an accessible label, not color alone.
- Run diff: a distinct "no shared cases" empty state (when two runs have no comparable cases, e.g. different dataset versions) with a button to pick another baseline. The "no regressions" banner no longer shows when there are no comparable cases.
- Trend chart: runs on the same calendar day get a time-qualified X-axis label so their points no longer collapse onto one tick.

Solid status pills (`StatusBadge`) keep their existing colors; tokenizing them would need a separate foreground treatment and is out of scope. Build and eslint clean.
