### PR TITLE
UI fixes: button cursor, column overflow, dialog centering

### DIFF
--- a/dokimos-server/frontend/src/components/ui/button.tsx
+++ b/dokimos-server/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/dokimos-server/frontend/src/index.css
+++ b/dokimos-server/frontend/src/index.css
@@ -127,4 +127,9 @@
   body {
     @apply bg-background text-foreground;
   }
+  /* Tailwind preflight resets margin to 0 on every element, which overrides the
+     user-agent rule that centers a modal dialog. Restore it so dialogs center. */
+  dialog {
+    margin: auto;
+  }
 }

--- a/dokimos-server/frontend/src/pages/run-page.tsx
+++ b/dokimos-server/frontend/src/pages/run-page.tsx
@@ -299,8 +299,8 @@ export default function RunPage() {
                             <ChevronRight className="h-4 w-4" />
                           )}
                         </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
+                        <TableCell className="max-w-xs align-top">
+                          <div className="flex items-center gap-2 min-w-0">
                             {item.annotation?.verdict && (
                               <VerdictChip verdict={item.annotation.verdict} />
                             )}
@@ -310,13 +310,13 @@ export default function RunPage() {
                             />
                           </div>
                         </TableCell>
-                        <TableCell>
+                        <TableCell className="max-w-xs align-top">
                           <TruncatedText
                             text={stringify(item.expectedOutput, "—")}
                             maxLength={80}
                           />
                         </TableCell>
-                        <TableCell>
+                        <TableCell className="max-w-xs align-top">
                           <TruncatedText
                             text={stringify(item.actualOutput)}
                             maxLength={80}
@@ -412,7 +412,7 @@ export default function RunPage() {
                                               </span>
                                             </div>
                                             {evalResult.reason && (
-                                              <p className="text-muted-foreground mt-2">
+                                              <p className="text-muted-foreground mt-2 break-words">
                                                 {evalResult.reason}
                                               </p>
                                             )}


### PR DESCRIPTION
Buttons show the pointer cursor again (Tailwind v4 dropped the default), the run detail columns are capped so the items table stops scrolling sideways and long judge reasons wrap, and modal dialogs center again instead of sticking to the top-left (preflight was resetting their margin). The dialog fix also covers the promote dialog that already shipped.
