### PR TITLE
Lenient judge parsing and SPA deep-link fallback

### DIFF
--- a/dokimos-core/src/main/java/dev/dokimos/core/LlmResponseUtils.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/LlmResponseUtils.java
@@ -1,15 +1,41 @@
 package dev.dokimos.core;
 
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
 /**
  * Utility methods for processing LLM responses.
  * <p>
  * Provides common parsing functionality for handling responses from
- * {@link JudgeLM} implementations.
+ * {@link JudgeLM} implementations. Judges are language models, so their replies are not always
+ * strict JSON: they may wrap the payload in a markdown fence, add a sentence of preamble, or emit
+ * single quotes, unquoted keys, or a trailing comma. The helpers here recover the JSON payload and
+ * parse it leniently so an otherwise correct judgment is not lost to a formatting quirk.
  */
 public final class LlmResponseUtils {
 
+    private static final ObjectMapper LENIENT_MAPPER = JsonMapper.builder()
+            .enable(JsonReadFeature.ALLOW_TRAILING_COMMA)
+            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+            .enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
+            .enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+            .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+            .build();
+
     private LlmResponseUtils() {
         // Utility class, prevent instantiation
+    }
+
+    /**
+     * An {@link ObjectMapper} configured to tolerate the common ways a language model deviates from
+     * strict JSON (trailing commas, single quotes, unquoted field names, comments, and unescaped
+     * control characters). Shared and thread-safe for reads.
+     *
+     * @return the shared lenient object mapper
+     */
+    public static ObjectMapper lenientMapper() {
+        return LENIENT_MAPPER;
     }
 
     /**
@@ -34,5 +60,43 @@ public final class LlmResponseUtils {
                 .replaceAll("^```(?:json)?\\s*", "")
                 .replaceAll("\\s*```$", "")
                 .strip();
+    }
+
+    /**
+     * Extracts the JSON payload from an LLM response. Markdown fences are removed, then the substring
+     * from the first opening brace or bracket to its matching closing character is returned, dropping
+     * any preamble or trailing prose around the JSON. When the response contains both an object and an
+     * array, the one that appears first is used. When no JSON structure is found the stripped response
+     * is returned unchanged so the caller surfaces a meaningful parse error.
+     *
+     * @param response the LLM response that may wrap JSON in prose or a code fence
+     * @return the extracted JSON text, or null when the response is null
+     */
+    public static String extractJson(String response) {
+        if (response == null) {
+            return null;
+        }
+        String stripped = stripMarkdown(response);
+        int objectStart = stripped.indexOf('{');
+        int arrayStart = stripped.indexOf('[');
+
+        int start;
+        char close;
+        boolean arrayFirst = arrayStart >= 0 && (objectStart < 0 || arrayStart < objectStart);
+        if (arrayFirst) {
+            start = arrayStart;
+            close = ']';
+        } else if (objectStart >= 0) {
+            start = objectStart;
+            close = '}';
+        } else {
+            return stripped;
+        }
+
+        int end = stripped.lastIndexOf(close);
+        if (end > start) {
+            return stripped.substring(start, end + 1);
+        }
+        return stripped;
     }
 }

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/ContextualRelevanceEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/ContextualRelevanceEvaluator.java
@@ -42,7 +42,7 @@ import java.util.Map;
  */
 public class ContextualRelevanceEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private static final String DEFAULT_RETRIEVAL_CONTEXT_KEY = "retrievalContext";
 
     private final String retrievalContextKey;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/FaithfulnessEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/FaithfulnessEvaluator.java
@@ -15,7 +15,7 @@ import java.util.*;
  */
 public class FaithfulnessEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private final String contextKey;
     private final JudgeLM judge;
     private final boolean includeReason;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/HallucinationEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/HallucinationEvaluator.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class HallucinationEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private final String contextKey;
     private final JudgeLM judge;
     private final boolean includeReason;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LLMJudgeEvaluator extends BaseEvaluator {
     private static final Logger LOGGER = LoggerFactory.getLogger(LLMJudgeEvaluator.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private final String criteria;
     private final double minScore;
     private final double maxScore;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/TaskCompletionEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/TaskCompletionEvaluator.java
@@ -21,7 +21,7 @@ import java.util.Map;
  */
 public class TaskCompletionEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
 
     private final JudgeLM judge;
     private final String tasksKey;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluator.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class ToolArgumentHallucinationEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
 
     private final JudgeLM judge;
     private final String toolCallsKey;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolDescriptionReliabilityEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolDescriptionReliabilityEvaluator.java
@@ -6,6 +6,7 @@ import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.EvalTestCaseParam;
 import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.LlmResponseUtils;
 import dev.dokimos.core.agents.ToolDefinition;
 import dev.dokimos.core.evaluators.EvaluationException;
 import java.util.*;
@@ -42,7 +43,7 @@ import java.util.regex.Pattern;
  */
 public class ToolDescriptionReliabilityEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
 
     private static final List<String> LLM_CHECK_KEYS = List.of(
             "general_structure",

--- a/dokimos-core/src/test/java/dev/dokimos/core/LlmResponseUtilsTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/LlmResponseUtilsTest.java
@@ -2,6 +2,9 @@ package dev.dokimos.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class LlmResponseUtilsTest {
@@ -65,5 +68,39 @@ class LlmResponseUtilsTest {
         String result = LlmResponseUtils.stripMarkdown(input);
 
         assertThat(result).isEqualTo("{\"key\": \"value\"}");
+    }
+
+    @Test
+    void extractJson_dropsPreambleAndTrailingProse() {
+        String response =
+                "Sure, here is the result:\n{\"score\": 0.8, \"reason\": \"good\"}\nLet me know if you need more.";
+        assertThat(LlmResponseUtils.extractJson(response)).isEqualTo("{\"score\": 0.8, \"reason\": \"good\"}");
+    }
+
+    @Test
+    void extractJson_picksTheArrayWhenItComesFirst() {
+        assertThat(LlmResponseUtils.extractJson("```json\n[{\"grounded\": true}]\n```"))
+                .isEqualTo("[{\"grounded\": true}]");
+    }
+
+    @Test
+    void extractJson_returnsStrippedResponseWhenNoJsonPresent() {
+        assertThat(LlmResponseUtils.extractJson("no json here")).isEqualTo("no json here");
+    }
+
+    @Test
+    void lenientMapper_toleratesTrailingCommasAndSingleQuotes() throws Exception {
+        Map<String, Object> parsed = LlmResponseUtils.lenientMapper()
+                .readValue("{'score': 0.5, 'reason': 'ok',}", new TypeReference<Map<String, Object>>() {});
+        assertThat(parsed).containsEntry("score", 0.5).containsEntry("reason", "ok");
+    }
+
+    @Test
+    void lenientMapper_toleratesUnquotedFieldNames() throws Exception {
+        List<Map<String, Object>> parsed = LlmResponseUtils.lenientMapper()
+                .readValue("[{grounded: true}, {grounded: false}]", new TypeReference<List<Map<String, Object>>>() {});
+        assertThat(parsed).hasSize(2);
+        assertThat(parsed.get(0)).containsEntry("grounded", true);
+        assertThat(parsed.get(1)).containsEntry("grounded", false);
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/config/SpaResourceConfig.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/config/SpaResourceConfig.java
@@ -1,0 +1,45 @@
+package dev.dokimos.server.config;
+
+import java.io.IOException;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.PathResourceResolver;
+
+/**
+ * Serves the single-page React app and forwards client side routes to {@code index.html} so a deep
+ * link or a page refresh on a route such as {@code /traces} or {@code /api-keys} is handled by the SPA
+ * router instead of returning 404. Real static assets are served directly; only unmatched, non-API
+ * paths fall back to {@code index.html}. API, actuator, and OpenAPI paths are left to their
+ * controllers, so an unknown one still returns 404 rather than the app shell.
+ */
+@Configuration
+public class SpaResourceConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(@NonNull ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/static/")
+                .resourceChain(true)
+                .addResolver(new PathResourceResolver() {
+                    @Override
+                    protected Resource getResource(@NonNull String resourcePath, @NonNull Resource location)
+                            throws IOException {
+                        Resource requested = location.createRelative(resourcePath);
+                        if (requested.exists() && requested.isReadable()) {
+                            return requested;
+                        }
+                        if (resourcePath.startsWith("api/")
+                                || resourcePath.startsWith("actuator/")
+                                || resourcePath.startsWith("v3/")) {
+                            return null;
+                        }
+                        Resource index = new ClassPathResource("/static/index.html");
+                        return index.exists() ? index : null;
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Two hardening fixes.

Judge responses are now parsed leniently. Judges are language models, so their JSON replies sometimes carry a markdown fence, a sentence of preamble, single quotes, unquoted field names, or a trailing comma. The shared parser now extracts the JSON payload from the reply and tolerates those quirks, so an otherwise correct judgment is not lost to a formatting slip. This is the class of failure that occasionally reddens the live integration suite.

The server now serves the single page app for client side routes. A deep link or a page refresh on a route such as /traces or /api-keys returned a 404 because the server had no fallback to index.html. It now serves the app shell for unmatched non-API paths, while API, actuator, and docs paths are still left to their controllers so an unknown one returns 404 rather than the shell.
