### PR TITLE
Server-side LLM judge

### DIFF
--- a/dokimos-server/src/main/java/dev/dokimos/server/DokimosServerApplication.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/DokimosServerApplication.java
@@ -2,8 +2,10 @@ package dev.dokimos.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DokimosServerApplication {
 
     public static void main(String[] args) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/config/ApiKeyProperties.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/config/ApiKeyProperties.java
@@ -19,12 +19,26 @@ public class ApiKeyProperties {
 
     private String apiKey;
 
+    private String encryptionKey;
+
     public String getApiKey() {
         return apiKey;
     }
 
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
+    }
+
+    /**
+     * Returns the master key used to encrypt inline connection API keys at rest, or null when unset.
+     * Required only when at least one connection stores an inline key.
+     */
+    public String getEncryptionKey() {
+        return encryptionKey;
+    }
+
+    public void setEncryptionKey(String encryptionKey) {
+        this.encryptionKey = encryptionKey;
     }
 
     /**

--- a/dokimos-server/src/main/java/dev/dokimos/server/config/JudgeProperties.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/config/JudgeProperties.java
@@ -1,0 +1,42 @@
+package dev.dokimos.server.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Tuning knobs for the background judge worker, bound from the {@code dokimos.judge} prefix.
+ * {@code pollIntervalMs} sets how often the worker polls for claimable jobs, {@code maxAttempts} the
+ * retry ceiling per job, and {@code pageSize} the number of items scored per page.
+ */
+@Component
+@ConfigurationProperties(prefix = "dokimos.judge")
+public class JudgeProperties {
+
+    private long pollIntervalMs = 5000;
+    private int maxAttempts = 3;
+    private int pageSize = 50;
+
+    public long getPollIntervalMs() {
+        return pollIntervalMs;
+    }
+
+    public void setPollIntervalMs(long pollIntervalMs) {
+        this.pollIntervalMs = pollIntervalMs;
+    }
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/config/JudgeProperties.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/config/JudgeProperties.java
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Component;
 /**
  * Tuning knobs for the background judge worker, bound from the {@code dokimos.judge} prefix.
  * {@code pollIntervalMs} sets how often the worker polls for claimable jobs, {@code maxAttempts} the
- * retry ceiling per job, and {@code pageSize} the number of items scored per page.
+ * retry ceiling per job, {@code pageSize} the number of items scored per page, and
+ * {@code claimTimeoutMs} how long a claimed job may run before it is treated as orphaned and requeued.
  */
 @Component
 @ConfigurationProperties(prefix = "dokimos.judge")
@@ -15,6 +16,7 @@ public class JudgeProperties {
     private long pollIntervalMs = 5000;
     private int maxAttempts = 3;
     private int pageSize = 50;
+    private long claimTimeoutMs = 600_000;
 
     public long getPollIntervalMs() {
         return pollIntervalMs;
@@ -38,5 +40,13 @@ public class JudgeProperties {
 
     public void setPageSize(int pageSize) {
         this.pageSize = pageSize;
+    }
+
+    public long getClaimTimeoutMs() {
+        return claimTimeoutMs;
+    }
+
+    public void setClaimTimeoutMs(long claimTimeoutMs) {
+        this.claimTimeoutMs = claimTimeoutMs;
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/EvalJobController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/EvalJobController.java
@@ -1,0 +1,42 @@
+package dev.dokimos.server.controller.v1;
+
+import dev.dokimos.server.dto.v1.EnqueueJudgeRequest;
+import dev.dokimos.server.dto.v1.EvalJobView;
+import dev.dokimos.server.service.EvalJobService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/runs/{runId}/judge-jobs")
+public class EvalJobController {
+
+    private final EvalJobService jobService;
+
+    public EvalJobController(EvalJobService jobService) {
+        this.jobService = jobService;
+    }
+
+    /** Enqueues server-side scoring for a run. Returns 201 with the created job. */
+    @PostMapping
+    public ResponseEntity<EvalJobView> enqueue(
+            @PathVariable UUID runId, @Valid @RequestBody EnqueueJudgeRequest request) {
+        EvalJobView view = jobService.enqueue(runId, request);
+        return ResponseEntity.created(URI.create("/api/v1/runs/" + runId + "/judge-jobs/" + view.id()))
+                .body(view);
+    }
+
+    /** Lists the judge jobs registered for a run, oldest first. */
+    @GetMapping
+    public List<EvalJobView> list(@PathVariable UUID runId) {
+        return jobService.getJobsForRun(runId);
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/LlmConnectionController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/LlmConnectionController.java
@@ -1,0 +1,47 @@
+package dev.dokimos.server.controller.v1;
+
+import dev.dokimos.server.dto.v1.CreateLlmConnectionRequest;
+import dev.dokimos.server.dto.v1.LlmConnectionView;
+import dev.dokimos.server.service.LlmConnectionService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/llm-connections")
+public class LlmConnectionController {
+
+    private final LlmConnectionService connectionService;
+
+    public LlmConnectionController(LlmConnectionService connectionService) {
+        this.connectionService = connectionService;
+    }
+
+    /** Registers an LLM connection. Returns 201 with a {@code Location} header pointing at the connection. */
+    @PostMapping
+    public ResponseEntity<LlmConnectionView> create(@Valid @RequestBody CreateLlmConnectionRequest request) {
+        LlmConnectionView view = connectionService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/llm-connections/" + view.id()))
+                .body(view);
+    }
+
+    /** Lists every registered connection. Key material is never included. */
+    @GetMapping
+    public List<LlmConnectionView> list() {
+        return connectionService.list();
+    }
+
+    /** Returns a single connection by id, or 404 if it does not exist. */
+    @GetMapping("/{id}")
+    public LlmConnectionView get(@PathVariable UUID id) {
+        return connectionService.get(id);
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/CreateLlmConnectionRequest.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/CreateLlmConnectionRequest.java
@@ -1,0 +1,30 @@
+package dev.dokimos.server.dto.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request to register an OpenAI-compatible LLM connection. Exactly one of {@code apiKey} (supplied
+ * inline and stored encrypted) or {@code credentialRef} (the name of an environment variable holding
+ * the key) must be set.
+ */
+public record CreateLlmConnectionRequest(
+        @NotBlank String name,
+        @NotBlank String baseUrl,
+        @NotBlank String model,
+        String apiKey,
+        String credentialRef) {
+
+    /**
+     * Cross-field rule enforcing that exactly one credential source is supplied. Returning
+     * {@code false} surfaces a 400 instead of letting the database check constraint produce a 409.
+     */
+    @AssertTrue(message = "exactly one of apiKey or credentialRef must be set")
+    @JsonIgnore
+    public boolean isCredentialSourceValid() {
+        boolean hasKey = apiKey != null && !apiKey.isBlank();
+        boolean hasRef = credentialRef != null && !credentialRef.isBlank();
+        return hasKey != hasRef;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/EnqueueJudgeRequest.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/EnqueueJudgeRequest.java
@@ -1,0 +1,59 @@
+package dev.dokimos.server.dto.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import dev.dokimos.core.EvalTestCaseParam;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request to enqueue a server-side judge job for a run. {@code evaluationParams} names which test-case
+ * fields are included in the judge prompt; each entry must match a {@link EvalTestCaseParam} name.
+ */
+public record EnqueueJudgeRequest(
+        @NotNull UUID connectionId,
+        @NotBlank String evaluatorName,
+        @NotBlank String criteria,
+        List<String> evaluationParams,
+        double minScore,
+        double maxScore,
+        Double threshold) {
+
+    public EnqueueJudgeRequest {
+        evaluationParams = evaluationParams == null ? List.of() : List.copyOf(evaluationParams);
+    }
+
+    @AssertTrue(message = "evaluationParams must be non-empty and contain valid parameter names")
+    @JsonIgnore
+    public boolean isEvaluationParamsValid() {
+        if (evaluationParams.isEmpty()) {
+            return false;
+        }
+        for (String param : evaluationParams) {
+            if (!isKnownParam(param)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @AssertTrue(message = "minScore must be less than maxScore")
+    @JsonIgnore
+    public boolean isScoreRangeValid() {
+        return minScore < maxScore;
+    }
+
+    private static boolean isKnownParam(String name) {
+        if (name == null) {
+            return false;
+        }
+        for (EvalTestCaseParam param : EvalTestCaseParam.values()) {
+            if (param.name().equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/EvalJobView.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/EvalJobView.java
@@ -1,0 +1,34 @@
+package dev.dokimos.server.dto.v1;
+
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.EvalJobStatus;
+import java.time.Instant;
+import java.util.UUID;
+
+/** Public view of an {@link EvalJob}, returned by the enqueue endpoint and the per-run job listing. */
+public record EvalJobView(
+        UUID id,
+        UUID runId,
+        UUID connectionId,
+        String evaluatorName,
+        EvalJobStatus status,
+        int attemptCount,
+        String lastError,
+        Instant createdAt,
+        Instant claimedAt,
+        Instant completedAt) {
+
+    public static EvalJobView from(EvalJob job) {
+        return new EvalJobView(
+                job.getId(),
+                job.getRun().getId(),
+                job.getConnection().getId(),
+                job.getEvaluatorName(),
+                job.getStatus(),
+                job.getAttemptCount(),
+                job.getLastError(),
+                job.getCreatedAt(),
+                job.getClaimedAt(),
+                job.getCompletedAt());
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/LlmConnectionView.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/LlmConnectionView.java
@@ -1,0 +1,31 @@
+package dev.dokimos.server.dto.v1;
+
+import dev.dokimos.server.entity.LlmConnection;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Public view of an {@link LlmConnection}. Never carries raw or encrypted key material:
+ * {@code hasInlineKey} reports whether an inline key is stored, and {@code credentialRef} is populated
+ * only when an external credential reference is in use.
+ */
+public record LlmConnectionView(
+        UUID id,
+        String name,
+        String baseUrl,
+        String model,
+        String credentialRef,
+        boolean hasInlineKey,
+        Instant createdAt) {
+
+    public static LlmConnectionView from(LlmConnection connection) {
+        return new LlmConnectionView(
+                connection.getId(),
+                connection.getName(),
+                connection.getBaseUrl(),
+                connection.getModel(),
+                connection.getCredentialRef(),
+                connection.hasInlineKey(),
+                connection.getCreatedAt());
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/EvalJob.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/EvalJob.java
@@ -1,0 +1,201 @@
+package dev.dokimos.server.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A unit of server-side scoring work: score every not-yet-evaluated item of a run with a single
+ * evaluator configuration, using a registered {@link LlmConnection}. A background worker claims a
+ * pending job, scores items in seek-keyed pages, and finalizes the run when the job completes. At most
+ * one job exists per {@code (run, evaluatorName)} pair.
+ */
+@Entity
+@Table(
+        name = "eval_jobs",
+        uniqueConstraints =
+                @UniqueConstraint(
+                        name = "uq_eval_job_run_evaluator",
+                        columnNames = {"run_id", "evaluator_name"}))
+public class EvalJob {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "run_id", nullable = false)
+    private ExperimentRun run;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "connection_id", nullable = false)
+    private LlmConnection connection;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EvalJobStatus status;
+
+    @Column(name = "evaluator_name", nullable = false)
+    private String evaluatorName;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String criteria;
+
+    @Column(name = "evaluation_params", nullable = false)
+    private String evaluationParams;
+
+    @Column(name = "min_score", nullable = false)
+    private double minScore;
+
+    @Column(name = "max_score", nullable = false)
+    private double maxScore;
+
+    private Double threshold;
+
+    @Column(name = "last_item_id")
+    private UUID lastItemId;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "last_error", columnDefinition = "text")
+    private String lastError;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "claimed_at")
+    private Instant claimedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    protected EvalJob() {}
+
+    public EvalJob(ExperimentRun run, LlmConnection connection, String evaluatorName, String criteria) {
+        this.run = run;
+        this.connection = connection;
+        this.evaluatorName = evaluatorName;
+        this.criteria = criteria;
+        this.status = EvalJobStatus.PENDING;
+        this.minScore = 0.0;
+        this.maxScore = 1.0;
+        this.attemptCount = 0;
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public ExperimentRun getRun() {
+        return run;
+    }
+
+    public LlmConnection getConnection() {
+        return connection;
+    }
+
+    public EvalJobStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(EvalJobStatus status) {
+        this.status = status;
+    }
+
+    public String getEvaluatorName() {
+        return evaluatorName;
+    }
+
+    public String getCriteria() {
+        return criteria;
+    }
+
+    public String getEvaluationParams() {
+        return evaluationParams;
+    }
+
+    public void setEvaluationParams(String evaluationParams) {
+        this.evaluationParams = evaluationParams;
+    }
+
+    public double getMinScore() {
+        return minScore;
+    }
+
+    public void setMinScore(double minScore) {
+        this.minScore = minScore;
+    }
+
+    public double getMaxScore() {
+        return maxScore;
+    }
+
+    public void setMaxScore(double maxScore) {
+        this.maxScore = maxScore;
+    }
+
+    public Double getThreshold() {
+        return threshold;
+    }
+
+    public void setThreshold(Double threshold) {
+        this.threshold = threshold;
+    }
+
+    public UUID getLastItemId() {
+        return lastItemId;
+    }
+
+    public void setLastItemId(UUID lastItemId) {
+        this.lastItemId = lastItemId;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public void setAttemptCount(int attemptCount) {
+        this.attemptCount = attemptCount;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public void setLastError(String lastError) {
+        this.lastError = lastError;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getClaimedAt() {
+        return claimedAt;
+    }
+
+    public void setClaimedAt(Instant claimedAt) {
+        this.claimedAt = claimedAt;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(Instant completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/EvalJobStatus.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/EvalJobStatus.java
@@ -1,0 +1,9 @@
+package dev.dokimos.server.entity;
+
+/** Lifecycle state of an {@link EvalJob}. Stored as a string in the {@code eval_jobs.status} column. */
+public enum EvalJobStatus {
+    PENDING,
+    CLAIMED,
+    SUCCEEDED,
+    FAILED
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/LlmConnection.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/LlmConnection.java
@@ -1,0 +1,103 @@
+package dev.dokimos.server.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * A named, reusable pointer to an OpenAI-compatible chat completions endpoint used by the server-side
+ * judge. Exactly one credential source is set: {@code credentialRef} names an environment variable
+ * (or external path) that holds the key, or {@code encryptedApiKey} carries an inline key encrypted at
+ * rest. The entity never exposes raw key material; decryption is the responsibility of the credential
+ * service.
+ */
+@Entity
+@Table(name = "llm_connections")
+public class LlmConnection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "base_url", nullable = false, length = 512)
+    private String baseUrl;
+
+    @Column(nullable = false)
+    private String model;
+
+    @Column(name = "credential_ref")
+    private String credentialRef;
+
+    @Column(name = "encrypted_api_key", columnDefinition = "text")
+    private String encryptedApiKey;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected LlmConnection() {}
+
+    public LlmConnection(String name, String baseUrl, String model) {
+        Instant now = Instant.now();
+        this.name = name;
+        this.baseUrl = baseUrl;
+        this.model = model;
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public String getCredentialRef() {
+        return credentialRef;
+    }
+
+    public void setCredentialRef(String credentialRef) {
+        this.credentialRef = credentialRef;
+    }
+
+    public String getEncryptedApiKey() {
+        return encryptedApiKey;
+    }
+
+    public void setEncryptedApiKey(String encryptedApiKey) {
+        this.encryptedApiKey = encryptedApiKey;
+    }
+
+    /** Returns true when an inline encrypted key is stored rather than an external credential reference. */
+    public boolean hasInlineKey() {
+        return encryptedApiKey != null && !encryptedApiKey.isBlank();
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/RunStatus.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/RunStatus.java
@@ -2,6 +2,7 @@ package dev.dokimos.server.entity;
 
 public enum RunStatus {
     RUNNING,
+    EVALUATING,
     SUCCESS,
     FAILED,
     CANCELLED

--- a/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgeCallException.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgeCallException.java
@@ -1,0 +1,33 @@
+package dev.dokimos.server.judge;
+
+/**
+ * Unchecked failure raised when a judge HTTP call cannot complete. The {@code httpStatus} carries the
+ * response status, or {@code -1} for a network or timeout error, so the worker can distinguish
+ * retryable failures (5xx, timeout) from non-retryable ones (4xx).
+ */
+public class JudgeCallException extends RuntimeException {
+
+    /** Status used when the failure is a network error or timeout rather than an HTTP response. */
+    public static final int NETWORK_ERROR = -1;
+
+    private final int httpStatus;
+
+    public JudgeCallException(int httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public JudgeCallException(int httpStatus, String message, Throwable cause) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    /** Returns true when the failure is worth retrying: a timeout, network error, or 5xx response. */
+    public boolean isRetryable() {
+        return httpStatus == NETWORK_ERROR || httpStatus >= 500;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgePromptBuilder.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgePromptBuilder.java
@@ -1,0 +1,46 @@
+package dev.dokimos.server.judge;
+
+import dev.dokimos.core.EvalTestCaseParam;
+import java.util.List;
+
+/**
+ * Builds the judge prompt in the same shape the core LLM judge evaluator produces, so server-side and
+ * in-process scoring stay aligned. The criteria, the selected parameters in their given order, the
+ * score range, and the JSON response instruction match the core format exactly.
+ */
+final class JudgePromptBuilder {
+
+    private JudgePromptBuilder() {}
+
+    static String build(
+            String criteria,
+            List<EvalTestCaseParam> params,
+            double minScore,
+            double maxScore,
+            String input,
+            String expectedOutput,
+            String actualOutput) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Evaluate the following based on this criteria: ")
+                .append(criteria)
+                .append("\n\n");
+
+        for (EvalTestCaseParam param : params) {
+            switch (param) {
+                case INPUT -> sb.append("Input: ").append(input).append("\n");
+                case ACTUAL_OUTPUT ->
+                    sb.append("Actual Output: ").append(actualOutput).append("\n");
+                case EXPECTED_OUTPUT ->
+                    sb.append("Expected Output: ").append(expectedOutput).append("\n");
+            }
+        }
+
+        sb.append("Provide a score between ")
+                .append(minScore)
+                .append(" and ")
+                .append(maxScore)
+                .append(", and a brief reasoning.");
+        sb.append("Respond in JSON format: {\"score\": <number>, \"reason\": \"<explanation>\"}");
+        return sb.toString();
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgeResponseParser.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgeResponseParser.java
@@ -1,0 +1,46 @@
+package dev.dokimos.server.judge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.LlmResponseUtils;
+
+/**
+ * Parses a judge response into a score and reason using the same markdown-stripping and JSON pipeline
+ * as the core LLM judge evaluator. Unlike the evaluator, parsing never throws: a malformed or
+ * incomplete response yields a {@link ParsedScore#failure} so the worker can record a failing eval
+ * result and move on without aborting the job.
+ */
+final class JudgeResponseParser {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private JudgeResponseParser() {}
+
+    /** Result of parsing a judge response: a numeric score and the judge's reasoning. */
+    record ParsedScore(double score, String reason, boolean parsed) {
+
+        static ParsedScore of(double score, String reason) {
+            return new ParsedScore(score, reason, true);
+        }
+
+        static ParsedScore failure(String reason) {
+            return new ParsedScore(0.0, reason, false);
+        }
+    }
+
+    static ParsedScore parse(String response) {
+        try {
+            String json = LlmResponseUtils.stripMarkdown(response);
+            JsonNode node = OBJECT_MAPPER.readTree(json);
+            JsonNode scoreNode = node.get("score");
+            if (scoreNode == null || !scoreNode.isNumber()) {
+                return ParsedScore.failure("Judge response missing numeric score: " + response);
+            }
+            double score = scoreNode.asDouble();
+            String reason = node.has("reason") ? node.get("reason").asText() : "No reason provided.";
+            return ParsedScore.of(score, reason);
+        } catch (Exception e) {
+            return ParsedScore.failure("Failed to parse judge response: " + e.getMessage());
+        }
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgeScorer.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/judge/JudgeScorer.java
@@ -1,0 +1,60 @@
+package dev.dokimos.server.judge;
+
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.JudgeLM;
+import java.util.List;
+
+/**
+ * Drives a single judge scoring: builds the prompt from a criteria and the selected parameters, calls
+ * the underlying {@link JudgeLM}, and parses the response. A failed parse yields a non-successful
+ * outcome with the failure reason rather than throwing; an HTTP failure propagates as a
+ * {@link JudgeCallException} so the worker can apply retry logic.
+ */
+public final class JudgeScorer {
+
+    private final JudgeLM judge;
+    private final String criteria;
+    private final List<EvalTestCaseParam> params;
+    private final double minScore;
+    private final double maxScore;
+    private final Double threshold;
+
+    public JudgeScorer(
+            JudgeLM judge,
+            String criteria,
+            List<EvalTestCaseParam> params,
+            double minScore,
+            double maxScore,
+            Double threshold) {
+        this.judge = judge;
+        this.criteria = criteria;
+        this.params = List.copyOf(params);
+        this.minScore = minScore;
+        this.maxScore = maxScore;
+        this.threshold = threshold;
+    }
+
+    /**
+     * Scores one item.
+     *
+     * @param input          the rendered input value
+     * @param expectedOutput the rendered expected output value
+     * @param actualOutput   the rendered actual output value
+     * @return the score, reason, and pass/fail decision
+     * @throws JudgeCallException if the underlying judge call fails
+     */
+    public ScoreOutcome score(String input, String expectedOutput, String actualOutput) {
+        String prompt =
+                JudgePromptBuilder.build(criteria, params, minScore, maxScore, input, expectedOutput, actualOutput);
+        String response = judge.generate(prompt);
+        JudgeResponseParser.ParsedScore parsed = JudgeResponseParser.parse(response);
+        if (!parsed.parsed()) {
+            return new ScoreOutcome(0.0, parsed.reason(), false);
+        }
+        boolean success = threshold == null || parsed.score() >= threshold;
+        return new ScoreOutcome(parsed.score(), parsed.reason(), success);
+    }
+
+    /** The result of scoring one item: a numeric score, the judge's reasoning, and the pass decision. */
+    public record ScoreOutcome(double score, String reason, boolean success) {}
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/judge/OpenAiCompatibleJudge.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/judge/OpenAiCompatibleJudge.java
@@ -75,7 +75,7 @@ public class OpenAiCompatibleJudge implements JudgeLM {
 
     private String endpoint() {
         String trimmed = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-        return trimmed + "/v1/chat/completions";
+        return trimmed + "/chat/completions";
     }
 
     private String buildPayload(String prompt) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/judge/OpenAiCompatibleJudge.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/judge/OpenAiCompatibleJudge.java
@@ -1,0 +1,109 @@
+package dev.dokimos.server.judge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.dokimos.core.JudgeLM;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * A {@link JudgeLM} that calls an OpenAI-compatible chat completions endpoint over the JDK HTTP
+ * client, with no vendor SDK. The payload is built and parsed with Jackson. A failed call (HTTP
+ * status 400 or above, a timeout, or a network error) raises a {@link JudgeCallException} carrying the
+ * status so the worker can decide whether to retry. The API key is held only for the lifetime of the
+ * job and is never logged.
+ */
+public class OpenAiCompatibleJudge implements JudgeLM {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(60);
+
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final String model;
+    private final String apiKey;
+
+    public OpenAiCompatibleJudge(String baseUrl, String model, String apiKey) {
+        this(HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build(), baseUrl, model, apiKey);
+    }
+
+    OpenAiCompatibleJudge(HttpClient httpClient, String baseUrl, String model, String apiKey) {
+        this.httpClient = httpClient;
+        this.baseUrl = baseUrl;
+        this.model = model;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public String generate(String prompt) {
+        HttpRequest request;
+        try {
+            request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint()))
+                    .timeout(REQUEST_TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + apiKey)
+                    .POST(HttpRequest.BodyPublishers.ofString(buildPayload(prompt)))
+                    .build();
+        } catch (Exception e) {
+            throw new JudgeCallException(JudgeCallException.NETWORK_ERROR, "Failed to build judge request", e);
+        }
+
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new JudgeCallException(JudgeCallException.NETWORK_ERROR, "Judge call interrupted", e);
+        } catch (Exception e) {
+            throw new JudgeCallException(JudgeCallException.NETWORK_ERROR, "Judge call failed", e);
+        }
+
+        if (response.statusCode() >= 400) {
+            throw new JudgeCallException(
+                    response.statusCode(), "Judge endpoint returned HTTP " + response.statusCode());
+        }
+
+        return extractContent(response.body());
+    }
+
+    private String endpoint() {
+        String trimmed = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return trimmed + "/v1/chat/completions";
+    }
+
+    private String buildPayload(String prompt) {
+        ObjectNode root = OBJECT_MAPPER.createObjectNode();
+        root.put("model", model);
+        ArrayNode messages = root.putArray("messages");
+        ObjectNode userMessage = messages.addObject();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt);
+        try {
+            return OBJECT_MAPPER.writeValueAsString(root);
+        } catch (Exception e) {
+            throw new JudgeCallException(JudgeCallException.NETWORK_ERROR, "Failed to serialize judge payload", e);
+        }
+    }
+
+    private String extractContent(String body) {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(body);
+            JsonNode content = root.path("choices").path(0).path("message").path("content");
+            if (content.isMissingNode() || content.isNull()) {
+                throw new JudgeCallException(JudgeCallException.NETWORK_ERROR, "Judge response has no message content");
+            }
+            return content.asText();
+        } catch (JudgeCallException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new JudgeCallException(JudgeCallException.NETWORK_ERROR, "Failed to read judge response", e);
+        }
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/EvalJobRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/EvalJobRepository.java
@@ -3,15 +3,13 @@ package dev.dokimos.server.repository;
 import dev.dokimos.server.entity.EvalJob;
 import dev.dokimos.server.entity.EvalJobStatus;
 import dev.dokimos.server.entity.ExperimentRun;
-import jakarta.persistence.LockModeType;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 public interface EvalJobRepository extends JpaRepository<EvalJob, UUID> {
@@ -21,27 +19,38 @@ public interface EvalJobRepository extends JpaRepository<EvalJob, UUID> {
     List<EvalJob> findByRunOrderByCreatedAtAsc(ExperimentRun run);
 
     /**
-     * Selects the oldest pending job below the retry ceiling and locks its row so the polling worker
-     * can claim it atomically. {@code SKIP LOCKED} lets concurrent workers each pick a distinct job
-     * instead of blocking on the same row; callers pass a one-row {@link Pageable}.
+     * Atomically claims the oldest pending job below the retry ceiling using {@code FOR UPDATE SKIP
+     * LOCKED}, so multiple worker instances each pick a distinct job instead of blocking on, or
+     * double-processing, the same row. Must run inside a transaction.
      *
      * @param maxAttempts the retry ceiling; jobs at or above this count are skipped
-     * @param pageable    a one-row page request
      * @return the locked candidate job, if any
      */
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints(@jakarta.persistence.QueryHint(name = "jakarta.persistence.lock.timeout", value = "-2"))
-    @Query("""
-            SELECT j FROM EvalJob j
-            WHERE j.status = dev.dokimos.server.entity.EvalJobStatus.PENDING
-            AND j.attemptCount < :maxAttempts
-            ORDER BY j.createdAt ASC
-            """)
-    List<EvalJob> findClaimableJobs(@Param("maxAttempts") int maxAttempts, Pageable pageable);
+    @Query(value = """
+                    SELECT * FROM eval_jobs
+                    WHERE status = 'PENDING' AND attempt_count < :maxAttempts
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    FOR UPDATE SKIP LOCKED
+                    """, nativeQuery = true)
+    Optional<EvalJob> claimNext(@Param("maxAttempts") int maxAttempts);
 
-    default Optional<EvalJob> claimNext(int maxAttempts) {
-        return findClaimableJobs(maxAttempts, Pageable.ofSize(1)).stream().findFirst();
-    }
+    /**
+     * Returns jobs claimed before the cutoff to PENDING so a job orphaned by a crashed worker is
+     * picked up again rather than stranded in CLAIMED forever. The attempt count is left as-is, so the
+     * retry ceiling still bounds how many times a job is reclaimed.
+     *
+     * @param cutoff jobs claimed before this instant are requeued
+     * @return the number of jobs requeued
+     */
+    @Modifying
+    @Query("""
+            UPDATE EvalJob j
+            SET j.status = dev.dokimos.server.entity.EvalJobStatus.PENDING
+            WHERE j.status = dev.dokimos.server.entity.EvalJobStatus.CLAIMED
+            AND j.claimedAt < :cutoff
+            """)
+    int requeueStaleClaims(@Param("cutoff") Instant cutoff);
 
     List<EvalJob> findByStatus(EvalJobStatus status);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/EvalJobRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/EvalJobRepository.java
@@ -1,0 +1,47 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.EvalJobStatus;
+import dev.dokimos.server.entity.ExperimentRun;
+import jakarta.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
+
+public interface EvalJobRepository extends JpaRepository<EvalJob, UUID> {
+
+    boolean existsByRunAndEvaluatorName(ExperimentRun run, String evaluatorName);
+
+    List<EvalJob> findByRunOrderByCreatedAtAsc(ExperimentRun run);
+
+    /**
+     * Selects the oldest pending job below the retry ceiling and locks its row so the polling worker
+     * can claim it atomically. {@code SKIP LOCKED} lets concurrent workers each pick a distinct job
+     * instead of blocking on the same row; callers pass a one-row {@link Pageable}.
+     *
+     * @param maxAttempts the retry ceiling; jobs at or above this count are skipped
+     * @param pageable    a one-row page request
+     * @return the locked candidate job, if any
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@jakarta.persistence.QueryHint(name = "jakarta.persistence.lock.timeout", value = "-2"))
+    @Query("""
+            SELECT j FROM EvalJob j
+            WHERE j.status = dev.dokimos.server.entity.EvalJobStatus.PENDING
+            AND j.attemptCount < :maxAttempts
+            ORDER BY j.createdAt ASC
+            """)
+    List<EvalJob> findClaimableJobs(@Param("maxAttempts") int maxAttempts, Pageable pageable);
+
+    default Optional<EvalJob> claimNext(int maxAttempts) {
+        return findClaimableJobs(maxAttempts, Pageable.ofSize(1)).stream().findFirst();
+    }
+
+    List<EvalJob> findByStatus(EvalJobStatus status);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
 
@@ -37,4 +38,33 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
                         AND EXISTS (SELECT e FROM EvalResult e WHERE e.itemResult = i)
                         """)
     long countItemsWithAllEvalsPassed(ExperimentRun run);
+
+    /**
+     * Seek-based page of run items that carry no eval result for the given evaluator yet. Items are
+     * ordered by id so the worker can page forward by passing the last id it saw as {@code afterId};
+     * the {@code NOT EXISTS} filter is scoped by evaluator name so adding an evaluator to a previously
+     * scored run still picks up every item for that evaluator. Pass the all-zero UUID for the first
+     * page.
+     *
+     * @param runId         the run whose items to scan
+     * @param evaluatorName the evaluator whose results gate the scan
+     * @param afterId       the seek cursor; rows with a strictly greater id are returned
+     * @param pageable      a one-page request bounding the result size
+     * @return the next page of unevaluated items, ordered by id
+     */
+    @Query("""
+            SELECT i FROM ItemResult i
+            WHERE i.run.id = :runId
+            AND i.id > :afterId
+            AND NOT EXISTS (
+                SELECT e FROM EvalResult e
+                WHERE e.itemResult = i AND e.evaluatorName = :evaluatorName
+            )
+            ORDER BY i.id ASC
+            """)
+    List<ItemResult> findItemsNotYetEvaluated(
+            @Param("runId") UUID runId,
+            @Param("evaluatorName") String evaluatorName,
+            @Param("afterId") UUID afterId,
+            Pageable pageable);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepository.java
@@ -1,0 +1,13 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.LlmConnection;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LlmConnectionRepository extends JpaRepository<LlmConnection, UUID> {
+
+    Optional<LlmConnection> findByName(String name);
+
+    boolean existsByName(String name);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/EvalJobService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/EvalJobService.java
@@ -1,0 +1,90 @@
+package dev.dokimos.server.service;
+
+import dev.dokimos.server.dto.v1.EnqueueJudgeRequest;
+import dev.dokimos.server.dto.v1.EvalJobView;
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.entity.RunStatus;
+import dev.dokimos.server.repository.EvalJobRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.repository.LlmConnectionRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Enqueues server-side judge jobs and reads the jobs registered for a run. Enqueuing transitions the
+ * run to {@link RunStatus#EVALUATING} so materialized pass-rate fields stay deferred until the worker
+ * finishes scoring.
+ */
+@Service
+public class EvalJobService {
+
+    private final EvalJobRepository jobRepository;
+    private final ExperimentRunRepository runRepository;
+    private final LlmConnectionRepository connectionRepository;
+
+    public EvalJobService(
+            EvalJobRepository jobRepository,
+            ExperimentRunRepository runRepository,
+            LlmConnectionRepository connectionRepository) {
+        this.jobRepository = jobRepository;
+        this.runRepository = runRepository;
+        this.connectionRepository = connectionRepository;
+    }
+
+    /**
+     * Enqueues a judge job for a run and moves the run into the evaluating state. The run row is locked
+     * for the transition so it serializes against item ingestion and completion.
+     *
+     * @param runId   the run to score
+     * @param request the connection and evaluator configuration
+     * @return the public view of the created job
+     * @throws IllegalArgumentException if the run or connection does not exist (mapped to 404)
+     * @throws IllegalStateException if the run already has a job for this evaluator (mapped to 409)
+     */
+    @Transactional
+    public EvalJobView enqueue(UUID runId, EnqueueJudgeRequest request) {
+        ExperimentRun run = runRepository
+                .findByIdForUpdate(runId)
+                .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
+
+        LlmConnection connection = connectionRepository
+                .findById(request.connectionId())
+                .orElseThrow(() -> new IllegalArgumentException("Connection not found: " + request.connectionId()));
+
+        if (jobRepository.existsByRunAndEvaluatorName(run, request.evaluatorName())) {
+            throw new IllegalStateException(
+                    "A judge job already exists for evaluator '" + request.evaluatorName() + "' on run " + runId);
+        }
+
+        EvalJob job = new EvalJob(run, connection, request.evaluatorName(), request.criteria());
+        job.setEvaluationParams(String.join(",", request.evaluationParams()));
+        job.setMinScore(request.minScore());
+        job.setMaxScore(request.maxScore());
+        job.setThreshold(request.threshold());
+        EvalJob saved = jobRepository.save(job);
+
+        run.setStatus(RunStatus.EVALUATING);
+        runRepository.save(run);
+
+        return EvalJobView.from(saved);
+    }
+
+    /**
+     * Lists the judge jobs registered for a run, oldest first.
+     *
+     * @throws IllegalArgumentException if the run does not exist (mapped to 404)
+     */
+    @Transactional(readOnly = true)
+    public List<EvalJobView> getJobsForRun(UUID runId) {
+        ExperimentRun run = runRepository
+                .findById(runId)
+                .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
+        return jobRepository.findByRunOrderByCreatedAtAsc(run).stream()
+                .map(EvalJobView::from)
+                .toList();
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
@@ -1,0 +1,148 @@
+package dev.dokimos.server.service;
+
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.EvalJobStatus;
+import dev.dokimos.server.entity.EvalResult;
+import dev.dokimos.server.entity.ItemResult;
+import dev.dokimos.server.repository.EvalJobRepository;
+import dev.dokimos.server.repository.EvalResultRepository;
+import dev.dokimos.server.repository.ItemResultRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The transactional steps of the judge worker, each in its own committed transaction so the worker can
+ * make the LLM HTTP call between them without holding a database transaction open. Splitting these out
+ * of the worker also makes {@code REQUIRES_NEW} boundaries effective, since self-invocation would
+ * otherwise bypass the proxy.
+ */
+@Component
+public class JudgeJobTransactions {
+
+    private final EvalJobRepository jobRepository;
+    private final EvalResultRepository evalResultRepository;
+    private final ItemResultRepository itemResultRepository;
+    private final RunService runService;
+
+    public JudgeJobTransactions(
+            EvalJobRepository jobRepository,
+            EvalResultRepository evalResultRepository,
+            ItemResultRepository itemResultRepository,
+            RunService runService) {
+        this.jobRepository = jobRepository;
+        this.evalResultRepository = evalResultRepository;
+        this.itemResultRepository = itemResultRepository;
+        this.runService = runService;
+    }
+
+    /**
+     * Claims the oldest pending job below the retry ceiling: locks its row, marks it CLAIMED, stamps
+     * the claim time, and increments the attempt count. Commits before returning so the lock is not
+     * held during the HTTP work that follows.
+     *
+     * @param maxAttempts the retry ceiling
+     * @return the claimed job, or empty if none is available
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Optional<EvalJob> claimNextJob(int maxAttempts) {
+        Optional<EvalJob> claimed = jobRepository.claimNext(maxAttempts);
+        claimed.ifPresent(job -> {
+            job.setStatus(EvalJobStatus.CLAIMED);
+            job.setClaimedAt(Instant.now());
+            job.setAttemptCount(job.getAttemptCount() + 1);
+            jobRepository.save(job);
+        });
+        return claimed;
+    }
+
+    /**
+     * Reads a seek-keyed page of items that have no result yet for the job's evaluator. Returns plain
+     * snapshots so the worker can score them after the transaction closes without touching detached
+     * entities.
+     *
+     * @param runId         the run whose items to scan
+     * @param evaluatorName the evaluator whose results gate the scan
+     * @param afterId       the seek cursor; the all-zero UUID for the first page
+     * @param pageSize      the maximum number of items to return
+     * @return the next page of unevaluated item snapshots, ordered by id
+     */
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public List<ItemSnapshot> loadUnevaluatedPage(UUID runId, String evaluatorName, UUID afterId, int pageSize) {
+        return itemResultRepository
+                .findItemsNotYetEvaluated(runId, evaluatorName, afterId, Pageable.ofSize(pageSize))
+                .stream()
+                .map(item -> new ItemSnapshot(
+                        item.getId(), item.getInput(), item.getExpectedOutput(), item.getActualOutput()))
+                .toList();
+    }
+
+    /**
+     * Persists a page of eval results and advances the job's seek cursor in one transaction.
+     *
+     * @param jobId      the job being processed
+     * @param results    the eval results to attach to their item results
+     * @param lastItemId the id of the last item scored in this page
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void persistPage(UUID jobId, List<ScoredResult> results, UUID lastItemId) {
+        for (ScoredResult scored : results) {
+            ItemResult item = itemResultRepository.getReferenceById(scored.itemId());
+            item.addEvalResult(scored.evalResult());
+            evalResultRepository.save(scored.evalResult());
+        }
+        EvalJob job = jobRepository.getReferenceById(jobId);
+        job.setLastItemId(lastItemId);
+        jobRepository.save(job);
+    }
+
+    /**
+     * Marks the job SUCCEEDED and finalizes its run (re-materializes counts, moves the run to SUCCESS).
+     *
+     * @param jobId the job that finished scoring
+     * @param runId the run to finalize
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markSucceeded(UUID jobId, UUID runId) {
+        EvalJob job = jobRepository.getReferenceById(jobId);
+        job.setStatus(EvalJobStatus.SUCCEEDED);
+        job.setCompletedAt(Instant.now());
+        jobRepository.save(job);
+        runService.finalizeEvaluatedRun(runId);
+    }
+
+    /**
+     * Records a failure. When the failure is retryable and the attempt ceiling has not been reached,
+     * the job is returned to PENDING for a later poll; otherwise it is marked FAILED.
+     *
+     * @param jobId       the job that failed
+     * @param error       the error message to record
+     * @param retryable   whether the failure is worth retrying
+     * @param maxAttempts the retry ceiling
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordFailure(UUID jobId, String error, boolean retryable, int maxAttempts) {
+        EvalJob job = jobRepository.getReferenceById(jobId);
+        job.setLastError(error);
+        if (retryable && job.getAttemptCount() < maxAttempts) {
+            job.setStatus(EvalJobStatus.PENDING);
+        } else {
+            job.setStatus(EvalJobStatus.FAILED);
+            job.setCompletedAt(Instant.now());
+        }
+        jobRepository.save(job);
+    }
+
+    /** Pairs an eval result with the id of the item result it belongs to, for batch persistence. */
+    public record ScoredResult(UUID itemId, EvalResult evalResult) {}
+
+    /** A detached view of an item result carrying only the fields the judge prompt needs. */
+    public record ItemSnapshot(
+            UUID id, Map<String, Object> input, Map<String, Object> expectedOutput, Map<String, Object> actualOutput) {}
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.hibernate.Hibernate;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -71,6 +72,9 @@ public class JudgeJobTransactions {
             job.setClaimedAt(Instant.now());
             job.setAttemptCount(job.getAttemptCount() + 1);
             jobRepository.save(job);
+            // The worker reads the connection after this transaction closes (the LLM call must not
+            // hold a database session open), so initialize it now while the session is open.
+            Hibernate.initialize(job.getConnection());
         });
         return claimed;
     }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
@@ -43,6 +43,19 @@ public class JudgeJobTransactions {
     }
 
     /**
+     * Returns jobs orphaned by a crashed worker (claimed before the cutoff and never finished) to
+     * PENDING so the next poll can reclaim them. The attempt count is left as-is, so the retry ceiling
+     * still bounds reclaims.
+     *
+     * @param cutoff jobs claimed before this instant are requeued
+     * @return the number of jobs requeued
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int recoverStaleClaims(Instant cutoff) {
+        return jobRepository.requeueStaleClaims(cutoff);
+    }
+
+    /**
      * Claims the oldest pending job below the retry ceiling: locks its row, marks it CLAIMED, stamps
      * the claim time, and increments the attempt count. Commits before returning so the lock is not
      * held during the HTTP work that follows.
@@ -132,11 +145,14 @@ public class JudgeJobTransactions {
         job.setLastError(error);
         if (retryable && job.getAttemptCount() < maxAttempts) {
             job.setStatus(EvalJobStatus.PENDING);
-        } else {
-            job.setStatus(EvalJobStatus.FAILED);
-            job.setCompletedAt(Instant.now());
+            jobRepository.save(job);
+            return;
         }
+        job.setStatus(EvalJobStatus.FAILED);
+        job.setCompletedAt(Instant.now());
         jobRepository.save(job);
+        // A terminally failed job must not leave its run stuck in EVALUATING.
+        runService.failEvaluatedRun(job.getRun().getId());
     }
 
     /** Pairs an eval result with the id of the item result it belongs to, for batch persistence. */

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeWorker.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeWorker.java
@@ -67,6 +67,7 @@ public class JudgeWorker {
     /** Polls for and processes one job per cycle. The fixed delay is read from {@code dokimos.judge.poll-interval-ms}. */
     @org.springframework.scheduling.annotation.Scheduled(fixedDelayString = "${dokimos.judge.poll-interval-ms:5000}")
     public void poll() {
+        transactions.recoverStaleClaims(java.time.Instant.now().minusMillis(properties.getClaimTimeoutMs()));
         Optional<EvalJob> claimed = transactions.claimNextJob(properties.getMaxAttempts());
         claimed.ifPresent(this::process);
     }
@@ -101,11 +102,24 @@ public class JudgeWorker {
             LOGGER.info("Judge job {} succeeded for run {}", jobId, runId);
         } catch (JudgeCallException e) {
             LOGGER.warn("Judge job {} failed with HTTP status {}: {}", jobId, e.getHttpStatus(), e.getMessage());
-            transactions.recordFailure(jobId, e.getMessage(), e.isRetryable(), properties.getMaxAttempts());
+            transactions.recordFailure(jobId, sanitize(e.getMessage()), e.isRetryable(), properties.getMaxAttempts());
         } catch (Exception e) {
             LOGGER.error("Judge job {} failed", jobId, e);
-            transactions.recordFailure(jobId, e.getMessage(), false, properties.getMaxAttempts());
+            transactions.recordFailure(jobId, sanitize(e.getMessage()), false, properties.getMaxAttempts());
         }
+    }
+
+    /**
+     * Scrubs anything resembling an authorization header or bearer token from an error string before
+     * it is persisted and exposed over the API, and caps its length, so a low-level failure cannot
+     * leak credential material into {@code eval_jobs.last_error}.
+     */
+    private static String sanitize(String message) {
+        if (message == null) {
+            return null;
+        }
+        String scrubbed = message.replaceAll("(?i)(authorization|bearer)\\s*\\S+", "$1 [redacted]");
+        return scrubbed.length() > 500 ? scrubbed.substring(0, 500) : scrubbed;
     }
 
     private JudgeScorer buildScorer(EvalJob job) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeWorker.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeWorker.java
@@ -1,0 +1,145 @@
+package dev.dokimos.server.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.server.config.JudgeProperties;
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.EvalResult;
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.judge.JudgeCallException;
+import dev.dokimos.server.judge.JudgeScorer;
+import dev.dokimos.server.judge.OpenAiCompatibleJudge;
+import dev.dokimos.server.service.JudgeJobTransactions.ItemSnapshot;
+import dev.dokimos.server.service.JudgeJobTransactions.ScoredResult;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Background worker that drains the judge job queue. Each poll claims at most one pending job in its
+ * own transaction, scores the run's not-yet-evaluated items in seek-keyed pages with the LLM call made
+ * outside any database transaction, persists each page of results in its own transaction, and on
+ * completion finalizes the run. Failures are recorded with retry for transient errors and a terminal
+ * FAILED for non-retryable ones or once the attempt ceiling is reached.
+ */
+@Component
+public class JudgeWorker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JudgeWorker.class);
+    private static final UUID ZERO_UUID = new UUID(0L, 0L);
+
+    private final JudgeJobTransactions transactions;
+    private final LlmCredentialService credentialService;
+    private final JudgeProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final BiFunction<LlmConnection, String, JudgeLM> judgeFactory;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    public JudgeWorker(
+            JudgeJobTransactions transactions, LlmCredentialService credentialService, JudgeProperties properties) {
+        this(
+                transactions,
+                credentialService,
+                properties,
+                (connection, key) -> new OpenAiCompatibleJudge(connection.getBaseUrl(), connection.getModel(), key));
+    }
+
+    JudgeWorker(
+            JudgeJobTransactions transactions,
+            LlmCredentialService credentialService,
+            JudgeProperties properties,
+            BiFunction<LlmConnection, String, JudgeLM> judgeFactory) {
+        this.transactions = transactions;
+        this.credentialService = credentialService;
+        this.properties = properties;
+        this.judgeFactory = judgeFactory;
+    }
+
+    /** Polls for and processes one job per cycle. The fixed delay is read from {@code dokimos.judge.poll-interval-ms}. */
+    @org.springframework.scheduling.annotation.Scheduled(fixedDelayString = "${dokimos.judge.poll-interval-ms:5000}")
+    public void poll() {
+        Optional<EvalJob> claimed = transactions.claimNextJob(properties.getMaxAttempts());
+        claimed.ifPresent(this::process);
+    }
+
+    private void process(EvalJob job) {
+        UUID jobId = job.getId();
+        UUID runId = job.getRun().getId();
+        String evaluatorName = job.getEvaluatorName();
+        try {
+            JudgeScorer scorer = buildScorer(job);
+            UUID cursor = job.getLastItemId() != null ? job.getLastItemId() : ZERO_UUID;
+            int pageSize = properties.getPageSize();
+
+            List<ItemSnapshot> page = transactions.loadUnevaluatedPage(runId, evaluatorName, cursor, pageSize);
+            while (!page.isEmpty()) {
+                List<ScoredResult> scored = new ArrayList<>(page.size());
+                UUID lastItemId = cursor;
+                for (ItemSnapshot item : page) {
+                    JudgeScorer.ScoreOutcome outcome = scorer.score(
+                            render(item.input()), render(item.expectedOutput()), render(item.actualOutput()));
+                    EvalResult result = new EvalResult(
+                            evaluatorName, outcome.score(), job.getThreshold(), outcome.success(), outcome.reason());
+                    scored.add(new ScoredResult(item.id(), result));
+                    lastItemId = item.id();
+                }
+                transactions.persistPage(jobId, scored, lastItemId);
+                cursor = lastItemId;
+                page = transactions.loadUnevaluatedPage(runId, evaluatorName, cursor, pageSize);
+            }
+
+            transactions.markSucceeded(jobId, runId);
+            LOGGER.info("Judge job {} succeeded for run {}", jobId, runId);
+        } catch (JudgeCallException e) {
+            LOGGER.warn("Judge job {} failed with HTTP status {}: {}", jobId, e.getHttpStatus(), e.getMessage());
+            transactions.recordFailure(jobId, e.getMessage(), e.isRetryable(), properties.getMaxAttempts());
+        } catch (Exception e) {
+            LOGGER.error("Judge job {} failed", jobId, e);
+            transactions.recordFailure(jobId, e.getMessage(), false, properties.getMaxAttempts());
+        }
+    }
+
+    private JudgeScorer buildScorer(EvalJob job) {
+        LlmConnection connection = job.getConnection();
+        String key = credentialService.resolveKey(connection);
+        JudgeLM judge = judgeFactory.apply(connection, key);
+        return new JudgeScorer(
+                judge,
+                job.getCriteria(),
+                parseParams(job.getEvaluationParams()),
+                job.getMinScore(),
+                job.getMaxScore(),
+                job.getThreshold());
+    }
+
+    private List<EvalTestCaseParam> parseParams(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(EvalTestCaseParam::valueOf)
+                .toList();
+    }
+
+    private String render(Map<String, Object> value) {
+        if (value == null) {
+            return "";
+        }
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/LlmConnectionService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/LlmConnectionService.java
@@ -1,0 +1,73 @@
+package dev.dokimos.server.service;
+
+import dev.dokimos.server.dto.v1.CreateLlmConnectionRequest;
+import dev.dokimos.server.dto.v1.LlmConnectionView;
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.repository.LlmConnectionRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Registers and reads LLM connections. Inline keys are encrypted before persistence; responses never
+ * carry key material. Connection names are unique across the server.
+ */
+@Service
+public class LlmConnectionService {
+
+    private final LlmConnectionRepository connectionRepository;
+    private final LlmCredentialService credentialService;
+
+    public LlmConnectionService(LlmConnectionRepository connectionRepository, LlmCredentialService credentialService) {
+        this.connectionRepository = connectionRepository;
+        this.credentialService = credentialService;
+    }
+
+    /**
+     * Registers a connection. Exactly one of an inline key or a credential reference is stored; an
+     * inline key is encrypted at rest.
+     *
+     * @param request the connection definition
+     * @return the public view of the saved connection
+     * @throws IllegalStateException if a connection with the same name already exists (mapped to 409)
+     */
+    @Transactional
+    public LlmConnectionView create(CreateLlmConnectionRequest request) {
+        if (connectionRepository.existsByName(request.name())) {
+            throw new IllegalStateException("Connection already exists: " + request.name());
+        }
+
+        LlmConnection connection = new LlmConnection(request.name(), request.baseUrl(), request.model());
+        if (request.apiKey() != null && !request.apiKey().isBlank()) {
+            credentialService.encryptInlineKey(connection, request.apiKey());
+        } else {
+            connection.setCredentialRef(request.credentialRef());
+        }
+
+        return LlmConnectionView.from(connectionRepository.save(connection));
+    }
+
+    @Transactional(readOnly = true)
+    public List<LlmConnectionView> list() {
+        return connectionRepository.findAll().stream()
+                .map(LlmConnectionView::from)
+                .toList();
+    }
+
+    /**
+     * Returns a connection by id.
+     *
+     * @throws IllegalArgumentException if no connection has the id (mapped to 404)
+     */
+    @Transactional(readOnly = true)
+    public LlmConnectionView get(UUID id) {
+        return LlmConnectionView.from(loadConnection(id));
+    }
+
+    private LlmConnection loadConnection(UUID id) {
+        return connectionRepository
+                .findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Connection not found: " + id));
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/LlmCredentialService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/LlmCredentialService.java
@@ -3,11 +3,12 @@ package dev.dokimos.server.service;
 import dev.dokimos.server.config.ApiKeyProperties;
 import dev.dokimos.server.entity.LlmConnection;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +25,8 @@ public class LlmCredentialService {
     private static final String TRANSFORMATION = "AES/GCM/NoPadding";
     private static final int IV_LENGTH = 12;
     private static final int TAG_LENGTH_BITS = 128;
+    private static final byte[] KDF_SALT = "dokimos-llm-connection-key".getBytes(StandardCharsets.UTF_8);
+    private static final int KDF_ITERATIONS = 100_000;
 
     private final ApiKeyProperties properties;
     private final SecureRandom secureRandom = new SecureRandom();
@@ -111,7 +114,10 @@ public class LlmCredentialService {
                     "DOKIMOS_ENCRYPTION_KEY must be set to register or use a connection with an inline API key");
         }
         try {
-            byte[] derived = MessageDigest.getInstance("SHA-256").digest(secret.getBytes(StandardCharsets.UTF_8));
+            PBEKeySpec spec = new PBEKeySpec(secret.toCharArray(), KDF_SALT, KDF_ITERATIONS, 256);
+            byte[] derived = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+                    .generateSecret(spec)
+                    .getEncoded();
             return new SecretKeySpec(derived, "AES");
         } catch (Exception e) {
             throw new IllegalStateException("Failed to derive encryption key", e);

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/LlmCredentialService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/LlmCredentialService.java
@@ -1,0 +1,120 @@
+package dev.dokimos.server.service;
+
+import dev.dokimos.server.config.ApiKeyProperties;
+import dev.dokimos.server.entity.LlmConnection;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves and protects the API key for an {@link LlmConnection}. Inline keys are encrypted with
+ * AES-256-GCM under a key derived from the configured encryption secret; external keys are read from
+ * the named environment variable at resolution time. The master encryption secret is required only
+ * when an inline key is encrypted or decrypted, so deployments that use only environment-backed
+ * connections need not configure it.
+ */
+@Service
+public class LlmCredentialService {
+
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int IV_LENGTH = 12;
+    private static final int TAG_LENGTH_BITS = 128;
+
+    private final ApiKeyProperties properties;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public LlmCredentialService(ApiKeyProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Returns a copy of the connection with its inline key encrypted. Used on the create path before
+     * the connection is persisted.
+     *
+     * @param connection the connection to populate
+     * @param rawKey     the plaintext API key supplied by the caller
+     * @return the connection with {@code encryptedApiKey} set
+     * @throws IllegalStateException if the encryption secret is not configured
+     */
+    public LlmConnection encryptInlineKey(LlmConnection connection, String rawKey) {
+        connection.setEncryptedApiKey(encrypt(rawKey));
+        return connection;
+    }
+
+    /**
+     * Resolves the effective plaintext API key for a connection.
+     *
+     * @param connection the connection to resolve
+     * @return the plaintext API key
+     * @throws IllegalStateException if a referenced environment variable is absent, or if an inline key
+     *     cannot be decrypted, or if neither credential source is set
+     */
+    public String resolveKey(LlmConnection connection) {
+        if (connection.hasInlineKey()) {
+            return decrypt(connection.getEncryptedApiKey());
+        }
+        String ref = connection.getCredentialRef();
+        if (ref != null && !ref.isBlank()) {
+            String value = System.getenv(ref);
+            if (value == null || value.isBlank()) {
+                throw new IllegalStateException("Credential environment variable is not set: " + ref);
+            }
+            return value;
+        }
+        throw new IllegalStateException("Connection has no credential source: " + connection.getId());
+    }
+
+    private String encrypt(String plaintext) {
+        try {
+            byte[] iv = new byte[IV_LENGTH];
+            secureRandom.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey(), new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            byte[] ciphertext = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+            byte[] combined = new byte[iv.length + ciphertext.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(ciphertext, 0, combined, iv.length, ciphertext.length);
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encrypt API key", e);
+        }
+    }
+
+    private String decrypt(String encoded) {
+        try {
+            byte[] combined = Base64.getDecoder().decode(encoded);
+            byte[] iv = new byte[IV_LENGTH];
+            byte[] ciphertext = new byte[combined.length - IV_LENGTH];
+            System.arraycopy(combined, 0, iv, 0, IV_LENGTH);
+            System.arraycopy(combined, IV_LENGTH, ciphertext, 0, ciphertext.length);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey(), new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to decrypt API key", e);
+        }
+    }
+
+    private SecretKeySpec secretKey() {
+        String secret = properties.getEncryptionKey();
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                    "DOKIMOS_ENCRYPTION_KEY must be set to register or use a connection with an inline API key");
+        }
+        try {
+            byte[] derived = MessageDigest.getInstance("SHA-256").digest(secret.getBytes(StandardCharsets.UTF_8));
+            return new SecretKeySpec(derived, "AES");
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to derive encryption key", e);
+        }
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
@@ -185,11 +185,31 @@ public class RunService {
     @Transactional
     public void updateRun(UUID runId, UpdateRunRequest request) {
         ExperimentRun run = getRunForUpdate(runId);
+        if (run.getStatus() == RunStatus.EVALUATING && request.status() == RunStatus.RUNNING) {
+            throw new IllegalStateException("Cannot move a run from EVALUATING back to RUNNING: " + runId);
+        }
         run.setStatus(request.status());
         if (request.status() != RunStatus.RUNNING) {
             run.setCompletedAt(Instant.now());
             materializeCounts(run);
         }
+        runRepository.save(run);
+    }
+
+    /**
+     * Finalizes a run whose judge job has finished scoring: re-computes the materialized pass-rate
+     * fields and moves the run to SUCCESS. The run row is locked so the finalization serializes against
+     * any concurrent ingestion or status update.
+     *
+     * @param runId the run to finalize
+     * @throws IllegalArgumentException if the run does not exist
+     */
+    @Transactional
+    public void finalizeEvaluatedRun(UUID runId) {
+        ExperimentRun run = getRunForUpdate(runId);
+        materializeCounts(run);
+        run.setStatus(RunStatus.SUCCESS);
+        run.setCompletedAt(Instant.now());
         runRepository.save(run);
     }
 
@@ -215,7 +235,7 @@ public class RunService {
         long totalItems;
         long passedItems;
         Double passRate;
-        if (run.getStatus() == RunStatus.RUNNING) {
+        if (run.getStatus() == RunStatus.RUNNING || run.getStatus() == RunStatus.EVALUATING) {
             totalItems = itemResultRepository.countByRun(run);
             passedItems = itemResultRepository.countItemsWithAllEvalsPassed(run);
             passRate = totalItems > 0 ? (double) passedItems / totalItems : null;
@@ -271,7 +291,7 @@ public class RunService {
         long totalItems;
         long passedItems;
         Double passRate;
-        if (run.getStatus() == RunStatus.RUNNING) {
+        if (run.getStatus() == RunStatus.RUNNING || run.getStatus() == RunStatus.EVALUATING) {
             totalItems = itemResultRepository.countByRun(run);
             passedItems = itemResultRepository.countItemsWithAllEvalsPassed(run);
             passRate = totalItems > 0 ? (double) passedItems / totalItems : null;

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
@@ -185,8 +185,9 @@ public class RunService {
     @Transactional
     public void updateRun(UUID runId, UpdateRunRequest request) {
         ExperimentRun run = getRunForUpdate(runId);
-        if (run.getStatus() == RunStatus.EVALUATING && request.status() == RunStatus.RUNNING) {
-            throw new IllegalStateException("Cannot move a run from EVALUATING back to RUNNING: " + runId);
+        if (run.getStatus() == RunStatus.EVALUATING) {
+            throw new IllegalStateException(
+                    "Run " + runId + " is evaluating; its status is managed by the judge worker");
         }
         run.setStatus(request.status());
         if (request.status() != RunStatus.RUNNING) {
@@ -207,8 +208,30 @@ public class RunService {
     @Transactional
     public void finalizeEvaluatedRun(UUID runId) {
         ExperimentRun run = getRunForUpdate(runId);
+        if (run.getStatus() != RunStatus.EVALUATING) {
+            return;
+        }
         materializeCounts(run);
         run.setStatus(RunStatus.SUCCESS);
+        run.setCompletedAt(Instant.now());
+        runRepository.save(run);
+    }
+
+    /**
+     * Moves an evaluating run to FAILED when its judge job has terminally failed, so the run does not
+     * stay stuck in EVALUATING. No-op if the run is no longer EVALUATING.
+     *
+     * @param runId the run to fail
+     * @throws IllegalArgumentException if the run does not exist
+     */
+    @Transactional
+    public void failEvaluatedRun(UUID runId) {
+        ExperimentRun run = getRunForUpdate(runId);
+        if (run.getStatus() != RunStatus.EVALUATING) {
+            return;
+        }
+        materializeCounts(run);
+        run.setStatus(RunStatus.FAILED);
         run.setCompletedAt(Instant.now());
         runRepository.save(run);
     }

--- a/dokimos-server/src/main/resources/application.yml
+++ b/dokimos-server/src/main/resources/application.yml
@@ -3,6 +3,11 @@ server:
 
 dokimos:
   api-key: ${DOKIMOS_API_KEY:}
+  encryption-key: ${DOKIMOS_ENCRYPTION_KEY:}
+  judge:
+    poll-interval-ms: ${DOKIMOS_JUDGE_POLL_INTERVAL_MS:5000}
+    max-attempts: ${DOKIMOS_JUDGE_MAX_ATTEMPTS:3}
+    page-size: ${DOKIMOS_JUDGE_PAGE_SIZE:50}
 
 spring:
   application:

--- a/dokimos-server/src/main/resources/db/migration/V8__llm_judge.sql
+++ b/dokimos-server/src/main/resources/db/migration/V8__llm_judge.sql
@@ -1,0 +1,42 @@
+-- Server-side LLM judge subsystem: reusable OpenAI-compatible connections and a poll-and-claim job
+-- queue for scoring run items. A connection stores exactly one credential source, enforced by the
+-- check constraint as a backstop to the request-level validation: either an external credential_ref
+-- (an environment variable name) or an inline encrypted_api_key, never both and never neither.
+CREATE TABLE llm_connections (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    base_url VARCHAR(512) NOT NULL,
+    model VARCHAR(255) NOT NULL,
+    credential_ref VARCHAR(255),
+    encrypted_api_key TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT ck_llm_connection_credential CHECK ((credential_ref IS NULL) <> (encrypted_api_key IS NULL))
+);
+
+-- A job scores every not-yet-evaluated item of a run with one evaluator configuration. The unique
+-- constraint on (run_id, evaluator_name) keeps a single job per evaluator per run. Deleting a run
+-- cascades to its jobs; deleting a connection is blocked while a job references it.
+CREATE TABLE eval_jobs (
+    id UUID PRIMARY KEY,
+    run_id UUID NOT NULL REFERENCES experiment_runs(id) ON DELETE CASCADE,
+    connection_id UUID NOT NULL REFERENCES llm_connections(id),
+    status VARCHAR(50) NOT NULL DEFAULT 'PENDING',
+    evaluator_name VARCHAR(255) NOT NULL,
+    criteria TEXT NOT NULL,
+    evaluation_params VARCHAR(255) NOT NULL,
+    min_score DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    max_score DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    threshold DOUBLE PRECISION,
+    last_item_id UUID,
+    attempt_count INT NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    claimed_at TIMESTAMP WITH TIME ZONE,
+    completed_at TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT uq_eval_job_run_evaluator UNIQUE (run_id, evaluator_name)
+);
+
+-- The worker polls for the oldest pending job; a partial index keeps that scan cheap.
+CREATE INDEX idx_eval_jobs_pending ON eval_jobs(created_at) WHERE status = 'PENDING';
+CREATE INDEX idx_eval_jobs_run_id ON eval_jobs(run_id);

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/EvalJobControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/EvalJobControllerTest.java
@@ -1,0 +1,101 @@
+package dev.dokimos.server.controller.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dev.dokimos.server.controller.GlobalExceptionHandler;
+import dev.dokimos.server.dto.v1.EnqueueJudgeRequest;
+import dev.dokimos.server.dto.v1.EvalJobView;
+import dev.dokimos.server.entity.EvalJobStatus;
+import dev.dokimos.server.service.EvalJobService;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@SuppressWarnings("null")
+@ExtendWith(MockitoExtension.class)
+class EvalJobControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private EvalJobService jobService;
+
+    private UUID runId;
+    private UUID connectionId;
+
+    @BeforeEach
+    void setUp() {
+        EvalJobController controller = new EvalJobController(jobService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+        runId = UUID.randomUUID();
+        connectionId = UUID.randomUUID();
+    }
+
+    private EnqueueJudgeRequest request() {
+        return new EnqueueJudgeRequest(connectionId, "judge", "is correct", List.of("ACTUAL_OUTPUT"), 0.0, 1.0, 0.5);
+    }
+
+    private EvalJobView view(UUID id) {
+        return new EvalJobView(
+                id, runId, connectionId, "judge", EvalJobStatus.PENDING, 0, null, Instant.now(), null, null);
+    }
+
+    @Test
+    void enqueue_shouldReturn201() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        when(jobService.enqueue(eq(runId), any())).thenReturn(view(jobId));
+
+        mockMvc.perform(post("/api/v1/runs/" + runId + "/judge-jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(jobId.toString()))
+                .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    void enqueue_shouldReturn409OnDuplicateJob() throws Exception {
+        doThrow(new IllegalStateException("A judge job already exists"))
+                .when(jobService)
+                .enqueue(eq(runId), any());
+
+        mockMvc.perform(post("/api/v1/runs/" + runId + "/judge-jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request())))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void enqueue_shouldReturn400WhenParamsEmpty() throws Exception {
+        EnqueueJudgeRequest invalid =
+                new EnqueueJudgeRequest(connectionId, "judge", "is correct", List.of(), 0.0, 1.0, 0.5);
+
+        mockMvc.perform(post("/api/v1/runs/" + runId + "/judge-jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void list_shouldReturnEmptyList() throws Exception {
+        when(jobService.getJobsForRun(runId)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/runs/" + runId + "/judge-jobs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/LlmConnectionControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/LlmConnectionControllerTest.java
@@ -1,0 +1,95 @@
+package dev.dokimos.server.controller.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dev.dokimos.server.controller.GlobalExceptionHandler;
+import dev.dokimos.server.dto.v1.CreateLlmConnectionRequest;
+import dev.dokimos.server.dto.v1.LlmConnectionView;
+import dev.dokimos.server.service.LlmConnectionService;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@SuppressWarnings("null")
+@ExtendWith(MockitoExtension.class)
+class LlmConnectionControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private LlmConnectionService connectionService;
+
+    @BeforeEach
+    void setUp() {
+        LlmConnectionController controller = new LlmConnectionController(connectionService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    private LlmConnectionView view(UUID id) {
+        return new LlmConnectionView(
+                id, "conn", "https://api.example.com", "gpt-4", "OPENAI_KEY", false, Instant.now());
+    }
+
+    @Test
+    void create_shouldReturn201AndNoKeyMaterial() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(connectionService.create(any())).thenReturn(view(id));
+        CreateLlmConnectionRequest request =
+                new CreateLlmConnectionRequest("conn", "https://api.example.com", "gpt-4", null, "OPENAI_KEY");
+
+        mockMvc.perform(post("/api/v1/llm-connections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(id.toString()))
+                .andExpect(jsonPath("$.hasInlineKey").value(false))
+                .andExpect(jsonPath("$.encryptedApiKey").doesNotExist())
+                .andExpect(jsonPath("$.apiKey").doesNotExist());
+    }
+
+    @Test
+    void create_shouldReturn400WhenBothCredentialsSupplied() throws Exception {
+        CreateLlmConnectionRequest request =
+                new CreateLlmConnectionRequest("conn", "https://api.example.com", "gpt-4", "sk-inline", "OPENAI_KEY");
+
+        mockMvc.perform(post("/api/v1/llm-connections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_shouldReturn409OnDuplicateName() throws Exception {
+        doThrow(new IllegalStateException("Connection already exists: conn"))
+                .when(connectionService)
+                .create(any());
+        CreateLlmConnectionRequest request =
+                new CreateLlmConnectionRequest("conn", "https://api.example.com", "gpt-4", null, "OPENAI_KEY");
+
+        mockMvc.perform(post("/api/v1/llm-connections")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void get_shouldReturn404WhenMissing() throws Exception {
+        UUID id = UUID.randomUUID();
+        when(connectionService.get(eq(id))).thenThrow(new IllegalArgumentException("Connection not found: " + id));
+
+        mockMvc.perform(get("/api/v1/llm-connections/" + id)).andExpect(status().isNotFound());
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/judge/JudgePromptBuilderTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/judge/JudgePromptBuilderTest.java
@@ -1,0 +1,37 @@
+package dev.dokimos.server.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.dokimos.core.EvalTestCaseParam;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JudgePromptBuilderTest {
+
+    @Test
+    void includesCriteriaSelectedParamsAndJsonInstruction() {
+        String prompt = JudgePromptBuilder.build(
+                "answer is correct",
+                List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT),
+                0.0,
+                1.0,
+                "what is 2+2",
+                "4",
+                "four");
+
+        assertThat(prompt).contains("answer is correct");
+        assertThat(prompt).contains("Input: what is 2+2");
+        assertThat(prompt).contains("Actual Output: four");
+        assertThat(prompt).contains("{\"score\": <number>, \"reason\": \"<explanation>\"}");
+    }
+
+    @Test
+    void omitsParamsNotRequested() {
+        String prompt = JudgePromptBuilder.build(
+                "criteria", List.of(EvalTestCaseParam.ACTUAL_OUTPUT), 0.0, 1.0, "in", "exp", "act");
+
+        assertThat(prompt).doesNotContain("Input:");
+        assertThat(prompt).doesNotContain("Expected Output:");
+        assertThat(prompt).contains("Actual Output: act");
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/judge/JudgeResponseParserTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/judge/JudgeResponseParserTest.java
@@ -1,0 +1,53 @@
+package dev.dokimos.server.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.dokimos.server.judge.JudgeResponseParser.ParsedScore;
+import org.junit.jupiter.api.Test;
+
+class JudgeResponseParserTest {
+
+    @Test
+    void parsesPlainJson() {
+        ParsedScore result = JudgeResponseParser.parse("{\"score\": 0.8, \"reason\": \"good\"}");
+
+        assertThat(result.parsed()).isTrue();
+        assertThat(result.score()).isEqualTo(0.8);
+        assertThat(result.reason()).isEqualTo("good");
+    }
+
+    @Test
+    void parsesMarkdownWrappedJson() {
+        ParsedScore result = JudgeResponseParser.parse("```json\n{\"score\": 1.0, \"reason\": \"perfect\"}\n```");
+
+        assertThat(result.parsed()).isTrue();
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.reason()).isEqualTo("perfect");
+    }
+
+    @Test
+    void defaultsReasonWhenMissing() {
+        ParsedScore result = JudgeResponseParser.parse("{\"score\": 0.5}");
+
+        assertThat(result.parsed()).isTrue();
+        assertThat(result.score()).isEqualTo(0.5);
+        assertThat(result.reason()).isEqualTo("No reason provided.");
+    }
+
+    @Test
+    void failsWhenScoreMissing() {
+        ParsedScore result = JudgeResponseParser.parse("{\"reason\": \"no score here\"}");
+
+        assertThat(result.parsed()).isFalse();
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("missing numeric score");
+    }
+
+    @Test
+    void failsOnMalformedJson() {
+        ParsedScore result = JudgeResponseParser.parse("not json at all");
+
+        assertThat(result.parsed()).isFalse();
+        assertThat(result.reason()).contains("Failed to parse judge response");
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/judge/OpenAiCompatibleJudgeTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/judge/OpenAiCompatibleJudgeTest.java
@@ -1,0 +1,53 @@
+package dev.dokimos.server.judge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class OpenAiCompatibleJudgeTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void appendsChatCompletionsToTheConfiguredBaseUrl() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"choices\":[{\"message\":{\"content\":\"{\\\"score\\\":1.0}\"}}]}");
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        OpenAiCompatibleJudge judge =
+                new OpenAiCompatibleJudge(client, "https://api.openai.com/v1", "gpt-4o-mini", "test-key");
+        judge.generate("score this");
+
+        ArgumentCaptor<HttpRequest> request = ArgumentCaptor.forClass(HttpRequest.class);
+        org.mockito.Mockito.verify(client).send(request.capture(), any(HttpResponse.BodyHandler.class));
+        assertThat(request.getValue().uri().toString()).isEqualTo("https://api.openai.com/v1/chat/completions");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void trimsTrailingSlashOnTheBaseUrl() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"choices\":[{\"message\":{\"content\":\"{\\\"score\\\":1.0}\"}}]}");
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        OpenAiCompatibleJudge judge =
+                new OpenAiCompatibleJudge(client, "http://localhost:11434/v1/", "llama3", "test-key");
+        judge.generate("score this");
+
+        ArgumentCaptor<HttpRequest> request = ArgumentCaptor.forClass(HttpRequest.class);
+        org.mockito.Mockito.verify(client).send(request.capture(), any(HttpResponse.BodyHandler.class));
+        assertThat(request.getValue().uri().toString()).isEqualTo("http://localhost:11434/v1/chat/completions");
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/migration/FlywayMigrationTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/migration/FlywayMigrationTest.java
@@ -20,7 +20,7 @@ import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
- * Verifies the Flyway migrations (V1 through V6) against a real PostgreSQL instance. Self-skips when
+ * Verifies the Flyway migrations against a real PostgreSQL instance. Self-skips when
  * Docker is unavailable so it stays safe in the normal build. Not tagged as an integration test: when
  * Docker is present it runs as part of {@code mvn test}. One container is shared across tests and
  * the schema is dropped (Flyway clean) before each test.
@@ -766,6 +766,110 @@ class FlywayMigrationTest {
                     assertThat(rs.wasNull()).isTrue();
                 }
             }
+        }
+    }
+
+    /**
+     * Verifies V8 builds the judge tables. Migrates to V7, applies V8, and checks that
+     * llm_connections enforces the one-credential-source check constraint, that eval_jobs enforces the
+     * unique (run_id, evaluator_name) constraint and the references it declares, and that deleting a
+     * run cascades to its jobs.
+     */
+    @Test
+    void v8BuildsJudgeTables() throws Exception {
+        DataSource ds = dataSource();
+
+        Flyway.configure().dataSource(ds).target("7").load().migrate();
+        Flyway.configure().dataSource(ds).target("8").load().migrate();
+
+        UUID projectId = UUID.randomUUID();
+        UUID experimentId = UUID.randomUUID();
+        UUID runId = UUID.randomUUID();
+        UUID otherRunId = UUID.randomUUID();
+        UUID connectionId = UUID.randomUUID();
+
+        try (Connection conn = ds.getConnection()) {
+            assertColumnExists(conn, "llm_connections", "name");
+            assertColumnExists(conn, "llm_connections", "base_url");
+            assertColumnExists(conn, "llm_connections", "encrypted_api_key");
+            assertColumnExists(conn, "eval_jobs", "run_id");
+            assertColumnExists(conn, "eval_jobs", "evaluator_name");
+            assertColumnExists(conn, "eval_jobs", "last_item_id");
+            assertColumnExists(conn, "eval_jobs", "attempt_count");
+
+            insertProject(conn, projectId, "v8-project");
+            insertExperiment(conn, experimentId, projectId, "v8-experiment");
+            insertRun(conn, runId, experimentId, "EVALUATING");
+            insertRun(conn, otherRunId, experimentId, "EVALUATING");
+            insertConnection(conn, connectionId, "v8-conn");
+
+            // The credential check constraint rejects a row with neither credential source.
+            assertThatThrownBy(() -> insertConnectionRaw(conn, UUID.randomUUID(), "no-cred", null, null))
+                    .isInstanceOf(java.sql.SQLException.class);
+
+            // The credential check constraint rejects a row with both credential sources.
+            assertThatThrownBy(() -> insertConnectionRaw(conn, UUID.randomUUID(), "both-cred", "ENV_KEY", "cipher"))
+                    .isInstanceOf(java.sql.SQLException.class);
+
+            insertEvalJob(conn, UUID.randomUUID(), runId, connectionId, "judge");
+
+            // The unique (run_id, evaluator_name) constraint rejects a second job for the same evaluator.
+            assertThatThrownBy(() -> insertEvalJob(conn, UUID.randomUUID(), runId, connectionId, "judge"))
+                    .isInstanceOf(java.sql.SQLException.class);
+
+            // The same evaluator on a different run is allowed.
+            insertEvalJob(conn, UUID.randomUUID(), otherRunId, connectionId, "judge");
+
+            // Deleting a run cascades to its jobs.
+            try (PreparedStatement ps = conn.prepareStatement("DELETE FROM experiment_runs WHERE id = ?")) {
+                ps.setObject(1, runId);
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = conn.prepareStatement("SELECT COUNT(*) FROM eval_jobs WHERE run_id = ?")) {
+                ps.setObject(1, runId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getInt(1)).isZero();
+                }
+            }
+        }
+    }
+
+    private void insertConnection(Connection conn, UUID id, String name) throws Exception {
+        insertConnectionRaw(conn, id, name, "ENV_KEY", null);
+    }
+
+    private void insertConnectionRaw(Connection conn, UUID id, String name, String credentialRef, String encryptedKey)
+            throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO llm_connections "
+                + "(id, name, base_url, model, credential_ref, encrypted_api_key, created_at, updated_at) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) {
+            ps.setObject(1, id);
+            ps.setString(2, name);
+            ps.setString(3, "https://api.example.com");
+            ps.setString(4, "gpt-4");
+            ps.setString(5, credentialRef);
+            ps.setString(6, encryptedKey);
+            ps.setObject(7, Instant.now().atOffset(java.time.ZoneOffset.UTC));
+            ps.setObject(8, Instant.now().atOffset(java.time.ZoneOffset.UTC));
+            ps.executeUpdate();
+        }
+    }
+
+    private void insertEvalJob(Connection conn, UUID id, UUID runId, UUID connectionId, String evaluatorName)
+            throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement("INSERT INTO eval_jobs "
+                + "(id, run_id, connection_id, status, evaluator_name, criteria, evaluation_params, created_at) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) {
+            ps.setObject(1, id);
+            ps.setObject(2, runId);
+            ps.setObject(3, connectionId);
+            ps.setString(4, "PENDING");
+            ps.setString(5, evaluatorName);
+            ps.setString(6, "is correct");
+            ps.setString(7, "ACTUAL_OUTPUT");
+            ps.setObject(8, Instant.now().atOffset(java.time.ZoneOffset.UTC));
+            ps.executeUpdate();
         }
     }
 

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/EvalJobServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/EvalJobServiceTest.java
@@ -1,0 +1,105 @@
+package dev.dokimos.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.dokimos.server.dto.v1.EnqueueJudgeRequest;
+import dev.dokimos.server.dto.v1.EvalJobView;
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.entity.RunStatus;
+import dev.dokimos.server.repository.EvalJobRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.repository.LlmConnectionRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EvalJobServiceTest {
+
+    @Mock
+    private EvalJobRepository jobRepository;
+
+    @Mock
+    private ExperimentRunRepository runRepository;
+
+    @Mock
+    private LlmConnectionRepository connectionRepository;
+
+    private EvalJobService service;
+
+    private UUID runId;
+    private UUID connectionId;
+    private ExperimentRun run;
+    private LlmConnection connection;
+
+    @BeforeEach
+    void setUp() {
+        service = new EvalJobService(jobRepository, runRepository, connectionRepository);
+        runId = UUID.randomUUID();
+        connectionId = UUID.randomUUID();
+        run = mock(ExperimentRun.class);
+        connection = mock(LlmConnection.class);
+    }
+
+    private EnqueueJudgeRequest request() {
+        return new EnqueueJudgeRequest(connectionId, "judge", "is correct", List.of("ACTUAL_OUTPUT"), 0.0, 1.0, 0.5);
+    }
+
+    @Test
+    void enqueueCreatesPendingJobAndMovesRunToEvaluating() {
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(connectionRepository.findById(connectionId)).thenReturn(Optional.of(connection));
+        when(jobRepository.existsByRunAndEvaluatorName(run, "judge")).thenReturn(false);
+        when(jobRepository.save(any(EvalJob.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        EvalJobView view = service.enqueue(runId, request());
+
+        assertThat(view.evaluatorName()).isEqualTo("judge");
+        verify(run).setStatus(RunStatus.EVALUATING);
+
+        ArgumentCaptor<EvalJob> jobCaptor = ArgumentCaptor.forClass(EvalJob.class);
+        verify(jobRepository).save(jobCaptor.capture());
+        assertThat(jobCaptor.getValue().getEvaluationParams()).isEqualTo("ACTUAL_OUTPUT");
+        verify(runRepository).save(run);
+    }
+
+    @Test
+    void enqueueRejectsDuplicateEvaluator() {
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(connectionRepository.findById(connectionId)).thenReturn(Optional.of(connection));
+        when(jobRepository.existsByRunAndEvaluatorName(run, "judge")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.enqueue(runId, request())).isInstanceOf(IllegalStateException.class);
+
+        verify(jobRepository, never()).save(any());
+    }
+
+    @Test
+    void enqueueRejectsMissingRun() {
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.enqueue(runId, request())).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void enqueueRejectsMissingConnection() {
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(connectionRepository.findById(connectionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.enqueue(runId, request())).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/JudgeWorkerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/JudgeWorkerTest.java
@@ -1,0 +1,157 @@
+package dev.dokimos.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.server.config.JudgeProperties;
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.judge.JudgeCallException;
+import dev.dokimos.server.service.JudgeJobTransactions.ItemSnapshot;
+import dev.dokimos.server.service.JudgeJobTransactions.ScoredResult;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JudgeWorkerTest {
+
+    @Mock
+    private JudgeJobTransactions transactions;
+
+    @Mock
+    private LlmCredentialService credentialService;
+
+    private JudgeProperties properties;
+    private UUID jobId;
+    private UUID runId;
+    private EvalJob job;
+    private LlmConnection connection;
+
+    @BeforeEach
+    void setUp() {
+        properties = new JudgeProperties();
+        jobId = UUID.randomUUID();
+        runId = UUID.randomUUID();
+        connection = new LlmConnection("conn", "https://api.example.com", "gpt-4");
+        ExperimentRun run = mock(ExperimentRun.class);
+        org.mockito.Mockito.lenient().when(run.getId()).thenReturn(runId);
+        job = new EvalJob(run, connection, "judge", "is correct");
+        job.setEvaluationParams("ACTUAL_OUTPUT");
+        setId(job, jobId);
+    }
+
+    private JudgeWorker worker(JudgeLM judge) {
+        BiFunction<LlmConnection, String, JudgeLM> factory = (c, key) -> judge;
+        return new JudgeWorker(transactions, credentialService, properties, factory);
+    }
+
+    @Test
+    void fullCyclePersistsResultsAndFinalizesRun() {
+        JudgeLM judge = prompt -> "{\"score\": 0.9, \"reason\": \"good\"}";
+        when(transactions.claimNextJob(anyInt())).thenReturn(Optional.of(job));
+        when(credentialService.resolveKey(connection)).thenReturn("sk-test");
+        when(transactions.loadUnevaluatedPage(eq(runId), eq("judge"), any(UUID.class), anyInt()))
+                .thenReturn(List.of(snapshot(), snapshot()))
+                .thenReturn(List.of());
+
+        worker(judge).poll();
+
+        ArgumentCaptor<List<ScoredResult>> captor = ArgumentCaptor.forClass(List.class);
+        verify(transactions).persistPage(eq(jobId), captor.capture(), any(UUID.class));
+        assertThat(captor.getValue()).hasSize(2);
+        assertThat(captor.getValue().get(0).evalResult().getScore()).isEqualTo(0.9);
+        assertThat(captor.getValue().get(0).evalResult().isSuccess()).isTrue();
+        verify(transactions).markSucceeded(jobId, runId);
+        verify(transactions, never()).recordFailure(any(), any(), anyBoolean(), anyInt());
+    }
+
+    @Test
+    void retryableFailureIsRecordedAsRetryable() {
+        JudgeLM judge = prompt -> {
+            throw new JudgeCallException(503, "service unavailable");
+        };
+        when(transactions.claimNextJob(anyInt())).thenReturn(Optional.of(job));
+        when(credentialService.resolveKey(connection)).thenReturn("sk-test");
+        when(transactions.loadUnevaluatedPage(eq(runId), eq("judge"), any(UUID.class), anyInt()))
+                .thenReturn(List.of(snapshot()));
+
+        worker(judge).poll();
+
+        verify(transactions).recordFailure(eq(jobId), any(), eq(true), eq(properties.getMaxAttempts()));
+        verify(transactions, never()).markSucceeded(any(), any());
+    }
+
+    @Test
+    void nonRetryableFailureIsRecordedAsTerminal() {
+        JudgeLM judge = prompt -> {
+            throw new JudgeCallException(401, "unauthorized");
+        };
+        when(transactions.claimNextJob(anyInt())).thenReturn(Optional.of(job));
+        when(credentialService.resolveKey(connection)).thenReturn("sk-test");
+        when(transactions.loadUnevaluatedPage(eq(runId), eq("judge"), any(UUID.class), anyInt()))
+                .thenReturn(List.of(snapshot()));
+
+        worker(judge).poll();
+
+        verify(transactions).recordFailure(eq(jobId), any(), eq(false), eq(properties.getMaxAttempts()));
+    }
+
+    @Test
+    void noClaimableJobDoesNothing() {
+        when(transactions.claimNextJob(anyInt())).thenReturn(Optional.empty());
+
+        worker(prompt -> "{}").poll();
+
+        verify(transactions, never()).loadUnevaluatedPage(any(), any(), any(), anyInt());
+        verify(transactions, never()).markSucceeded(any(), any());
+    }
+
+    @Test
+    void malformedJudgeResponseStillScoresAsFailureAndSucceeds() {
+        JudgeLM judge = prompt -> "not valid json";
+        when(transactions.claimNextJob(anyInt())).thenReturn(Optional.of(job));
+        when(credentialService.resolveKey(connection)).thenReturn("sk-test");
+        when(transactions.loadUnevaluatedPage(eq(runId), eq("judge"), any(UUID.class), anyInt()))
+                .thenReturn(List.of(snapshot()))
+                .thenReturn(List.of());
+
+        worker(judge).poll();
+
+        ArgumentCaptor<List<ScoredResult>> captor = ArgumentCaptor.forClass(List.class);
+        verify(transactions).persistPage(eq(jobId), captor.capture(), any(UUID.class));
+        assertThat(captor.getValue().get(0).evalResult().isSuccess()).isFalse();
+        verify(transactions).markSucceeded(jobId, runId);
+    }
+
+    private ItemSnapshot snapshot() {
+        return new ItemSnapshot(UUID.randomUUID(), Map.of("q", "x"), Map.of("a", "y"), Map.of("a", "y"));
+    }
+
+    private static void setId(EvalJob job, UUID id) {
+        try {
+            var field = EvalJob.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(job, id);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/LlmCredentialServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/LlmCredentialServiceTest.java
@@ -1,0 +1,75 @@
+package dev.dokimos.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import dev.dokimos.server.config.ApiKeyProperties;
+import dev.dokimos.server.entity.LlmConnection;
+import org.junit.jupiter.api.Test;
+
+class LlmCredentialServiceTest {
+
+    private static LlmCredentialService serviceWithKey(String encryptionKey) {
+        ApiKeyProperties properties = new ApiKeyProperties();
+        properties.setEncryptionKey(encryptionKey);
+        return new LlmCredentialService(properties);
+    }
+
+    @Test
+    void encryptDecryptRoundTrip() {
+        LlmCredentialService service = serviceWithKey("master-secret");
+        LlmConnection connection = new LlmConnection("c", "https://api.example.com", "gpt-4");
+
+        service.encryptInlineKey(connection, "sk-secret-123");
+
+        assertThat(connection.getEncryptedApiKey()).isNotBlank();
+        assertThat(connection.getEncryptedApiKey()).doesNotContain("sk-secret-123");
+        assertThat(service.resolveKey(connection)).isEqualTo("sk-secret-123");
+    }
+
+    @Test
+    void encryptingProducesDistinctCiphertextForSamePlaintext() {
+        LlmCredentialService service = serviceWithKey("master-secret");
+        LlmConnection first = new LlmConnection("a", "https://api.example.com", "gpt-4");
+        LlmConnection second = new LlmConnection("b", "https://api.example.com", "gpt-4");
+
+        service.encryptInlineKey(first, "sk-same");
+        service.encryptInlineKey(second, "sk-same");
+
+        assertThat(first.getEncryptedApiKey()).isNotEqualTo(second.getEncryptedApiKey());
+    }
+
+    @Test
+    void missingEncryptionKeyFailsForInlineKey() {
+        LlmCredentialService service = serviceWithKey("");
+        LlmConnection connection = new LlmConnection("c", "https://api.example.com", "gpt-4");
+
+        assertThatThrownBy(() -> service.encryptInlineKey(connection, "sk-secret"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("DOKIMOS_ENCRYPTION_KEY");
+    }
+
+    @Test
+    void resolvesKeyFromEnvironmentVariable() {
+        String existingVar = "PATH";
+        assumeTrue(System.getenv(existingVar) != null, "PATH not available in environment");
+
+        LlmCredentialService service = serviceWithKey(null);
+        LlmConnection connection = new LlmConnection("c", "https://api.example.com", "gpt-4");
+        connection.setCredentialRef(existingVar);
+
+        assertThat(service.resolveKey(connection)).isEqualTo(System.getenv(existingVar));
+    }
+
+    @Test
+    void missingEnvironmentVariableFails() {
+        LlmCredentialService service = serviceWithKey(null);
+        LlmConnection connection = new LlmConnection("c", "https://api.example.com", "gpt-4");
+        connection.setCredentialRef("DOKIMOS_DEFINITELY_NOT_SET_VAR_XYZ");
+
+        assertThatThrownBy(() -> service.resolveKey(connection))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not set");
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceTest.java
@@ -264,6 +264,22 @@ class RunServiceTest {
     }
 
     @Test
+    void updateRun_shouldRejectClientTransitionWhileEvaluating() {
+        UUID runId = UUID.randomUUID();
+        Project project = createProject("my-project");
+        Experiment experiment = createExperiment(project, "my-experiment");
+        ExperimentRun run = createRun(experiment, RunStatus.EVALUATING);
+        setField(run, "id", runId);
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+
+        assertThatThrownBy(() -> runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("evaluating");
+
+        verify(runRepository, never()).save(any(ExperimentRun.class));
+    }
+
+    @Test
     void updateRun_shouldThrowWhenIdIsNull() {
         assertThatThrownBy(() -> runService.updateRun(null, new UpdateRunRequest(RunStatus.SUCCESS)))
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
Adds a server-side LLM judge. You register an OpenAI-compatible connection (the key is stored encrypted), enqueue a scoring job for a run, and a background worker scores the items and writes the results, moving the run to success or failed. Verified end to end against OpenAI.

API-driven for now: no UI to manage connections or trigger scoring yet, and no automated test against a live LLM endpoint.
