### PR TITLE
Token, cost, and latency metrics on item results

### DIFF
--- a/dokimos-core/src/main/java/dev/dokimos/core/CallMetrics.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/CallMetrics.java
@@ -1,0 +1,12 @@
+package dev.dokimos.core;
+
+/**
+ * Optional metrics describing the LLM call that produced an item result. Any field may be null when
+ * the corresponding measurement is not available.
+ *
+ * @param tokensIn prompt tokens consumed by the call, or null if not measured
+ * @param tokensOut completion tokens produced by the call, or null if not measured
+ * @param costUsd cost of the call in US dollars, or null if not measured
+ * @param latencyMs wall-clock latency of the call in milliseconds, or null if not measured
+ */
+public record CallMetrics(Integer tokensIn, Integer tokensOut, Double costUsd, Long latencyMs) {}

--- a/dokimos-core/src/main/java/dev/dokimos/core/ItemResult.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/ItemResult.java
@@ -3,10 +3,40 @@ package dev.dokimos.core;
 import java.util.List;
 import java.util.Map;
 
-public record ItemResult(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
+/**
+ * The outcome of executing a single example: the example itself, the actual outputs the task
+ * produced, the evaluator results, and optional metrics describing the underlying LLM call.
+ *
+ * @param example the example that was executed
+ * @param actualOutputs the outputs the task produced, never null (empty map if absent)
+ * @param evalResults the evaluator results, never null (empty list if absent)
+ * @param tokensIn prompt tokens consumed by the call, or null if not measured
+ * @param tokensOut completion tokens produced by the call, or null if not measured
+ * @param costUsd cost of the call in US dollars, or null if not measured
+ * @param latencyMs wall-clock latency of the call in milliseconds, or null if not measured
+ */
+public record ItemResult(
+        Example example,
+        Map<String, Object> actualOutputs,
+        List<EvalResult> evalResults,
+        Integer tokensIn,
+        Integer tokensOut,
+        Double costUsd,
+        Long latencyMs) {
     public ItemResult {
         actualOutputs = actualOutputs != null ? Map.copyOf(actualOutputs) : Map.of();
         evalResults = evalResults != null ? List.copyOf(evalResults) : List.of();
+    }
+
+    /**
+     * Creates a result without call metrics. The metric fields default to null.
+     *
+     * @param example the example that was executed
+     * @param actualOutputs the outputs the task produced
+     * @param evalResults the evaluator results
+     */
+    public ItemResult(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
+        this(example, actualOutputs, evalResults, null, null, null, null);
     }
 
     public boolean success() {
@@ -15,5 +45,88 @@ public record ItemResult(Example example, Map<String, Object> actualOutputs, Lis
 
     public EvalTestCase toTestCase() {
         return example.toTestCase(actualOutputs);
+    }
+
+    /**
+     * Returns a builder for assembling an {@link ItemResult} with optional call metrics, so callers
+     * can set only the fields they have without a long positional argument list.
+     *
+     * @param example the example that was executed
+     * @param actualOutputs the outputs the task produced
+     * @param evalResults the evaluator results
+     * @return a new builder seeded with the required fields
+     */
+    public static Builder builder(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
+        return new Builder(example, actualOutputs, evalResults);
+    }
+
+    /** Builder for {@link ItemResult} that allows the call metrics to be set selectively. */
+    public static final class Builder {
+        private final Example example;
+        private final Map<String, Object> actualOutputs;
+        private final List<EvalResult> evalResults;
+        private Integer tokensIn;
+        private Integer tokensOut;
+        private Double costUsd;
+        private Long latencyMs;
+
+        private Builder(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
+            this.example = example;
+            this.actualOutputs = actualOutputs;
+            this.evalResults = evalResults;
+        }
+
+        /**
+         * Sets the prompt tokens consumed by the call.
+         *
+         * @param tokensIn prompt token count, or null if unknown
+         * @return this builder
+         */
+        public Builder tokensIn(Integer tokensIn) {
+            this.tokensIn = tokensIn;
+            return this;
+        }
+
+        /**
+         * Sets the completion tokens produced by the call.
+         *
+         * @param tokensOut completion token count, or null if unknown
+         * @return this builder
+         */
+        public Builder tokensOut(Integer tokensOut) {
+            this.tokensOut = tokensOut;
+            return this;
+        }
+
+        /**
+         * Sets the cost of the call in US dollars.
+         *
+         * @param costUsd cost in USD, or null if unknown
+         * @return this builder
+         */
+        public Builder costUsd(Double costUsd) {
+            this.costUsd = costUsd;
+            return this;
+        }
+
+        /**
+         * Sets the wall-clock latency of the call in milliseconds.
+         *
+         * @param latencyMs latency in milliseconds, or null if unknown
+         * @return this builder
+         */
+        public Builder latencyMs(Long latencyMs) {
+            this.latencyMs = latencyMs;
+            return this;
+        }
+
+        /**
+         * Builds the immutable {@link ItemResult}.
+         *
+         * @return the assembled result
+         */
+        public ItemResult build() {
+            return new ItemResult(example, actualOutputs, evalResults, tokensIn, tokensOut, costUsd, latencyMs);
+        }
     }
 }

--- a/dokimos-core/src/main/java/dev/dokimos/core/ItemResult.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/ItemResult.java
@@ -10,33 +10,24 @@ import java.util.Map;
  * @param example the example that was executed
  * @param actualOutputs the outputs the task produced, never null (empty map if absent)
  * @param evalResults the evaluator results, never null (empty list if absent)
- * @param tokensIn prompt tokens consumed by the call, or null if not measured
- * @param tokensOut completion tokens produced by the call, or null if not measured
- * @param costUsd cost of the call in US dollars, or null if not measured
- * @param latencyMs wall-clock latency of the call in milliseconds, or null if not measured
+ * @param metrics optional metrics for the underlying LLM call, or null if not measured
  */
 public record ItemResult(
-        Example example,
-        Map<String, Object> actualOutputs,
-        List<EvalResult> evalResults,
-        Integer tokensIn,
-        Integer tokensOut,
-        Double costUsd,
-        Long latencyMs) {
+        Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults, CallMetrics metrics) {
     public ItemResult {
         actualOutputs = actualOutputs != null ? Map.copyOf(actualOutputs) : Map.of();
         evalResults = evalResults != null ? List.copyOf(evalResults) : List.of();
     }
 
     /**
-     * Creates a result without call metrics. The metric fields default to null.
+     * Creates a result without call metrics.
      *
      * @param example the example that was executed
      * @param actualOutputs the outputs the task produced
      * @param evalResults the evaluator results
      */
     public ItemResult(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
-        this(example, actualOutputs, evalResults, null, null, null, null);
+        this(example, actualOutputs, evalResults, null);
     }
 
     public boolean success() {
@@ -45,88 +36,5 @@ public record ItemResult(
 
     public EvalTestCase toTestCase() {
         return example.toTestCase(actualOutputs);
-    }
-
-    /**
-     * Returns a builder for assembling an {@link ItemResult} with optional call metrics, so callers
-     * can set only the fields they have without a long positional argument list.
-     *
-     * @param example the example that was executed
-     * @param actualOutputs the outputs the task produced
-     * @param evalResults the evaluator results
-     * @return a new builder seeded with the required fields
-     */
-    public static Builder builder(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
-        return new Builder(example, actualOutputs, evalResults);
-    }
-
-    /** Builder for {@link ItemResult} that allows the call metrics to be set selectively. */
-    public static final class Builder {
-        private final Example example;
-        private final Map<String, Object> actualOutputs;
-        private final List<EvalResult> evalResults;
-        private Integer tokensIn;
-        private Integer tokensOut;
-        private Double costUsd;
-        private Long latencyMs;
-
-        private Builder(Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults) {
-            this.example = example;
-            this.actualOutputs = actualOutputs;
-            this.evalResults = evalResults;
-        }
-
-        /**
-         * Sets the prompt tokens consumed by the call.
-         *
-         * @param tokensIn prompt token count, or null if unknown
-         * @return this builder
-         */
-        public Builder tokensIn(Integer tokensIn) {
-            this.tokensIn = tokensIn;
-            return this;
-        }
-
-        /**
-         * Sets the completion tokens produced by the call.
-         *
-         * @param tokensOut completion token count, or null if unknown
-         * @return this builder
-         */
-        public Builder tokensOut(Integer tokensOut) {
-            this.tokensOut = tokensOut;
-            return this;
-        }
-
-        /**
-         * Sets the cost of the call in US dollars.
-         *
-         * @param costUsd cost in USD, or null if unknown
-         * @return this builder
-         */
-        public Builder costUsd(Double costUsd) {
-            this.costUsd = costUsd;
-            return this;
-        }
-
-        /**
-         * Sets the wall-clock latency of the call in milliseconds.
-         *
-         * @param latencyMs latency in milliseconds, or null if unknown
-         * @return this builder
-         */
-        public Builder latencyMs(Long latencyMs) {
-            this.latencyMs = latencyMs;
-            return this;
-        }
-
-        /**
-         * Builds the immutable {@link ItemResult}.
-         *
-         * @return the assembled result
-         */
-        public ItemResult build() {
-            return new ItemResult(example, actualOutputs, evalResults, tokensIn, tokensOut, costUsd, latencyMs);
-        }
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/ItemResultTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ItemResultTest.java
@@ -43,4 +43,31 @@ class ItemResultTest {
         assertThat(testCase.expectedOutput()).isEqualTo("expected");
         assertThat(testCase.actualOutput()).isEqualTo("actual");
     }
+
+    @Test
+    void shouldDefaultMetricsToNullForThreeArgConstructor() {
+        var item = new ItemResult(Example.of("q", "a"), Map.of("output", "a"), List.of());
+
+        assertThat(item.tokensIn()).isNull();
+        assertThat(item.tokensOut()).isNull();
+        assertThat(item.costUsd()).isNull();
+        assertThat(item.latencyMs()).isNull();
+    }
+
+    @Test
+    void shouldSetMetricsViaBuilder() {
+        var item = ItemResult.builder(
+                        Example.of("q", "a"), Map.of("output", "a"), List.of(EvalResult.success("eval1", 1.0, "ok")))
+                .tokensIn(120)
+                .tokensOut(40)
+                .costUsd(0.0023)
+                .latencyMs(512L)
+                .build();
+
+        assertThat(item.tokensIn()).isEqualTo(120);
+        assertThat(item.tokensOut()).isEqualTo(40);
+        assertThat(item.costUsd()).isEqualTo(0.0023);
+        assertThat(item.latencyMs()).isEqualTo(512L);
+        assertThat(item.success()).isTrue();
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/ItemResultTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ItemResultTest.java
@@ -48,26 +48,21 @@ class ItemResultTest {
     void shouldDefaultMetricsToNullForThreeArgConstructor() {
         var item = new ItemResult(Example.of("q", "a"), Map.of("output", "a"), List.of());
 
-        assertThat(item.tokensIn()).isNull();
-        assertThat(item.tokensOut()).isNull();
-        assertThat(item.costUsd()).isNull();
-        assertThat(item.latencyMs()).isNull();
+        assertThat(item.metrics()).isNull();
     }
 
     @Test
-    void shouldSetMetricsViaBuilder() {
-        var item = ItemResult.builder(
-                        Example.of("q", "a"), Map.of("output", "a"), List.of(EvalResult.success("eval1", 1.0, "ok")))
-                .tokensIn(120)
-                .tokensOut(40)
-                .costUsd(0.0023)
-                .latencyMs(512L)
-                .build();
+    void shouldCarryCallMetrics() {
+        var item = new ItemResult(
+                Example.of("q", "a"),
+                Map.of("output", "a"),
+                List.of(EvalResult.success("eval1", 1.0, "ok")),
+                new CallMetrics(120, 40, 0.0023, 512L));
 
-        assertThat(item.tokensIn()).isEqualTo(120);
-        assertThat(item.tokensOut()).isEqualTo(40);
-        assertThat(item.costUsd()).isEqualTo(0.0023);
-        assertThat(item.latencyMs()).isEqualTo(512L);
+        assertThat(item.metrics().tokensIn()).isEqualTo(120);
+        assertThat(item.metrics().tokensOut()).isEqualTo(40);
+        assertThat(item.metrics().costUsd()).isEqualTo(0.0023);
+        assertThat(item.metrics().latencyMs()).isEqualTo(512L);
         assertThat(item.success()).isTrue();
     }
 }

--- a/dokimos-server-client/src/main/java/dev/dokimos/server/client/DokimosServerReporter.java
+++ b/dokimos-server-client/src/main/java/dev/dokimos/server/client/DokimosServerReporter.java
@@ -341,6 +341,18 @@ public class DokimosServerReporter implements Reporter {
         if (datasetItemId != null) {
             map.put("datasetItemId", datasetItemId);
         }
+        if (result.tokensIn() != null) {
+            map.put("tokensIn", result.tokensIn());
+        }
+        if (result.tokensOut() != null) {
+            map.put("tokensOut", result.tokensOut());
+        }
+        if (result.costUsd() != null) {
+            map.put("costUsd", result.costUsd());
+        }
+        if (result.latencyMs() != null) {
+            map.put("latencyMs", result.latencyMs());
+        }
         return map;
     }
 

--- a/dokimos-server-client/src/main/java/dev/dokimos/server/client/DokimosServerReporter.java
+++ b/dokimos-server-client/src/main/java/dev/dokimos/server/client/DokimosServerReporter.java
@@ -341,17 +341,20 @@ public class DokimosServerReporter implements Reporter {
         if (datasetItemId != null) {
             map.put("datasetItemId", datasetItemId);
         }
-        if (result.tokensIn() != null) {
-            map.put("tokensIn", result.tokensIn());
-        }
-        if (result.tokensOut() != null) {
-            map.put("tokensOut", result.tokensOut());
-        }
-        if (result.costUsd() != null) {
-            map.put("costUsd", result.costUsd());
-        }
-        if (result.latencyMs() != null) {
-            map.put("latencyMs", result.latencyMs());
+        dev.dokimos.core.CallMetrics metrics = result.metrics();
+        if (metrics != null) {
+            if (metrics.tokensIn() != null) {
+                map.put("tokensIn", metrics.tokensIn());
+            }
+            if (metrics.tokensOut() != null) {
+                map.put("tokensOut", metrics.tokensOut());
+            }
+            if (metrics.costUsd() != null) {
+                map.put("costUsd", metrics.costUsd());
+            }
+            if (metrics.latencyMs() != null) {
+                map.put("latencyMs", metrics.latencyMs());
+            }
         }
         return map;
     }

--- a/dokimos-server-client/src/test/java/dev/dokimos/server/client/DokimosServerReporterTest.java
+++ b/dokimos-server-client/src/test/java/dev/dokimos/server/client/DokimosServerReporterTest.java
@@ -333,6 +333,45 @@ class DokimosServerReporterTest {
         }
     }
 
+    @Test
+    void shouldSendCallMetricsWhenPresentAndOmitWhenNull() throws Exception {
+        try (var reporter = createReporter()) {
+            RunHandle handle = reporter.startRun("test", Map.of());
+            recordedRequests.clear();
+
+            ItemResult withMetrics = ItemResult.builder(
+                            Example.of("q-metrics", "a"),
+                            Map.of("output", "a"),
+                            List.of(EvalResult.success("e", 1.0, "ok")))
+                    .tokensIn(100)
+                    .tokensOut(50)
+                    .costUsd(0.002)
+                    .latencyMs(430L)
+                    .build();
+            ItemResult withoutMetrics = new ItemResult(
+                    Example.of("q-bare", "a"), Map.of("output", "a"), List.of(EvalResult.success("e", 1.0, "ok")));
+
+            reporter.reportItem(handle, withMetrics);
+            reporter.reportItem(handle, withoutMetrics);
+            reporter.flush();
+
+            JsonNode items = collectItems();
+            assertThat(items).hasSize(2);
+
+            JsonNode metricsItem = findItemByInput(items, "q-metrics");
+            assertThat(metricsItem.get("tokensIn").asInt()).isEqualTo(100);
+            assertThat(metricsItem.get("tokensOut").asInt()).isEqualTo(50);
+            assertThat(metricsItem.get("costUsd").asDouble()).isEqualTo(0.002);
+            assertThat(metricsItem.get("latencyMs").asLong()).isEqualTo(430L);
+
+            JsonNode bareItem = findItemByInput(items, "q-bare");
+            assertThat(bareItem.has("tokensIn")).isFalse();
+            assertThat(bareItem.has("tokensOut")).isFalse();
+            assertThat(bareItem.has("costUsd")).isFalse();
+            assertThat(bareItem.has("latencyMs")).isFalse();
+        }
+    }
+
     private JsonNode collectItems() throws Exception {
         List<RecordedRequest> itemRequests =
                 recordedRequests.stream().filter(r -> r.path.contains("/items")).toList();

--- a/dokimos-server-client/src/test/java/dev/dokimos/server/client/DokimosServerReporterTest.java
+++ b/dokimos-server-client/src/test/java/dev/dokimos/server/client/DokimosServerReporterTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import dev.dokimos.core.CallMetrics;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.Example;
 import dev.dokimos.core.ItemResult;
@@ -339,15 +340,11 @@ class DokimosServerReporterTest {
             RunHandle handle = reporter.startRun("test", Map.of());
             recordedRequests.clear();
 
-            ItemResult withMetrics = ItemResult.builder(
-                            Example.of("q-metrics", "a"),
-                            Map.of("output", "a"),
-                            List.of(EvalResult.success("e", 1.0, "ok")))
-                    .tokensIn(100)
-                    .tokensOut(50)
-                    .costUsd(0.002)
-                    .latencyMs(430L)
-                    .build();
+            ItemResult withMetrics = new ItemResult(
+                    Example.of("q-metrics", "a"),
+                    Map.of("output", "a"),
+                    List.of(EvalResult.success("e", 1.0, "ok")),
+                    new CallMetrics(100, 50, 0.002, 430L));
             ItemResult withoutMetrics = new ItemResult(
                     Example.of("q-bare", "a"), Map.of("output", "a"), List.of(EvalResult.success("e", 1.0, "ok")));
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/AddItemsRequest.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/AddItemsRequest.java
@@ -13,8 +13,35 @@ public record AddItemsRequest(@NotEmpty List<ItemData> items) {
             Map<String, Object> metadata,
             List<EvalData> evalResults,
             boolean success,
-            UUID datasetItemId) {
-        /** Backwards-compatible 6-arg constructor: passes null datasetItemId. */
+            UUID datasetItemId,
+            Integer tokensIn,
+            Integer tokensOut,
+            Double costUsd,
+            Long latencyMs) {
+        /** Backwards-compatible 7-arg constructor: passes null call metrics. */
+        public ItemData(
+                Map<String, Object> inputs,
+                Map<String, Object> expectedOutputs,
+                Map<String, Object> actualOutputs,
+                Map<String, Object> metadata,
+                List<EvalData> evalResults,
+                boolean success,
+                UUID datasetItemId) {
+            this(
+                    inputs,
+                    expectedOutputs,
+                    actualOutputs,
+                    metadata,
+                    evalResults,
+                    success,
+                    datasetItemId,
+                    null,
+                    null,
+                    null,
+                    null);
+        }
+
+        /** Backwards-compatible 6-arg constructor: passes null datasetItemId and null call metrics. */
         public ItemData(
                 Map<String, Object> inputs,
                 Map<String, Object> expectedOutputs,
@@ -25,7 +52,7 @@ public record AddItemsRequest(@NotEmpty List<ItemData> items) {
             this(inputs, expectedOutputs, actualOutputs, metadata, evalResults, success, null);
         }
 
-        /** Backwards-compatible 5-arg constructor: passes null metadata and null datasetItemId. */
+        /** Backwards-compatible 5-arg constructor: passes null metadata, datasetItemId, and call metrics. */
         public ItemData(
                 Map<String, Object> inputs,
                 Map<String, Object> expectedOutputs,

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/RunDetails.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/RunDetails.java
@@ -21,6 +21,10 @@ public record RunDetails(
         Instant completedAt,
         UUID datasetVersionId,
         Integer datasetVersion,
+        Long totalTokensIn,
+        Long totalTokensOut,
+        Double totalCostUsd,
+        Double avgLatencyMs,
         Page<ItemSummary> items) {
     public record ItemSummary(
             UUID id,
@@ -31,7 +35,11 @@ public record RunDetails(
             List<EvalSummary> evalResults,
             Instant createdAt,
             UUID datasetItemId,
-            AnnotationView annotation) {}
+            AnnotationView annotation,
+            Integer tokensIn,
+            Integer tokensOut,
+            Double costUsd,
+            Long latencyMs) {}
 
     public record EvalSummary(
             UUID id, String evaluatorName, double score, Double threshold, boolean success, String reason) {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/RunSummary.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/RunSummary.java
@@ -15,4 +15,8 @@ public record RunSummary(
         Instant startedAt,
         Instant completedAt,
         UUID datasetVersionId,
-        Integer datasetVersion) {}
+        Integer datasetVersion,
+        Long totalTokensIn,
+        Long totalTokensOut,
+        Double totalCostUsd,
+        Double avgLatencyMs) {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/ExperimentRun.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/ExperimentRun.java
@@ -64,6 +64,18 @@ public class ExperimentRun {
     @Column(name = "pass_rate")
     private Double passRate;
 
+    @Column(name = "total_tokens_in")
+    private Long totalTokensIn;
+
+    @Column(name = "total_tokens_out")
+    private Long totalTokensOut;
+
+    @Column(name = "total_cost_usd")
+    private Double totalCostUsd;
+
+    @Column(name = "avg_latency_ms")
+    private Double avgLatencyMs;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dataset_version_id")
     private DatasetVersion datasetVersion;
@@ -183,6 +195,38 @@ public class ExperimentRun {
 
     public void setPassRate(Double passRate) {
         this.passRate = passRate;
+    }
+
+    public Long getTotalTokensIn() {
+        return totalTokensIn;
+    }
+
+    public void setTotalTokensIn(Long totalTokensIn) {
+        this.totalTokensIn = totalTokensIn;
+    }
+
+    public Long getTotalTokensOut() {
+        return totalTokensOut;
+    }
+
+    public void setTotalTokensOut(Long totalTokensOut) {
+        this.totalTokensOut = totalTokensOut;
+    }
+
+    public Double getTotalCostUsd() {
+        return totalCostUsd;
+    }
+
+    public void setTotalCostUsd(Double totalCostUsd) {
+        this.totalCostUsd = totalCostUsd;
+    }
+
+    public Double getAvgLatencyMs() {
+        return avgLatencyMs;
+    }
+
+    public void setAvgLatencyMs(Double avgLatencyMs) {
+        this.avgLatencyMs = avgLatencyMs;
     }
 
     public DatasetVersion getDatasetVersion() {

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/ItemResult.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/ItemResult.java
@@ -55,6 +55,18 @@ public class ItemResult {
     @Column(columnDefinition = "jsonb")
     private Map<String, Object> metadata;
 
+    @Column(name = "tokens_in")
+    private Integer tokensIn;
+
+    @Column(name = "tokens_out")
+    private Integer tokensOut;
+
+    @Column(name = "cost_usd")
+    private Double costUsd;
+
+    @Column(name = "latency_ms")
+    private Long latencyMs;
+
     @Column(nullable = false)
     private Instant createdAt;
 
@@ -107,6 +119,38 @@ public class ItemResult {
 
     public Map<String, Object> getMetadata() {
         return metadata;
+    }
+
+    public Integer getTokensIn() {
+        return tokensIn;
+    }
+
+    public void setTokensIn(Integer tokensIn) {
+        this.tokensIn = tokensIn;
+    }
+
+    public Integer getTokensOut() {
+        return tokensOut;
+    }
+
+    public void setTokensOut(Integer tokensOut) {
+        this.tokensOut = tokensOut;
+    }
+
+    public Double getCostUsd() {
+        return costUsd;
+    }
+
+    public void setCostUsd(Double costUsd) {
+        this.costUsd = costUsd;
+    }
+
+    public Long getLatencyMs() {
+        return latencyMs;
+    }
+
+    public void setLatencyMs(Long latencyMs) {
+        this.latencyMs = latencyMs;
     }
 
     public Instant getCreatedAt() {

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
@@ -40,6 +40,42 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
     long countItemsWithAllEvalsPassed(ExperimentRun run);
 
     /**
+     * Sums the prompt tokens across a run's items.
+     *
+     * @param run the run to aggregate
+     * @return the total prompt tokens, or null if no item carries a token count
+     */
+    @Query("SELECT SUM(i.tokensIn) FROM ItemResult i WHERE i.run = :run")
+    Long sumTokensInByRun(ExperimentRun run);
+
+    /**
+     * Sums the completion tokens across a run's items.
+     *
+     * @param run the run to aggregate
+     * @return the total completion tokens, or null if no item carries a token count
+     */
+    @Query("SELECT SUM(i.tokensOut) FROM ItemResult i WHERE i.run = :run")
+    Long sumTokensOutByRun(ExperimentRun run);
+
+    /**
+     * Sums the call cost across a run's items.
+     *
+     * @param run the run to aggregate
+     * @return the total cost in USD, or null if no item carries a cost
+     */
+    @Query("SELECT SUM(i.costUsd) FROM ItemResult i WHERE i.run = :run")
+    Double sumCostByRun(ExperimentRun run);
+
+    /**
+     * Averages the call latency across a run's items.
+     *
+     * @param run the run to aggregate
+     * @return the mean latency in milliseconds, or null if no item carries a latency
+     */
+    @Query("SELECT AVG(i.latencyMs) FROM ItemResult i WHERE i.run = :run")
+    Double avgLatencyByRun(ExperimentRun run);
+
+    /**
      * Seek-based page of run items that carry no eval result for the given evaluator yet. Items are
      * ordered by id so the worker can page forward by passing the last id it saw as {@code afterId};
      * the {@code NOT EXISTS} filter is scoped by evaluator name so adding an evaluator to a previously

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
@@ -135,6 +135,11 @@ public class RunService {
             ItemResult item = new ItemResult(
                     run, itemData.inputs(), itemData.expectedOutputs(), itemData.actualOutputs(), itemData.metadata());
 
+            item.setTokensIn(itemData.tokensIn());
+            item.setTokensOut(itemData.tokensOut());
+            item.setCostUsd(itemData.costUsd());
+            item.setLatencyMs(itemData.latencyMs());
+
             if (itemData.datasetItemId() != null) {
                 DatasetItem datasetItem = datasetItemsById.get(itemData.datasetItemId());
                 if (datasetItem != null) {
@@ -242,6 +247,10 @@ public class RunService {
         run.setItemCount((int) totalItems);
         run.setPassedCount((int) passedItems);
         run.setPassRate(totalItems > 0 ? (double) passedItems / totalItems : null);
+        run.setTotalTokensIn(itemResultRepository.sumTokensInByRun(run));
+        run.setTotalTokensOut(itemResultRepository.sumTokensOutByRun(run));
+        run.setTotalCostUsd(itemResultRepository.sumCostByRun(run));
+        run.setAvgLatencyMs(itemResultRepository.avgLatencyByRun(run));
     }
 
     @Transactional(readOnly = true)
@@ -291,6 +300,10 @@ public class RunService {
                 run.getCompletedAt(),
                 datasetVersionId,
                 datasetVersionNumber,
+                run.getTotalTokensIn(),
+                run.getTotalTokensOut(),
+                run.getTotalCostUsd(),
+                run.getAvgLatencyMs(),
                 itemSummaries);
     }
 
@@ -338,7 +351,11 @@ public class RunService {
                 run.getStartedAt(),
                 run.getCompletedAt(),
                 datasetVersionId,
-                datasetVersionNumber);
+                datasetVersionNumber,
+                run.getTotalTokensIn(),
+                run.getTotalTokensOut(),
+                run.getTotalCostUsd(),
+                run.getAvgLatencyMs());
     }
 
     private Map<UUID, DatasetItem> loadDatasetItems(List<AddItemsRequest.ItemData> items) {
@@ -375,7 +392,11 @@ public class RunService {
                 evalSummaries,
                 item.getCreatedAt(),
                 datasetItemId,
-                annotation);
+                annotation,
+                item.getTokensIn(),
+                item.getTokensOut(),
+                item.getCostUsd(),
+                item.getLatencyMs());
     }
 
     /**

--- a/dokimos-server/src/main/resources/db/migration/V9__item_metrics.sql
+++ b/dokimos-server/src/main/resources/db/migration/V9__item_metrics.sql
@@ -3,12 +3,12 @@
 -- metrics stay valid; no backfill.
 ALTER TABLE item_results ADD COLUMN tokens_in INTEGER;
 ALTER TABLE item_results ADD COLUMN tokens_out INTEGER;
-ALTER TABLE item_results ADD COLUMN cost_usd NUMERIC(18, 8);
+ALTER TABLE item_results ADD COLUMN cost_usd DOUBLE PRECISION;
 ALTER TABLE item_results ADD COLUMN latency_ms BIGINT;
 
 -- Run-level aggregates materialized at run completion, mirroring the existing pass-rate fields.
 -- All nullable; absent means no item in the run carried that metric.
 ALTER TABLE experiment_runs ADD COLUMN total_tokens_in BIGINT;
 ALTER TABLE experiment_runs ADD COLUMN total_tokens_out BIGINT;
-ALTER TABLE experiment_runs ADD COLUMN total_cost_usd NUMERIC(18, 8);
+ALTER TABLE experiment_runs ADD COLUMN total_cost_usd DOUBLE PRECISION;
 ALTER TABLE experiment_runs ADD COLUMN avg_latency_ms DOUBLE PRECISION;

--- a/dokimos-server/src/main/resources/db/migration/V9__item_metrics.sql
+++ b/dokimos-server/src/main/resources/db/migration/V9__item_metrics.sql
@@ -1,0 +1,14 @@
+-- Optional per-item call metrics describing the LLM call that produced an output: prompt and
+-- completion tokens, cost, and latency. All nullable so legacy rows and runs that capture no
+-- metrics stay valid; no backfill.
+ALTER TABLE item_results ADD COLUMN tokens_in INTEGER;
+ALTER TABLE item_results ADD COLUMN tokens_out INTEGER;
+ALTER TABLE item_results ADD COLUMN cost_usd NUMERIC(18, 8);
+ALTER TABLE item_results ADD COLUMN latency_ms BIGINT;
+
+-- Run-level aggregates materialized at run completion, mirroring the existing pass-rate fields.
+-- All nullable; absent means no item in the run carried that metric.
+ALTER TABLE experiment_runs ADD COLUMN total_tokens_in BIGINT;
+ALTER TABLE experiment_runs ADD COLUMN total_tokens_out BIGINT;
+ALTER TABLE experiment_runs ADD COLUMN total_cost_usd NUMERIC(18, 8);
+ALTER TABLE experiment_runs ADD COLUMN avg_latency_ms DOUBLE PRECISION;

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/ExperimentControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/ExperimentControllerTest.java
@@ -56,7 +56,20 @@ class ExperimentControllerTest {
         Experiment experiment = new Experiment(project, "my-experiment");
 
         RunSummary summary = new RunSummary(
-                runId, RunStatus.SUCCESS, Map.of(), 10, 8, 0.8, Instant.now(), Instant.now(), null, null);
+                runId,
+                RunStatus.SUCCESS,
+                Map.of(),
+                10,
+                8,
+                0.8,
+                Instant.now(),
+                Instant.now(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
 
         when(experimentService.getExperiment(experimentId)).thenReturn(experiment);
         when(runService.listRuns(experiment)).thenReturn(List.of(summary));

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/RunControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/RunControllerTest.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -59,7 +60,21 @@ class RunControllerTest extends AbstractControllerTest {
         UUID runId = UUID.randomUUID();
 
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Page<RunDetails.ItemSummary> emptyPage = new PageImpl<>(List.of(), pageRequest, 0);
+        RunDetails.ItemSummary itemSummary = new RunDetails.ItemSummary(
+                UUID.randomUUID(),
+                Map.of("input", "q"),
+                Map.of("output", "a"),
+                Map.of("output", "a"),
+                null,
+                List.of(),
+                Instant.now(),
+                null,
+                null,
+                100,
+                50,
+                0.002,
+                430L);
+        Page<RunDetails.ItemSummary> page = new PageImpl<>(List.of(itemSummary), pageRequest, 1);
         UUID experimentId = UUID.randomUUID();
 
         RunDetails details = new RunDetails(
@@ -76,7 +91,11 @@ class RunControllerTest extends AbstractControllerTest {
                 Instant.now(),
                 null,
                 null,
-                emptyPage);
+                300L,
+                150L,
+                0.006,
+                412.5,
+                page);
 
         when(runService.getRunDetails(eq(runId), any(Pageable.class))).thenReturn(details);
 
@@ -87,7 +106,15 @@ class RunControllerTest extends AbstractControllerTest {
                 .andExpect(jsonPath("$.experimentName").value("my-experiment"))
                 .andExpect(jsonPath("$.projectName").value("my-project"))
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.passRate").value(0.8));
+                .andExpect(jsonPath("$.passRate").value(0.8))
+                .andExpect(jsonPath("$.totalTokensIn").value(300))
+                .andExpect(jsonPath("$.totalTokensOut").value(150))
+                .andExpect(jsonPath("$.totalCostUsd").value(0.006))
+                .andExpect(jsonPath("$.avgLatencyMs").value(412.5))
+                .andExpect(jsonPath("$.items.content[0].tokensIn").value(100))
+                .andExpect(jsonPath("$.items.content[0].tokensOut").value(50))
+                .andExpect(jsonPath("$.items.content[0].costUsd").value(0.002))
+                .andExpect(jsonPath("$.items.content[0].latencyMs").value(430));
     }
 
     @Test
@@ -120,6 +147,29 @@ class RunControllerTest extends AbstractControllerTest {
                 .andExpect(jsonPath("$.status").value("ok"));
 
         verify(runService).addItems(eq(runId), any(AddItemsRequest.class), any());
+    }
+
+    @Test
+    void addItems_shouldAcceptMetricFields() throws Exception {
+        UUID runId = UUID.randomUUID();
+        String body = """
+                {"items":[{"inputs":{"input":"q"},"actualOutputs":{"output":"a"},"success":true,\
+                "tokensIn":100,"tokensOut":50,"costUsd":0.002,"latencyMs":430}]}""";
+
+        ArgumentCaptor<AddItemsRequest> captor = ArgumentCaptor.forClass(AddItemsRequest.class);
+        doNothing().when(runService).addItems(eq(runId), captor.capture(), any());
+
+        mockMvc.perform(post("/api/v1/runs/{runId}/items", runId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("ok"));
+
+        AddItemsRequest.ItemData item = captor.getValue().items().get(0);
+        org.assertj.core.api.Assertions.assertThat(item.tokensIn()).isEqualTo(100);
+        org.assertj.core.api.Assertions.assertThat(item.tokensOut()).isEqualTo(50);
+        org.assertj.core.api.Assertions.assertThat(item.costUsd()).isEqualTo(0.002);
+        org.assertj.core.api.Assertions.assertThat(item.latencyMs()).isEqualTo(430L);
     }
 
     @Test

--- a/dokimos-server/src/test/java/dev/dokimos/server/integration/ReporterIntegrationTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/integration/ReporterIntegrationTest.java
@@ -2,6 +2,7 @@ package dev.dokimos.server.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.dokimos.core.CallMetrics;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.Example;
 import dev.dokimos.core.ItemResult;
@@ -69,17 +70,13 @@ class ReporterIntegrationTest {
         UUID runId = UUID.fromString(handle.runId());
 
         // Report several items with some data
-        ItemResult item1 = ItemResult.builder(
-                        Example.of("What is the capital of France?", "Paris"),
-                        Map.of("output", "Paris"),
-                        List.of(
-                                EvalResult.success("exact-match", 1.0, "Output matches expected"),
-                                EvalResult.of("semantic-similarity", 0.95, 0.8, "High semantic similarity")))
-                .tokensIn(100)
-                .tokensOut(50)
-                .costUsd(0.002)
-                .latencyMs(430L)
-                .build();
+        ItemResult item1 = new ItemResult(
+                Example.of("What is the capital of France?", "Paris"),
+                Map.of("output", "Paris"),
+                List.of(
+                        EvalResult.success("exact-match", 1.0, "Output matches expected"),
+                        EvalResult.of("semantic-similarity", 0.95, 0.8, "High semantic similarity")),
+                new CallMetrics(100, 50, 0.002, 430L));
 
         ItemResult item2 = createItemResult(
                 "What is 2 + 2?", "4", "4", List.of(EvalResult.success("exact-match", 1.0, "Output matches expected")));

--- a/dokimos-server/src/test/java/dev/dokimos/server/integration/ReporterIntegrationTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/integration/ReporterIntegrationTest.java
@@ -69,13 +69,17 @@ class ReporterIntegrationTest {
         UUID runId = UUID.fromString(handle.runId());
 
         // Report several items with some data
-        ItemResult item1 = createItemResult(
-                "What is the capital of France?",
-                "Paris",
-                "Paris",
-                List.of(
-                        EvalResult.success("exact-match", 1.0, "Output matches expected"),
-                        EvalResult.of("semantic-similarity", 0.95, 0.8, "High semantic similarity")));
+        ItemResult item1 = ItemResult.builder(
+                        Example.of("What is the capital of France?", "Paris"),
+                        Map.of("output", "Paris"),
+                        List.of(
+                                EvalResult.success("exact-match", 1.0, "Output matches expected"),
+                                EvalResult.of("semantic-similarity", 0.95, 0.8, "High semantic similarity")))
+                .tokensIn(100)
+                .tokensOut(50)
+                .costUsd(0.002)
+                .latencyMs(430L)
+                .build();
 
         ItemResult item2 = createItemResult(
                 "What is 2 + 2?", "4", "4", List.of(EvalResult.success("exact-match", 1.0, "Output matches expected")));
@@ -134,6 +138,19 @@ class ReporterIntegrationTest {
         assertThat(firstItem.getExpectedOutput()).isEqualTo(Map.of("output", "Paris"));
         assertThat(firstItem.getActualOutput()).isEqualTo(Map.of("output", "Paris"));
         assertThat(firstItem.getEvalResults()).hasSize(2);
+
+        // The call metrics carried on the first item must round-trip into the stored row.
+        assertThat(firstItem.getTokensIn()).isEqualTo(100);
+        assertThat(firstItem.getTokensOut()).isEqualTo(50);
+        assertThat(firstItem.getCostUsd()).isCloseTo(0.002, org.assertj.core.data.Offset.offset(1e-9));
+        assertThat(firstItem.getLatencyMs()).isEqualTo(430L);
+
+        // The run-level aggregates are materialized at completion from the single item that carried
+        // metrics; the other two items contribute null and are ignored by SUM/AVG.
+        assertThat(storedRun.getTotalTokensIn()).isEqualTo(100L);
+        assertThat(storedRun.getTotalTokensOut()).isEqualTo(50L);
+        assertThat(storedRun.getTotalCostUsd()).isCloseTo(0.002, org.assertj.core.data.Offset.offset(1e-9));
+        assertThat(storedRun.getAvgLatencyMs()).isEqualTo(430.0);
 
         // Verify eval results for first item
         var evalResults = firstItem.getEvalResults();

--- a/dokimos-server/src/test/java/dev/dokimos/server/migration/FlywayMigrationTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/migration/FlywayMigrationTest.java
@@ -835,6 +835,108 @@ class FlywayMigrationTest {
         }
     }
 
+    /**
+     * Verifies V9 adds the per-item metric columns to item_results and the run-level aggregate columns
+     * to experiment_runs, that all eight are nullable, and that a stored item round-trips its metric
+     * values. Migrates to V8, applies V9, seeds an item carrying metrics, and reads the columns back.
+     */
+    @Test
+    void v9AddsItemMetricColumns() throws Exception {
+        DataSource ds = dataSource();
+
+        Flyway.configure().dataSource(ds).target("8").load().migrate();
+        Flyway.configure().dataSource(ds).target("9").load().migrate();
+
+        UUID projectId = UUID.randomUUID();
+        UUID experimentId = UUID.randomUUID();
+        UUID runId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+
+        try (Connection conn = ds.getConnection()) {
+            assertColumnIsNullable(conn, "item_results", "tokens_in");
+            assertColumnIsNullable(conn, "item_results", "tokens_out");
+            assertColumnIsNullable(conn, "item_results", "cost_usd");
+            assertColumnIsNullable(conn, "item_results", "latency_ms");
+            assertColumnIsNullable(conn, "experiment_runs", "total_tokens_in");
+            assertColumnIsNullable(conn, "experiment_runs", "total_tokens_out");
+            assertColumnIsNullable(conn, "experiment_runs", "total_cost_usd");
+            assertColumnIsNullable(conn, "experiment_runs", "avg_latency_ms");
+
+            insertProject(conn, projectId, "v9-project");
+            insertExperiment(conn, experimentId, projectId, "v9-experiment");
+            insertRun(conn, runId, experimentId);
+
+            // An item with no metrics is valid; the metric columns stay NULL.
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO item_results "
+                    + "(id, run_id, input, actual_output, created_at) VALUES (?, ?, ?::jsonb, ?::jsonb, ?)")) {
+                ps.setObject(1, itemId);
+                ps.setObject(2, runId);
+                ps.setString(3, "{\"input\":\"q\"}");
+                ps.setString(4, "{\"output\":\"a\"}");
+                ps.setObject(5, Instant.now().atOffset(java.time.ZoneOffset.UTC));
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps =
+                    conn.prepareStatement("SELECT tokens_in, cost_usd, latency_ms FROM item_results WHERE id = ?")) {
+                ps.setObject(1, itemId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    rs.getObject("tokens_in");
+                    assertThat(rs.wasNull()).isTrue();
+                }
+            }
+
+            // An item that carries metrics round-trips each column.
+            UUID metricItemId = UUID.randomUUID();
+            try (PreparedStatement ps = conn.prepareStatement("INSERT INTO item_results "
+                    + "(id, run_id, input, actual_output, created_at, tokens_in, tokens_out, cost_usd, latency_ms) "
+                    + "VALUES (?, ?, ?::jsonb, ?::jsonb, ?, ?, ?, ?, ?)")) {
+                ps.setObject(1, metricItemId);
+                ps.setObject(2, runId);
+                ps.setString(3, "{\"input\":\"q\"}");
+                ps.setString(4, "{\"output\":\"a\"}");
+                ps.setObject(5, Instant.now().atOffset(java.time.ZoneOffset.UTC));
+                ps.setInt(6, 100);
+                ps.setInt(7, 50);
+                ps.setBigDecimal(8, new java.math.BigDecimal("0.00200000"));
+                ps.setLong(9, 430L);
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "SELECT tokens_in, tokens_out, cost_usd, latency_ms FROM item_results WHERE id = ?")) {
+                ps.setObject(1, metricItemId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getInt("tokens_in")).isEqualTo(100);
+                    assertThat(rs.getInt("tokens_out")).isEqualTo(50);
+                    assertThat(rs.getBigDecimal("cost_usd")).isEqualByComparingTo(new java.math.BigDecimal("0.002"));
+                    assertThat(rs.getLong("latency_ms")).isEqualTo(430L);
+                }
+            }
+
+            // The run-level aggregate columns accept values too.
+            try (PreparedStatement ps = conn.prepareStatement("UPDATE experiment_runs SET "
+                    + "total_tokens_in = ?, total_tokens_out = ?, total_cost_usd = ?, avg_latency_ms = ? "
+                    + "WHERE id = ?")) {
+                ps.setLong(1, 100L);
+                ps.setLong(2, 50L);
+                ps.setBigDecimal(3, new java.math.BigDecimal("0.00200000"));
+                ps.setDouble(4, 430.0);
+                ps.setObject(5, runId);
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps =
+                    conn.prepareStatement("SELECT total_tokens_in, avg_latency_ms FROM experiment_runs WHERE id = ?")) {
+                ps.setObject(1, runId);
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getLong("total_tokens_in")).isEqualTo(100L);
+                    assertThat(rs.getDouble("avg_latency_ms")).isEqualTo(430.0);
+                }
+            }
+        }
+    }
+
     private void insertConnection(Connection conn, UUID id, String name) throws Exception {
         insertConnectionRaw(conn, id, name, "ENV_KEY", null);
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/migration/FlywayMigrationTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/migration/FlywayMigrationTest.java
@@ -909,7 +909,7 @@ class FlywayMigrationTest {
                     assertThat(rs.next()).isTrue();
                     assertThat(rs.getInt("tokens_in")).isEqualTo(100);
                     assertThat(rs.getInt("tokens_out")).isEqualTo(50);
-                    assertThat(rs.getBigDecimal("cost_usd")).isEqualByComparingTo(new java.math.BigDecimal("0.002"));
+                    assertThat(rs.getDouble("cost_usd")).isCloseTo(0.002, org.assertj.core.api.Assertions.within(1e-9));
                     assertThat(rs.getLong("latency_ms")).isEqualTo(430L);
                 }
             }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceTest.java
@@ -236,6 +236,94 @@ class RunServiceTest {
     }
 
     @Test
+    void addItems_shouldPersistMetrics() {
+        UUID runId = UUID.randomUUID();
+        Project project = createProject("my-project");
+        Experiment experiment = createExperiment(project, "my-experiment");
+        ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
+        setField(run, "id", runId);
+
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+
+        AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
+                Map.of("input", "q"),
+                Map.of("output", "a"),
+                Map.of("output", "a"),
+                null,
+                List.of(new AddItemsRequest.EvalData("exact-match", 1.0, 0.9, true, "ok", Map.of())),
+                true,
+                null,
+                100,
+                50,
+                0.002,
+                430L)));
+
+        runService.addItems(runId, request, null);
+
+        List<ItemResult> saved = captureSavedItems();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getTokensIn()).isEqualTo(100);
+        assertThat(saved.get(0).getTokensOut()).isEqualTo(50);
+        assertThat(saved.get(0).getCostUsd()).isEqualTo(0.002);
+        assertThat(saved.get(0).getLatencyMs()).isEqualTo(430L);
+    }
+
+    @Test
+    void materializeCounts_shouldAggregateTokensAndLatency() {
+        UUID runId = UUID.randomUUID();
+        Project project = createProject("my-project");
+        Experiment experiment = createExperiment(project, "my-experiment");
+        ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
+        setField(run, "id", runId);
+
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(itemResultRepository.countByRun(run)).thenReturn(3L);
+        when(itemResultRepository.countItemsWithAllEvalsPassed(run)).thenReturn(2L);
+        when(itemResultRepository.sumTokensInByRun(run)).thenReturn(300L);
+        when(itemResultRepository.sumTokensOutByRun(run)).thenReturn(150L);
+        when(itemResultRepository.sumCostByRun(run)).thenReturn(0.006);
+        when(itemResultRepository.avgLatencyByRun(run)).thenReturn(412.5);
+
+        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+
+        ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
+        verify(runRepository).save(captor.capture());
+        ExperimentRun saved = captor.getValue();
+        assertThat(saved.getTotalTokensIn()).isEqualTo(300L);
+        assertThat(saved.getTotalTokensOut()).isEqualTo(150L);
+        assertThat(saved.getTotalCostUsd()).isEqualTo(0.006);
+        assertThat(saved.getAvgLatencyMs()).isEqualTo(412.5);
+    }
+
+    @Test
+    void materializeCounts_shouldLeaveMetricsNullWhenNoItemsCarryThem() {
+        UUID runId = UUID.randomUUID();
+        Project project = createProject("my-project");
+        Experiment experiment = createExperiment(project, "my-experiment");
+        ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
+        setField(run, "id", runId);
+
+        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(itemResultRepository.countByRun(run)).thenReturn(2L);
+        when(itemResultRepository.countItemsWithAllEvalsPassed(run)).thenReturn(1L);
+        when(itemResultRepository.sumTokensInByRun(run)).thenReturn(null);
+        when(itemResultRepository.sumTokensOutByRun(run)).thenReturn(null);
+        when(itemResultRepository.sumCostByRun(run)).thenReturn(null);
+        when(itemResultRepository.avgLatencyByRun(run)).thenReturn(null);
+
+        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+
+        ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
+        verify(runRepository).save(captor.capture());
+        ExperimentRun saved = captor.getValue();
+        assertThat(saved.getTotalTokensIn()).isNull();
+        assertThat(saved.getTotalCostUsd()).isNull();
+        assertThat(saved.getAvgLatencyMs()).isNull();
+    }
+
+    @Test
     void updateRun_shouldNotSetCompletedAtForRunningStatus() {
         UUID runId = UUID.randomUUID();
         Project project = createProject("my-project");


### PR DESCRIPTION
Threads optional token usage, cost, and latency per item result through the core item result, the reporter, and new server columns (V9 migration), with run-level totals aggregated at completion. The values are exposed on the run detail and summary DTOs; the UI that renders them lands in a follow-up.
