### PR TITLE
Judge vs human alignment metric

### DIFF
--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AlignmentController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AlignmentController.java
@@ -1,0 +1,36 @@
+package dev.dokimos.server.controller.v1;
+
+import dev.dokimos.server.dto.v1.AlignmentView;
+import dev.dokimos.server.service.AlignmentService;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes the per-evaluator judge-human alignment for a run: the agreement rate between automated
+ * evaluator verdicts and human annotations. This is a read-only GET and is therefore allowed by the
+ * auth filter without an API key.
+ */
+@RestController
+@RequestMapping("/api/v1/runs")
+public class AlignmentController {
+
+    private final AlignmentService alignmentService;
+
+    public AlignmentController(AlignmentService alignmentService) {
+        this.alignmentService = alignmentService;
+    }
+
+    /**
+     * Returns the judge-human alignment breakdown for a run.
+     *
+     * @param runId the run to analyze
+     * @return HTTP 200 with the per-evaluator agreement breakdown; 404 when the run does not exist
+     */
+    @GetMapping("/{runId}/alignment")
+    public AlignmentView alignment(@PathVariable UUID runId) {
+        return alignmentService.getAlignment(runId);
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/AlignmentView.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/AlignmentView.java
@@ -1,0 +1,33 @@
+package dev.dokimos.server.dto.v1;
+
+import java.util.List;
+
+/**
+ * Per-run, per-evaluator agreement between automated evaluator verdicts and human annotations. For
+ * each evaluator the agreement rate is the fraction of comparable items where the evaluator's
+ * pass/fail matched the human verdict (CORRECT treated as pass, INCORRECT as fail). Items with an
+ * UNSURE verdict or no annotation are excluded from the rate and reported separately.
+ *
+ * @param annotatedItems the number of run items carrying any human verdict (including UNSURE)
+ * @param evaluators     per-evaluator agreement breakdown, one entry per distinct evaluator name
+ */
+public record AlignmentView(int annotatedItems, List<EvaluatorAlignment> evaluators) {
+
+    public AlignmentView {
+        evaluators = List.copyOf(evaluators);
+    }
+
+    /**
+     * Agreement breakdown for a single evaluator across a run's annotated items.
+     *
+     * @param evaluatorName  the evaluator the breakdown is for
+     * @param comparableCount items where the evaluator ran and the human verdict was CORRECT or
+     *     INCORRECT; the denominator of {@code alignmentRate}
+     * @param agreedCount    comparable items where the evaluator's pass/fail matched the human verdict
+     * @param excludedUnsure items the evaluator ran on whose human verdict was UNSURE
+     * @param alignmentRate  {@code agreedCount / comparableCount}, or null when {@code comparableCount}
+     *     is zero
+     */
+    public record EvaluatorAlignment(
+            String evaluatorName, int comparableCount, int agreedCount, int excludedUnsure, Double alignmentRate) {}
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
@@ -81,6 +81,7 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
             SELECT DISTINCT i FROM ItemResult i
             LEFT JOIN FETCH i.evalResults
             WHERE i.run.id = :runId
+            ORDER BY i.createdAt ASC, i.id ASC
             """)
     List<ItemResult> findByRunIdWithEvals(@Param("runId") UUID runId);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
@@ -67,4 +67,20 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
             @Param("evaluatorName") String evaluatorName,
             @Param("afterId") UUID afterId,
             Pageable pageable);
+
+    /**
+     * Loads all item results for a run with their eval results fetch-joined in one query. Annotations
+     * are deliberately not fetch-joined here: each item has at most one annotation but many eval
+     * results, so joining both would multiply rows in a Cartesian product. Callers that also need
+     * annotations batch-load them separately by item id.
+     *
+     * @param runId the run whose items to load
+     * @return the run's item results, each with its eval results initialized
+     */
+    @Query("""
+            SELECT DISTINCT i FROM ItemResult i
+            LEFT JOIN FETCH i.evalResults
+            WHERE i.run.id = :runId
+            """)
+    List<ItemResult> findByRunIdWithEvals(@Param("runId") UUID runId);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/AlignmentService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/AlignmentService.java
@@ -1,0 +1,116 @@
+package dev.dokimos.server.service;
+
+import dev.dokimos.server.dto.v1.AlignmentView;
+import dev.dokimos.server.entity.Annotation;
+import dev.dokimos.server.entity.AnnotationVerdict;
+import dev.dokimos.server.entity.EvalResult;
+import dev.dokimos.server.entity.ItemResult;
+import dev.dokimos.server.repository.AnnotationRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.repository.ItemResultRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Computes per-run, per-evaluator agreement between automated evaluator verdicts and human
+ * annotations. A CORRECT verdict is treated as the item passing and INCORRECT as failing; an
+ * evaluator result agrees when its success flag matches that expectation. UNSURE verdicts and items
+ * with no annotation are excluded from the rate, and UNSURE counts are reported separately so the
+ * caller can show how much of the run is still ambiguous.
+ */
+@Service
+public class AlignmentService {
+
+    private final ExperimentRunRepository runRepository;
+    private final ItemResultRepository itemResultRepository;
+    private final AnnotationRepository annotationRepository;
+
+    public AlignmentService(
+            ExperimentRunRepository runRepository,
+            ItemResultRepository itemResultRepository,
+            AnnotationRepository annotationRepository) {
+        this.runRepository = runRepository;
+        this.itemResultRepository = itemResultRepository;
+        this.annotationRepository = annotationRepository;
+    }
+
+    /**
+     * Computes the judge-human alignment breakdown for a run. Items are loaded with their eval
+     * results in one query and their annotations batch-loaded by item id to avoid an N+1 fan-out.
+     * Each evaluator's rate uses only items it ran on whose human verdict was CORRECT or INCORRECT.
+     *
+     * @param runId the run to analyze
+     * @return the per-evaluator agreement breakdown, ordered by first appearance of each evaluator
+     * @throws IllegalArgumentException if {@code runId} is null or the run does not exist
+     */
+    @Transactional(readOnly = true)
+    public AlignmentView getAlignment(UUID runId) {
+        if (runId == null) {
+            throw new IllegalArgumentException("Run ID cannot be null");
+        }
+        if (!runRepository.existsById(runId)) {
+            throw new IllegalArgumentException("Run not found: " + runId);
+        }
+
+        List<ItemResult> items = itemResultRepository.findByRunIdWithEvals(runId);
+        Map<UUID, AnnotationVerdict> verdictsByItemId = loadVerdicts(items);
+
+        Map<String, Tally> tallies = new LinkedHashMap<>();
+        for (ItemResult item : items) {
+            AnnotationVerdict verdict = verdictsByItemId.get(item.getId());
+            if (verdict == null) {
+                continue;
+            }
+            for (EvalResult eval : item.getEvalResults()) {
+                Tally tally = tallies.computeIfAbsent(eval.getEvaluatorName(), name -> new Tally());
+                if (verdict == AnnotationVerdict.UNSURE) {
+                    tally.excludedUnsure++;
+                    continue;
+                }
+                boolean expectedPass = verdict == AnnotationVerdict.CORRECT;
+                tally.comparableCount++;
+                if (eval.isSuccess() == expectedPass) {
+                    tally.agreedCount++;
+                }
+            }
+        }
+
+        List<AlignmentView.EvaluatorAlignment> evaluators = new ArrayList<>(tallies.size());
+        for (Map.Entry<String, Tally> entry : tallies.entrySet()) {
+            Tally tally = entry.getValue();
+            Double rate = tally.comparableCount > 0 ? (double) tally.agreedCount / tally.comparableCount : null;
+            evaluators.add(new AlignmentView.EvaluatorAlignment(
+                    entry.getKey(), tally.comparableCount, tally.agreedCount, tally.excludedUnsure, rate));
+        }
+
+        return new AlignmentView(verdictsByItemId.size(), evaluators);
+    }
+
+    /**
+     * Batch-loads the human verdict for each annotated item in one query, keyed by item result id.
+     * Replicated rather than shared with {@code RunService} so the two read paths stay independent.
+     */
+    private Map<UUID, AnnotationVerdict> loadVerdicts(List<ItemResult> items) {
+        if (items.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> ids = items.stream().map(ItemResult::getId).toList();
+        Map<UUID, AnnotationVerdict> byItemId = new HashMap<>();
+        for (Annotation annotation : annotationRepository.findByItemResultIdIn(ids)) {
+            byItemId.put(annotation.getItemResult().getId(), annotation.getVerdict());
+        }
+        return byItemId;
+    }
+
+    private static final class Tally {
+        private int comparableCount;
+        private int agreedCount;
+        private int excludedUnsure;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/AlignmentService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/AlignmentService.java
@@ -89,7 +89,11 @@ public class AlignmentService {
                     entry.getKey(), tally.comparableCount, tally.agreedCount, tally.excludedUnsure, rate));
         }
 
-        return new AlignmentView(verdictsByItemId.size(), evaluators);
+        long annotatedItems = items.stream()
+                .filter(item -> verdictsByItemId.containsKey(item.getId())
+                        && !item.getEvalResults().isEmpty())
+                .count();
+        return new AlignmentView((int) annotatedItems, evaluators);
     }
 
     /**

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/AlignmentControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/AlignmentControllerTest.java
@@ -1,0 +1,67 @@
+package dev.dokimos.server.controller.v1;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import dev.dokimos.server.controller.GlobalExceptionHandler;
+import dev.dokimos.server.dto.v1.AlignmentView;
+import dev.dokimos.server.service.AlignmentService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@SuppressWarnings("null")
+@ExtendWith(MockitoExtension.class)
+class AlignmentControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private AlignmentService alignmentService;
+
+    @BeforeEach
+    void setUp() {
+        AlignmentController controller = new AlignmentController(alignmentService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void alignment_returns200WithBreakdown() throws Exception {
+        UUID runId = UUID.randomUUID();
+        AlignmentView view = new AlignmentView(
+                3,
+                List.of(
+                        new AlignmentView.EvaluatorAlignment("accuracy", 2, 2, 1, 1.0),
+                        new AlignmentView.EvaluatorAlignment("relevance", 0, 0, 1, null)));
+        when(alignmentService.getAlignment(eq(runId))).thenReturn(view);
+
+        mockMvc.perform(get("/api/v1/runs/{runId}/alignment", runId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.annotatedItems").value(3))
+                .andExpect(jsonPath("$.evaluators[0].evaluatorName").value("accuracy"))
+                .andExpect(jsonPath("$.evaluators[0].comparableCount").value(2))
+                .andExpect(jsonPath("$.evaluators[0].agreedCount").value(2))
+                .andExpect(jsonPath("$.evaluators[0].excludedUnsure").value(1))
+                .andExpect(jsonPath("$.evaluators[0].alignmentRate").value(1.0))
+                .andExpect(jsonPath("$.evaluators[1].alignmentRate").doesNotExist());
+    }
+
+    @Test
+    void alignment_returns404WhenRunMissing() throws Exception {
+        UUID runId = UUID.randomUUID();
+        when(alignmentService.getAlignment(eq(runId)))
+                .thenThrow(new IllegalArgumentException("Run not found: " + runId));
+
+        mockMvc.perform(get("/api/v1/runs/{runId}/alignment", runId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Run not found: " + runId));
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/AlignmentServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/AlignmentServiceTest.java
@@ -1,0 +1,250 @@
+package dev.dokimos.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.dokimos.server.dto.v1.AlignmentView;
+import dev.dokimos.server.entity.Annotation;
+import dev.dokimos.server.entity.AnnotationVerdict;
+import dev.dokimos.server.entity.EvalResult;
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.ItemResult;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.repository.AnnotationRepository;
+import dev.dokimos.server.repository.ExperimentRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.repository.ProjectRepository;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Service-level coverage for {@link AlignmentService} backed by the in-memory H2 DataJpaTest stack.
+ * Verifies the agreement math, the UNSURE and unannotated exclusions, the sparse-evaluator matrix,
+ * and the missing-run guard.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(AlignmentServiceTest.TestConfig.class)
+class AlignmentServiceTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    static class TestConfig {
+        @org.springframework.context.annotation.Bean
+        AlignmentService alignmentService(
+                ExperimentRunRepository runRepository,
+                ItemResultRepository itemResultRepository,
+                AnnotationRepository annotationRepository) {
+            return new AlignmentService(runRepository, itemResultRepository, annotationRepository);
+        }
+    }
+
+    @Autowired
+    private AlignmentService alignmentService;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ExperimentRepository experimentRepository;
+
+    @Autowired
+    private ExperimentRunRepository runRepository;
+
+    @Autowired
+    private ItemResultRepository itemResultRepository;
+
+    @Autowired
+    private AnnotationRepository annotationRepository;
+
+    @Test
+    void allItemsAgree_rateIsOne() {
+        ExperimentRun run = newRun();
+        annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
+        annotate(itemWithEval(run, "accuracy", false), AnnotationVerdict.INCORRECT);
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+
+        assertThat(view.annotatedItems()).isEqualTo(2);
+        AlignmentView.EvaluatorAlignment accuracy = only(view);
+        assertThat(accuracy.evaluatorName()).isEqualTo("accuracy");
+        assertThat(accuracy.comparableCount()).isEqualTo(2);
+        assertThat(accuracy.agreedCount()).isEqualTo(2);
+        assertThat(accuracy.excludedUnsure()).isZero();
+        assertThat(accuracy.alignmentRate()).isEqualTo(1.0);
+    }
+
+    @Test
+    void allItemsDisagree_rateIsZero() {
+        ExperimentRun run = newRun();
+        annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.INCORRECT);
+        annotate(itemWithEval(run, "accuracy", false), AnnotationVerdict.CORRECT);
+
+        AlignmentView.EvaluatorAlignment accuracy = only(alignmentService.getAlignment(run.getId()));
+
+        assertThat(accuracy.comparableCount()).isEqualTo(2);
+        assertThat(accuracy.agreedCount()).isZero();
+        assertThat(accuracy.alignmentRate()).isEqualTo(0.0);
+    }
+
+    @Test
+    void unsureItemsExcludedFromRateButCounted() {
+        ExperimentRun run = newRun();
+        annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
+        annotate(itemWithEval(run, "accuracy", false), AnnotationVerdict.UNSURE);
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView.EvaluatorAlignment accuracy = only(view);
+
+        assertThat(view.annotatedItems()).isEqualTo(2);
+        assertThat(accuracy.comparableCount()).isEqualTo(1);
+        assertThat(accuracy.agreedCount()).isEqualTo(1);
+        assertThat(accuracy.excludedUnsure()).isEqualTo(1);
+        assertThat(accuracy.alignmentRate()).isEqualTo(1.0);
+    }
+
+    @Test
+    void unannotatedItemsSkippedEntirely() {
+        ExperimentRun run = newRun();
+        annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
+        itemWithEval(run, "accuracy", false);
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView.EvaluatorAlignment accuracy = only(view);
+
+        assertThat(view.annotatedItems()).isEqualTo(1);
+        assertThat(accuracy.comparableCount()).isEqualTo(1);
+        assertThat(accuracy.agreedCount()).isEqualTo(1);
+        assertThat(accuracy.alignmentRate()).isEqualTo(1.0);
+    }
+
+    @Test
+    void multipleEvaluatorsComputedIndependently() {
+        ExperimentRun run = newRun();
+        ItemResult first = newItem(run);
+        addEval(first, "accuracy", true);
+        addEval(first, "relevance", false);
+        itemResultRepository.save(first);
+        annotate(first, AnnotationVerdict.CORRECT);
+
+        ItemResult second = newItem(run);
+        addEval(second, "accuracy", false);
+        addEval(second, "relevance", false);
+        itemResultRepository.save(second);
+        annotate(second, AnnotationVerdict.CORRECT);
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+
+        AlignmentView.EvaluatorAlignment accuracy = byName(view, "accuracy");
+        AlignmentView.EvaluatorAlignment relevance = byName(view, "relevance");
+        assertThat(accuracy.comparableCount()).isEqualTo(2);
+        assertThat(accuracy.agreedCount()).isEqualTo(1);
+        assertThat(accuracy.alignmentRate()).isEqualTo(0.5);
+        assertThat(relevance.comparableCount()).isEqualTo(2);
+        assertThat(relevance.agreedCount()).isZero();
+        assertThat(relevance.alignmentRate()).isEqualTo(0.0);
+    }
+
+    @Test
+    void sparseEvaluatorUsesOnlyItemsItRanOn() {
+        ExperimentRun run = newRun();
+        annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
+        ItemResult second = newItem(run);
+        addEval(second, "accuracy", false);
+        addEval(second, "toxicity", true);
+        itemResultRepository.save(second);
+        annotate(second, AnnotationVerdict.CORRECT);
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+
+        assertThat(byName(view, "accuracy").comparableCount()).isEqualTo(2);
+        AlignmentView.EvaluatorAlignment toxicity = byName(view, "toxicity");
+        assertThat(toxicity.comparableCount()).isEqualTo(1);
+        assertThat(toxicity.agreedCount()).isEqualTo(1);
+    }
+
+    @Test
+    void evaluatorWithOnlyUnsureItems_rateIsNull() {
+        ExperimentRun run = newRun();
+        annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.UNSURE);
+
+        AlignmentView.EvaluatorAlignment accuracy = only(alignmentService.getAlignment(run.getId()));
+
+        assertThat(accuracy.comparableCount()).isZero();
+        assertThat(accuracy.excludedUnsure()).isEqualTo(1);
+        assertThat(accuracy.alignmentRate()).isNull();
+    }
+
+    @Test
+    void runWithNoAnnotations_hasNoEvaluators() {
+        ExperimentRun run = newRun();
+        itemWithEval(run, "accuracy", true);
+        itemWithEval(run, "accuracy", false);
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+
+        assertThat(view.annotatedItems()).isZero();
+        assertThat(view.evaluators()).isEmpty();
+    }
+
+    @Test
+    void emptyRun_hasNoEvaluators() {
+        ExperimentRun run = newRun();
+
+        AlignmentView view = alignmentService.getAlignment(run.getId());
+
+        assertThat(view.annotatedItems()).isZero();
+        assertThat(view.evaluators()).isEmpty();
+    }
+
+    @Test
+    void missingRunRaisesNotFound() {
+        assertThatThrownBy(() -> alignmentService.getAlignment(UUID.randomUUID()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Run not found");
+    }
+
+    private AlignmentView.EvaluatorAlignment only(AlignmentView view) {
+        assertThat(view.evaluators()).hasSize(1);
+        return view.evaluators().get(0);
+    }
+
+    private AlignmentView.EvaluatorAlignment byName(AlignmentView view, String name) {
+        return view.evaluators().stream()
+                .filter(e -> e.evaluatorName().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ItemResult itemWithEval(ExperimentRun run, String evaluatorName, boolean success) {
+        ItemResult item = newItem(run);
+        addEval(item, evaluatorName, success);
+        return itemResultRepository.save(item);
+    }
+
+    private ItemResult newItem(ExperimentRun run) {
+        return new ItemResult(run, Map.of("q", "question"), Map.of("a", "expected"), Map.of("a", "actual"), null);
+    }
+
+    private void addEval(ItemResult item, String evaluatorName, boolean success) {
+        item.addEvalResult(new EvalResult(evaluatorName, success ? 1.0 : 0.0, 0.5, success, null));
+    }
+
+    private void annotate(ItemResult item, AnnotationVerdict verdict) {
+        annotationRepository.save(new Annotation(item, verdict));
+    }
+
+    private ExperimentRun newRun() {
+        Project project = projectRepository.save(new Project("p-" + UUID.randomUUID()));
+        Experiment experiment = experimentRepository.save(new Experiment(project, "e-" + UUID.randomUUID()));
+        return runRepository.save(new ExperimentRun(experiment, null));
+    }
+}


### PR DESCRIPTION
Adds a per-run, per-evaluator agreement rate between an evaluator's pass/fail and the human annotation verdict (correct counts as pass, incorrect as fail, unsure is excluded), exposed via GET /api/v1/runs/{id}/alignment. Read-only; the UI that surfaces it lands in a follow-up.
