### PR TITLE
Dataset run reporting in the JUnit DatasetSource

### DIFF
--- a/dokimos-junit/pom.xml
+++ b/dokimos-junit/pom.xml
@@ -48,5 +48,17 @@
             <artifactId>openai-java</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetArgumentsProvider.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetArgumentsProvider.java
@@ -14,6 +14,17 @@ import org.junit.jupiter.params.support.AnnotationConsumer;
  */
 public class DatasetArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<DatasetSource> {
 
+    /**
+     * Namespace under which the resolved dataset is stashed for {@link DatasetRunExtension}.
+     */
+    static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(DatasetArgumentsProvider.class);
+
+    /**
+     * Store key for the resolved {@link Dataset}.
+     */
+    static final String DATASET_KEY = "dataset";
+
     private String uri;
     private String inlineJson;
     private String inlineJsonl;
@@ -28,6 +39,7 @@ public class DatasetArgumentsProvider implements ArgumentsProvider, AnnotationCo
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
         Dataset dataset = loadDataset();
+        context.getStore(NAMESPACE).put(DATASET_KEY, dataset);
         return dataset.examples().stream().map(Arguments::of);
     }
 

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetReporter.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetReporter.java
@@ -1,0 +1,40 @@
+package dev.dokimos.junit;
+
+import dev.dokimos.core.Reporter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a static field that supplies the {@link Reporter} for {@link DatasetSource} tests.
+ *
+ * <p>
+ * Run reporting is opt-in. When a test class declares a static field of type {@link Reporter}
+ * annotated with {@code @DatasetReporter}, {@link DatasetRunExtension} opens a run for each
+ * {@code @DatasetSource} method and reports every parameterized invocation as an item result.
+ * When no such field is present, no run is opened and the test behaves as a plain parameterized
+ * test.
+ *
+ * <p>
+ * The annotated field must be {@code static} and assignable to {@link Reporter}. Its lifecycle
+ * (creation and {@link Reporter#close() closing}) is owned by the test class; the extension never
+ * closes a reporter supplied this way.
+ *
+ * <pre>{@code
+ * class QaEvaluationTest {
+ *
+ *     @DatasetReporter
+ *     static final Reporter reporter = new DokimosServerReporter(...);
+ *
+ *     @ParameterizedTest
+ *     @DatasetSource("classpath:datasets/qa.json")
+ *     void testQa(Example example) {
+ *         ...
+ *     }
+ * }
+ * }</pre>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DatasetReporter {}

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetRunExtension.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetRunExtension.java
@@ -1,0 +1,250 @@
+package dev.dokimos.junit;
+
+import dev.dokimos.core.Dataset;
+import dev.dokimos.core.Example;
+import dev.dokimos.core.ItemResult;
+import dev.dokimos.core.NoOpReporter;
+import dev.dokimos.core.Reporter;
+import dev.dokimos.core.RunHandle;
+import dev.dokimos.core.RunStatus;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+/**
+ * Opens and reports a {@link Reporter} run for each {@link DatasetSource} test method.
+ *
+ * <p>
+ * Reporting is opt-in. The extension looks for a static field of type {@link Reporter} annotated
+ * with {@link DatasetReporter} on the test class. When none is found, {@link NoOpReporter} is used
+ * and the test runs exactly as a plain parameterized test would.
+ *
+ * <p>
+ * When a reporter is present, one run is opened per {@code @DatasetSource} method: the run starts
+ * before the first invocation, each parameterized invocation is reported as an {@link ItemResult},
+ * and the run is completed after the last invocation with {@link RunStatus#SUCCESS} when every
+ * invocation passed or {@link RunStatus#FAILED} when at least one threw. The reporter is always
+ * {@link Reporter#flush() flushed} after completion. The extension never closes a reporter supplied
+ * via {@link DatasetReporter}; that lifecycle belongs to the test class.
+ */
+public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallback, TestExecutionExceptionHandler {
+
+    private static final Namespace NAMESPACE = Namespace.create(DatasetRunExtension.class);
+
+    private static final String RUN_KEY = "run";
+    private static final String EXAMPLE_KEY = "example";
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        RunState run = runState(context);
+        if (run == null) {
+            return;
+        }
+
+        Dataset dataset = context.getStore(DatasetArgumentsProvider.NAMESPACE)
+                .get(DatasetArgumentsProvider.DATASET_KEY, Dataset.class);
+        Example example = exampleAt(dataset, run.nextIndex());
+        context.getStore(NAMESPACE).put(EXAMPLE_KEY, example);
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        RunState run = runState(context);
+        if (run != null) {
+            run.recordFailure();
+        }
+        throw throwable;
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        RunState run = runState(context);
+        if (run == null) {
+            return;
+        }
+
+        Example example = context.getStore(NAMESPACE).get(EXAMPLE_KEY, Example.class);
+        if (example == null) {
+            return;
+        }
+
+        ItemResult result = new ItemResult(example, Map.of(), List.of());
+        run.reporter().reportItem(run.handle(), result);
+    }
+
+    /**
+     * Returns the run for the current test method, creating it on first access. Returns {@code null}
+     * when no {@link DatasetReporter} field is present, signalling the no-op path.
+     */
+    private RunState runState(ExtensionContext context) {
+        Store methodStore = methodStore(context);
+        RunState existing = methodStore.get(RUN_KEY, RunState.class);
+        if (existing != null) {
+            return existing.active() ? existing : null;
+        }
+
+        Reporter reporter = findReporter(context);
+        if (reporter == null) {
+            methodStore.put(RUN_KEY, RunState.inactive());
+            return null;
+        }
+
+        DatasetSource source = annotation(context);
+        String experimentName = resolveExperimentName(source, context);
+        Map<String, Object> metadata = resolveMetadata(source);
+        RunHandle handle = reporter.startRun(experimentName, metadata);
+
+        RunState run = new RunState(reporter, handle);
+        methodStore.put(RUN_KEY, run);
+        return run;
+    }
+
+    private Store methodStore(ExtensionContext context) {
+        ExtensionContext methodContext = context.getParent().orElse(context);
+        return methodContext.getStore(NAMESPACE);
+    }
+
+    private DatasetSource annotation(ExtensionContext context) {
+        return context.getRequiredTestMethod().getAnnotation(DatasetSource.class);
+    }
+
+    private String resolveExperimentName(DatasetSource source, ExtensionContext context) {
+        if (source != null && !source.experimentName().isBlank()) {
+            return source.experimentName();
+        }
+        return context.getRequiredTestMethod().getName();
+    }
+
+    private Map<String, Object> resolveMetadata(DatasetSource source) {
+        if (source == null) {
+            return Map.of();
+        }
+        String[] pairs = source.metadata();
+        if (pairs.length == 0) {
+            return Map.of();
+        }
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException(
+                    "@DatasetSource metadata must contain an even number of key-value entries");
+        }
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            metadata.put(pairs[i], pairs[i + 1]);
+        }
+        return metadata;
+    }
+
+    private Example exampleAt(Dataset dataset, int index) {
+        if (dataset == null) {
+            return null;
+        }
+        List<Example> examples = dataset.examples();
+        if (index < 0 || index >= examples.size()) {
+            return null;
+        }
+        return examples.get(index);
+    }
+
+    private Reporter findReporter(ExtensionContext context) {
+        Class<?> testClass = context.getRequiredTestClass();
+        for (Class<?> type = testClass; type != null && type != Object.class; type = type.getSuperclass()) {
+            for (Field field : type.getDeclaredFields()) {
+                if (!field.isAnnotationPresent(DatasetReporter.class)) {
+                    continue;
+                }
+                if (!Modifier.isStatic(field.getModifiers())) {
+                    throw new IllegalStateException("@DatasetReporter field '" + field.getName() + "' must be static");
+                }
+                if (!Reporter.class.isAssignableFrom(field.getType())) {
+                    throw new IllegalStateException(
+                            "@DatasetReporter field '" + field.getName() + "' must be of type Reporter");
+                }
+                field.setAccessible(true);
+                try {
+                    return (Reporter) field.get(null);
+                } catch (IllegalAccessException e) {
+                    throw new IllegalStateException(
+                            "Unable to read @DatasetReporter field '" + field.getName() + "'", e);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Per-method run state held in the method-scoped store. When stored there it is closed once the
+     * test method finishes all parameterized invocations, completing and flushing the run.
+     *
+     * <p>
+     * Implements {@link CloseableResource} rather than {@link AutoCloseable} so the store closes it
+     * across the supported JUnit range (5.10.3 through 6.x); 6.x also recognizes
+     * {@link AutoCloseable}, but the older platforms only auto-close {@link CloseableResource}.
+     */
+    private static final class RunState implements CloseableResource {
+
+        private final Reporter reporter;
+        private final RunHandle handle;
+        private final boolean active;
+        private final AtomicInteger index = new AtomicInteger(0);
+        private final AtomicInteger failures = new AtomicInteger(0);
+
+        private RunState(Reporter reporter, RunHandle handle) {
+            this.reporter = reporter;
+            this.handle = handle;
+            this.active = true;
+        }
+
+        private RunState() {
+            this.reporter = null;
+            this.handle = null;
+            this.active = false;
+        }
+
+        static RunState inactive() {
+            return new RunState();
+        }
+
+        boolean active() {
+            return active;
+        }
+
+        Reporter reporter() {
+            return reporter;
+        }
+
+        RunHandle handle() {
+            return handle;
+        }
+
+        int nextIndex() {
+            return index.getAndIncrement();
+        }
+
+        void recordFailure() {
+            failures.incrementAndGet();
+        }
+
+        @Override
+        public void close() {
+            if (!active) {
+                return;
+            }
+            RunStatus status = failures.get() == 0 ? RunStatus.SUCCESS : RunStatus.FAILED;
+            try {
+                reporter.completeRun(handle, status);
+            } finally {
+                reporter.flush();
+            }
+        }
+    }
+}

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetSource.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetSource.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 /**
@@ -36,6 +37,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @ArgumentsSource(DatasetArgumentsProvider.class)
+@ExtendWith(DatasetRunExtension.class)
 public @interface DatasetSource {
 
     /**
@@ -54,4 +56,17 @@ public @interface DatasetSource {
      * Use this for small/quick tests only.
      */
     String jsonl() default "";
+
+    /**
+     * Name of the run opened when a {@link DatasetReporter} field is present.
+     * Defaults to the test method name when left empty.
+     */
+    String experimentName() default "";
+
+    /**
+     * Run metadata as alternating key-value pairs (for example
+     * {@code {"model", "gpt-4", "temperature", "0"}}). Forwarded to the reporter when a
+     * {@link DatasetReporter} field is present. Defaults to no metadata.
+     */
+    String[] metadata() default {};
 }

--- a/dokimos-junit/src/test/java/dev/dokimos/junit/DatasetRunExtensionTest.java
+++ b/dokimos-junit/src/test/java/dev/dokimos/junit/DatasetRunExtensionTest.java
@@ -1,0 +1,250 @@
+package dev.dokimos.junit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.dokimos.core.Example;
+import dev.dokimos.core.ItemResult;
+import dev.dokimos.core.Reporter;
+import dev.dokimos.core.RunHandle;
+import dev.dokimos.core.RunStatus;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+class DatasetRunExtensionTest {
+
+    private static Reporter reporter;
+
+    /**
+     * Forwards every call to the current {@link #reporter} mock. Fixture classes reference this
+     * stable instance from their static {@code @DatasetReporter} field, while each test swaps the
+     * underlying mock to keep verifications isolated.
+     */
+    private static final Reporter FORWARDING = new Reporter() {
+        @Override
+        public RunHandle startRun(String experimentName, Map<String, Object> metadata) {
+            return reporter.startRun(experimentName, metadata);
+        }
+
+        @Override
+        public void reportItem(RunHandle handle, ItemResult result) {
+            reporter.reportItem(handle, result);
+        }
+
+        @Override
+        public void completeRun(RunHandle handle, RunStatus status) {
+            reporter.completeRun(handle, status);
+        }
+
+        @Override
+        public void flush() {
+            reporter.flush();
+        }
+
+        @Override
+        public void close() {
+            reporter.close();
+        }
+    };
+
+    private static final String THREE_EXAMPLES = """
+            {
+              "examples": [
+                {"input": "Capital of France?", "expectedOutput": "Paris"},
+                {"input": "Capital of Germany?", "expectedOutput": "Berlin"},
+                {"input": "Capital of Italy?", "expectedOutput": "Rome"}
+              ]
+            }
+            """;
+
+    @BeforeEach
+    void setUp() {
+        reporter = mock(Reporter.class);
+        when(reporter.startRun(any(), anyMap())).thenReturn(new RunHandle("run-1"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        reporter = null;
+    }
+
+    private static void run(Class<?> testClass) {
+        Launcher launcher = LauncherFactory.create();
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(testClass))
+                .build();
+        launcher.execute(request);
+    }
+
+    @Test
+    void startsRunOncePerMethodWithMethodNameByDefault() {
+        run(PassingFixture.class);
+
+        verify(reporter).startRun(eq("passes"), anyMap());
+        verify(reporter, times(3)).reportItem(any(), any());
+        verify(reporter).completeRun(any(), eq(RunStatus.SUCCESS));
+    }
+
+    @Test
+    void reportsItemsInDatasetOrder() {
+        run(PassingFixture.class);
+
+        ArgumentCaptor<ItemResult> captor = ArgumentCaptor.forClass(ItemResult.class);
+        verify(reporter, times(3)).reportItem(any(), captor.capture());
+
+        List<String> inputs = new ArrayList<>();
+        for (ItemResult result : captor.getAllValues()) {
+            inputs.add(result.example().input());
+        }
+        assertThat(inputs).containsExactly("Capital of France?", "Capital of Germany?", "Capital of Italy?");
+    }
+
+    @Test
+    void completesWithSuccessWhenAllInvocationsPass() {
+        run(PassingFixture.class);
+
+        verify(reporter).completeRun(any(), eq(RunStatus.SUCCESS));
+        verify(reporter).flush();
+    }
+
+    @Test
+    void completesWithFailedWhenAnInvocationThrows() {
+        run(FailingFixture.class);
+
+        verify(reporter).completeRun(any(), eq(RunStatus.FAILED));
+    }
+
+    @Test
+    void flushesAfterCompleteRunEvenWithFailures() {
+        run(FailingFixture.class);
+
+        InOrder order = inOrder(reporter);
+        order.verify(reporter).completeRun(any(), eq(RunStatus.FAILED));
+        order.verify(reporter).flush();
+    }
+
+    @Test
+    void callsLifecycleInOrder() {
+        run(PassingFixture.class);
+
+        InOrder order = inOrder(reporter);
+        order.verify(reporter).startRun(any(), anyMap());
+        order.verify(reporter, times(3)).reportItem(any(), any());
+        order.verify(reporter).completeRun(any(), any());
+        order.verify(reporter).flush();
+    }
+
+    @Test
+    void doesNotReportWhenNoReporterFieldPresent() {
+        run(NoReporterFixture.class);
+
+        verify(reporter, never()).startRun(any(), anyMap());
+        verify(reporter, never()).reportItem(any(), any());
+        verify(reporter, never()).completeRun(any(), any());
+    }
+
+    @Test
+    void usesCustomExperimentName() {
+        run(CustomNameFixture.class);
+
+        verify(reporter).startRun(eq("custom-run"), anyMap());
+    }
+
+    @Test
+    void forwardsMetadataPairs() {
+        run(MetadataFixture.class);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(reporter).startRun(any(), captor.capture());
+        assertThat(captor.getValue()).containsEntry("model", "gpt-4").containsEntry("temperature", "0");
+    }
+
+    @Test
+    void doesNotCloseReporterSuppliedByField() {
+        run(PassingFixture.class);
+
+        verify(reporter, never()).close();
+    }
+
+    static class PassingFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(json = THREE_EXAMPLES)
+        void passes(Example example) {
+            assertThat(example.input()).contains("Capital");
+        }
+    }
+
+    static class FailingFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(json = THREE_EXAMPLES)
+        void mixed(Example example) {
+            if (example.input().contains("Germany")) {
+                Assertions.fail("forced failure");
+            }
+        }
+    }
+
+    static class NoReporterFixture {
+
+        @ParameterizedTest
+        @DatasetSource(json = THREE_EXAMPLES)
+        void noReporter(Example example) {
+            assertThat(example.input()).isNotBlank();
+        }
+    }
+
+    static class CustomNameFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(json = THREE_EXAMPLES, experimentName = "custom-run")
+        void named(Example example) {
+            assertThat(example.input()).isNotBlank();
+        }
+    }
+
+    static class MetadataFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(
+                json = THREE_EXAMPLES,
+                metadata = {"model", "gpt-4", "temperature", "0"})
+        void withMetadata(Example example) {
+            assertThat(example.input()).isNotBlank();
+        }
+    }
+}

--- a/dokimos-junit/src/test/java/dev/dokimos/junit/DatasetSourceTest.java
+++ b/dokimos-junit/src/test/java/dev/dokimos/junit/DatasetSourceTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 class DatasetSourceTest {
 
+    @DatasetReporter
+    static final Reporter reporter = NoOpReporter.INSTANCE;
+
     private final Evaluator passingEvaluator = new Evaluator() {
         @Override
         public EvalResult evaluate(EvalTestCase testCase) {


### PR DESCRIPTION
Makes @DatasetSource a real JUnit extension with a run lifecycle: a dataset-backed test opens a server run, reports each case as it runs, and completes the run, so a test execution shows up as a run on the server. Reporting is opt-in via a reporter; existing @DatasetSource tests behave exactly as before.
