### PR TITLE
Production loop docs and API key access hardening

### DIFF
--- a/docs/docs/evaluation/datasets.md
+++ b/docs/docs/evaluation/datasets.md
@@ -386,6 +386,10 @@ val datasetFromDefault = DatasetResolverRegistry.getInstance()
 
 JSON, JSONL, and CSV files are automatically detected based on the file extension.
 
+### Server datasets
+
+With the `dokimos-server-client` dependency on your classpath, the registry also resolves `dataset://name@version` URIs against a running Dokimos server, so a dataset can be versioned and shared instead of living in a file. See [Server datasets](../server/datasets) for the version model, the resolver's environment variables, and its offline cache.
+
 ## Using Datasets with JUnit
 
 The `dokimos-junit` module makes it easy to use datasets with JUnit's parameterized tests through the `@DatasetSource` annotation.

--- a/docs/docs/server/alerting.md
+++ b/docs/docs/server/alerting.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 10
+---
+
+# Regression alerting
+
+The server can POST to a webhook when a run regresses against its baseline, so a quality drop reaches your chat or on call tooling without anyone watching a dashboard. Alerting reuses the same comparison the [CI gate](./ci-gate) uses, so an alert fires on the same regression the gate would fail on.
+
+## Registering a webhook
+
+Webhooks are scoped to a project. Manage them from the project page in the web UI under **Alert webhooks**, or through the API.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/projects/{projectId}/alert-webhooks \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://hooks.example.com/dokimos",
+    "secret": "your-signing-secret",
+    "enabled": true
+  }'
+```
+
+The signing secret is write only. It is never returned in a response; the UI shows only whether a secret is configured.
+
+## When it fires
+
+When a run reaches a terminal status, the server resolves its baseline the way the gate does (the most recent successful run of the same experiment, scoped by dataset version and git branch) and compares the two. If the pass rate both regressed and the drop is statistically significant, every enabled webhook for the project receives a POST.
+
+The decision is made inside run completion, but delivery happens after the transaction commits, on a separate thread. A slow or failing receiver can never block, lengthen, or fail the run; a delivery failure is logged and dropped.
+
+## Payload
+
+```json
+{
+  "projectName": "my-llm-app",
+  "experimentId": "…",
+  "experimentName": "customer-support-qa",
+  "runId": "…",
+  "baselinePassRate": 0.92,
+  "candidatePassRate": 0.78,
+  "regressedCases": 7
+}
+```
+
+When the webhook has a secret, the body is signed with HMAC SHA256 and the lowercase hex digest is sent in the `X-Dokimos-Signature` header. Verify it by computing the same HMAC over the raw request body with your secret and comparing.
+
+## Next steps
+
+- [CI regression gate](./ci-gate): block a regression before it ships
+- [Production traces](./traces): evaluate production traffic online

--- a/docs/docs/server/authentication.md
+++ b/docs/docs/server/authentication.md
@@ -68,6 +68,36 @@ When authentication fails, the API returns:
 
 HTTP status: `401 Unauthorized`
 
+## Scoped API keys and roles
+
+The single `DOKIMOS_API_KEY` is the simplest setup: one shared secret for all writes. When you want more than one credential, or different levels of access, create **scoped API keys** with a role. Manage them under **API keys** in the web UI (admin only), or through the API.
+
+Each key carries a role:
+
+| Role | Can do |
+|------|--------|
+| `VIEWER` | Read only |
+| `EDITOR` | Reads plus writes (report runs, create connections, and so on) |
+| `ADMIN` | Everything, including managing API keys |
+
+The server stores only a hash of each key, never the key itself. A newly created key's raw value is returned exactly once; copy it then, because it cannot be shown again.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/api-keys \
+  -H 'Content-Type: application/json' \
+  -d '{ "name": "ci-pipeline", "role": "EDITOR" }'
+```
+
+### How enforcement works
+
+A request's `Bearer` token is matched against the stored keys, and the resulting role is enforced: writes require `EDITOR` or higher, managing API keys (including listing them, so key names and roles are not exposed) requires `ADMIN`, and other reads stay open. The deployment is in authenticated mode when either `DOKIMOS_API_KEY` is set or at least one scoped key exists.
+
+Backward compatibility is preserved. When no key is configured at all, the server behaves exactly as before (reads and writes both open). The legacy `DOKIMOS_API_KEY`, if set, keeps working and counts as an admin credential, so you can adopt scoped keys gradually.
+
+:::note
+Because key management requires `ADMIN`, keep at least one admin credential available (the legacy `DOKIMOS_API_KEY`, or an admin scoped key). Otherwise, after you create only non admin scoped keys, no one can manage keys through the API.
+:::
+
 ## UI Authentication with Reverse Proxy
 
 For restricting access to the web UI, the server can be placed behind a reverse proxy that handles authentication.

--- a/docs/docs/server/configuration.md
+++ b/docs/docs/server/configuration.md
@@ -24,6 +24,29 @@ The Dokimos server is configured through environment variables. This page covers
 |----------|-------------|---------|
 | `SERVER_PORT` | HTTP port to listen on | `8080` |
 | `DOKIMOS_API_KEY` | API key for write operations | _(disabled)_ |
+| `DOKIMOS_ENCRYPTION_KEY` | Passphrase used to encrypt inline LLM connection keys at rest. Required only if you store an inline `apiKey` on a connection. | _(disabled)_ |
+
+### Server side judge
+
+Tune the background worker that scores [LLM judge](./llm-judge) jobs. The defaults are fine for most deployments.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DOKIMOS_JUDGE_POLL_INTERVAL_MS` | How often the worker polls for pending judge jobs | `5000` |
+| `DOKIMOS_JUDGE_MAX_ATTEMPTS` | Retry ceiling for a judge job before it fails | `3` |
+| `DOKIMOS_JUDGE_PAGE_SIZE` | Items scored per database transaction | `50` |
+
+### Traces and online evals
+
+Control [production trace](./traces) retention and the online eval worker.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DOKIMOS_TRACE_RETENTION_DAYS` | Days an ingested trace is kept before the sweeper deletes it | `30` |
+| `DOKIMOS_TRACE_SWEEP_INTERVAL_MS` | How often the retention sweeper runs | `3600000` |
+| `DOKIMOS_TRACE_EVAL_POLL_INTERVAL_MS` | How often the worker polls for pending trace eval jobs | `5000` |
+| `DOKIMOS_TRACE_EVAL_MAX_ATTEMPTS` | Retry ceiling for a trace eval job before it fails | `3` |
+| `DOKIMOS_TRACE_EVAL_CLAIM_TIMEOUT_MS` | How long a claimed trace eval job can run before it is requeued | `600000` |
 
 ### Logging
 

--- a/docs/docs/server/curation.md
+++ b/docs/docs/server/curation.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 12
+---
+
+# Review and curation
+
+Automated evaluators are not always right, and the cases they get wrong are exactly the ones worth adding to a dataset. The review queue gathers run items that still need a human verdict, lets you annotate them, and promotes the ones you have judged into a new dataset version. That closes the loop: a production miss becomes a regression test.
+
+## The review queue
+
+Open **Review queue** in the web UI to see items waiting on a human, with enough context (input, expected output, produced output, and the automated eval results) to judge each one without opening its run first. An item appears when it has never been annotated, or when it was previously marked `UNSURE`.
+
+Through the API:
+
+```bash
+curl 'http://localhost:8080/api/v1/review-queue?projectName=my-llm-app'
+```
+
+The list is pageable and can be narrowed by `projectName`, `experimentId`, or `runId`.
+
+## Annotating an item
+
+A verdict is one of `CORRECT`, `INCORRECT`, or `UNSURE`. You can also record a corrected expected output and a free-text note. The annotation is keyed to the run item:
+
+```bash
+curl -X PUT \
+  http://localhost:8080/api/v1/runs/{runId}/items/{itemResultId}/annotation \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "verdict": "INCORRECT",
+    "overriddenExpectedOutput": { "answer": "Paris" },
+    "note": "Model answered Lyon; gold answer is Paris."
+  }'
+```
+
+`PUT` creates or replaces the annotation, `GET` reads it back, and `DELETE` removes it. When authentication is enabled the annotation records which principal made it. A `CORRECT` or `INCORRECT` verdict takes the item out of the queue; `UNSURE` keeps it there for another pass.
+
+## Promoting into a dataset
+
+Once you have judged a batch of items, promote them into a new immutable version of an existing dataset. Each promoted item carries its input and expected output from the run, and you can override the expected output per item (for instance the correction you recorded while annotating):
+
+```bash
+curl -X POST http://localhost:8080/api/v1/datasets/promote \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "datasetName": "qa-regression",
+    "description": "Added misses from the May run",
+    "items": [
+      {
+        "itemResultId": "<item-result-id>",
+        "overriddenExpectedOutput": { "answer": "Paris" }
+      }
+    ]
+  }'
+```
+
+The dataset named must already exist; promotion appends a version to it (it does not create a dataset). The response points at the new version, which you can then reference as `dataset://qa-regression@latest` from your tests. See [Server datasets](./datasets) for the dataset and version model.
+
+## The loop
+
+```
+run item fails -> appears in review queue -> annotated -> promoted -> new dataset version -> next run is gated on it
+```
+
+## Next steps
+
+- [Server datasets](./datasets): the dataset and version model promotion writes to
+- [LLM judge](./llm-judge): compare a judge against human verdicts to trust it

--- a/docs/docs/server/datasets.md
+++ b/docs/docs/server/datasets.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 11
+---
+
+# Server datasets
+
+The server can hold your datasets as the source of truth, versioned and shared, instead of every test embedding its own copy. You create a dataset once, add immutable versions to it over time, and reference a specific version from code by URI. This is what lets a regression gate compare like for like: a run records which dataset version it ran against.
+
+## Datasets and versions
+
+A dataset is a named container. Its data lives in **versions**, which are numbered from 1 and immutable once written. Adding examples never edits a version in place; it creates the next one. The alias `latest` always resolves to the highest version.
+
+Browse datasets under **Datasets** in the web UI. The list shows each dataset's latest version and item count; opening one shows its versions and lets you page through the items in a version.
+
+## Managing datasets through the API
+
+```bash
+# Create an empty dataset
+curl -X POST http://localhost:8080/api/v1/datasets \
+  -H 'Content-Type: application/json' \
+  -d '{ "name": "qa-regression", "description": "Customer support QA set" }'
+
+# Add a version with its items
+curl -X POST http://localhost:8080/api/v1/datasets/qa-regression/versions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "description": "Initial import",
+    "items": [
+      {
+        "inputs":          { "question": "What is the capital of France?" },
+        "expectedOutputs": { "answer": "Paris" },
+        "metadata":        { "category": "geography" }
+      }
+    ]
+  }'
+```
+
+`inputs` is required on each item; `expectedOutputs` and `metadata` are optional. Other endpoints:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/v1/datasets` | List datasets with their latest version |
+| `GET` | `/api/v1/datasets/{name}` | One dataset with all its versions |
+| `GET` | `/api/v1/datasets/{name}/versions/{version}` | A version (`latest` or a number) |
+| `GET` | `/api/v1/datasets/{name}/versions/{version}/items` | Page through a version's items |
+| `DELETE` | `/api/v1/datasets/{name}` | Delete a dataset and its versions |
+
+Writes require an EDITOR role when authentication is enabled; see [Authentication](./authentication). To grow a dataset from real run results instead of hand-writing items, see [Review and curation](./curation).
+
+## Referencing a dataset from code
+
+Add the `dokimos-server-client` dependency to your test classpath. It registers a resolver that handles `dataset://` URIs, so anywhere Dokimos resolves a dataset (the registry, or the JUnit `@DatasetSource` annotation) can point at the server:
+
+```java
+import dev.dokimos.core.DatasetResolverRegistry;
+
+Dataset dataset = DatasetResolverRegistry.getInstance()
+    .resolve("dataset://qa-regression@3");
+```
+
+```java
+@DatasetSource("dataset://qa-regression@latest")
+void evaluatesAnswers(Example example) { ... }
+```
+
+The URI is `dataset://<name>@<version>`, where the version is a positive integer or `latest`. The version is required, so a pinned test always states exactly which data it ran against.
+
+The resolver reads two environment variables and stays inert (resolving nothing) when the server URL is unset, so the same test runs offline against file based datasets when the server is not configured:
+
+| Variable | Purpose |
+|----------|---------|
+| `DOKIMOS_SERVER_URL` | Base URL of the server to fetch from |
+| `DOKIMOS_API_KEY` | Bearer key, when the server requires one |
+
+## Offline cache
+
+Resolved datasets are cached under `~/.dokimos/datasets-cache/<name>@<version>/items.json`. A pinned version is fetched network first and falls back to its cached copy when the server is briefly unreachable, so a transient outage does not break a CI run that already pulled that version once. The `latest` alias is always fetched fresh, and once it resolves to a concrete version that version is cached too. A 4xx response or a parse error is surfaced directly rather than masked by the cache, since those are not transient.
+
+## Next steps
+
+- [Review and curation](./curation): turn real run failures into new dataset versions
+- [CI regression gate](./ci-gate): fail a build when a run regresses against a dataset version

--- a/docs/docs/server/diff.md
+++ b/docs/docs/server/diff.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 13
+---
+
+# Comparing runs
+
+The diff view compares two runs of the same experiment item by item, so you can see exactly what a change moved before it ships. It is the same comparison the [CI gate](./ci-gate) and [regression alerting](./alerting) act on, shown as a table you can read.
+
+## Opening a diff
+
+From a run, open the comparison against its baseline to land on `/experiments/{experimentId}/runs/{candidateRunId}/diff` in the web UI. One run is the **candidate** (the one under review) and the other is the **baseline** (what you are comparing against, usually the previous successful run).
+
+Through the API:
+
+```bash
+curl 'http://localhost:8080/api/v1/experiments/{experimentId}/runs/{candidateRunId}/diff?baselineRunId={baselineRunId}&status=REGRESSED'
+```
+
+`baselineRunId` is required. Both runs must be terminal (a comparison of an in-flight run would be misleading). `status` filters the case list to `ALL` (default), `REGRESSED`, `IMPROVED`, or `CHANGED`, and the cases are pageable.
+
+## Reading the result
+
+The response has a summary and a page of cases. The summary reports the headline movement:
+
+| Field | Meaning |
+|-------|---------|
+| `baselinePassRate`, `candidatePassRate`, `passRateDelta` | Pass rate on each side and the change |
+| `significant` | Whether the pass-rate change is statistically significant, not noise |
+| `improvedCount`, `regressedCount`, `unchangedCount` | How items moved between the runs |
+| `addedCount`, `removedCount` | Items present in only one of the two runs |
+| `pairing` | Whether items were matched one to one across the runs |
+
+Each case shows its status (`IMPROVED`, `REGRESSED`, or `CHANGED`), whether the item flipped between pass and fail, its input, and the per-evaluator deltas so you can see which evaluator moved.
+
+## Significance gating
+
+A change counts as a regression only when it is both beyond a small epsilon and statistically significant: McNemar's test for single-run pass/fail flips, and a paired permutation test with a bootstrap interval otherwise. A noisy judge nudging one item does not register as a regression, which is what keeps the gate and alerts from flaking. The `significant` flag in the summary is that same gate, surfaced so you can tell a real move from sampling noise.
+
+## Next steps
+
+- [CI regression gate](./ci-gate): turn this comparison into a build pass or fail
+- [Regression alerting](./alerting): get a webhook when a comparison regresses

--- a/docs/docs/server/llm-judge.md
+++ b/docs/docs/server/llm-judge.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 8
+---
+
+# LLM judge
+
+The server can run LLM as judge evaluations on its own, scoring stored run items and production traces without a key living in your test code. It calls a model through a stored **LLM connection** and records the result like any other evaluation.
+
+This is separate from the client side judge you use in CI. In CI your tests bring their own `JudgeLM` and their own key. The server side judge is for evaluations that run on the server: scoring an already reported run from the UI, or evaluating production traces as they arrive.
+
+## LLM connections
+
+An LLM connection is a named, reusable pointer to an OpenAI compatible endpoint: a base URL, a model, the API protocol, and a credential. Connections are managed under **LLM connections** in the web UI, or through the API.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/llm-connections \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "openai-judge",
+    "baseUrl": "https://api.openai.com/v1",
+    "model": "gpt-4o-mini",
+    "protocol": "RESPONSES",
+    "apiKey": "sk-..."
+  }'
+```
+
+Responses never include key material. A connection stores exactly one credential:
+
+- **`apiKey`**: an inline key, encrypted at rest. Inline keys require `DOKIMOS_ENCRYPTION_KEY` to be set (see [Configuration](./configuration)).
+- **`credentialRef`**: the name of an environment variable the server reads the key from at call time, so the key never touches the database.
+
+### API protocol
+
+Each connection declares which API its endpoint speaks:
+
+- **`RESPONSES`** (default): the [Open Responses](https://www.openresponses.org) shape (`POST {baseUrl}/responses`). Open Responses is a vendor neutral, multi provider standard.
+- **`CHAT_COMPLETIONS`**: the older Chat Completions shape (`POST {baseUrl}/chat/completions`), which most self hosted and proxy endpoints implement.
+
+New connections default to Responses. Connections created before this feature existed keep Chat Completions, so nothing that worked before changes. Pick the one your endpoint supports; the judge builds the request and parses the reply accordingly. The server never depends on a vendor SDK; both protocols are spoken over plain HTTP.
+
+## Running the judge over a run
+
+From a run in the web UI, choose **Run LLM judge**, pick a connection and an evaluator, and the run is queued for scoring. The run moves to an `EVALUATING` status while the judge works, then back to a terminal status with the new scores attached to each item.
+
+Jobs are processed by a background worker that claims one job at a time, calls the model outside any database transaction, and records each page of results in its own transaction. Transient failures (timeouts, 5xx) are retried up to a ceiling; a non retryable failure (4xx) fails the job and the run is marked accordingly. The judge configuration (poll interval, retry ceiling) is covered in [Configuration](./configuration).
+
+## Judge and human agreement
+
+When you annotate items with a human verdict (correct, incorrect, unsure), the run page shows per evaluator agreement between the judge and the human. It is the share of annotated items where the judge's pass or fail matched the human verdict, with unsure annotations excluded. Use it to see where a judge is reliable and where it is not before you trust it on unlabeled data.
+
+## Next steps
+
+- [Production traces](./traces): evaluate production traces as they arrive
+- [Configuration](./configuration): judge and encryption settings

--- a/docs/docs/server/overview.md
+++ b/docs/docs/server/overview.md
@@ -104,6 +104,15 @@ Drill into specific runs to see individual test cases, scores, and evaluation re
 ### Expandable Items
 Click on any item to see full input/output text and detailed evaluation results.
 
+### LLM judge
+Score runs and traces on the server with an LLM as judge, using a stored connection that speaks the Open Responses or Chat Completions API. See [LLM judge](./llm-judge).
+
+### Production traces
+Ingest OTLP traces from your running app and evaluate them online as they arrive. See [Production traces](./traces).
+
+### Regression alerting
+Get a webhook when a run regresses against its baseline. See [Regression alerting](./alerting).
+
 ## Quick Start
 
 ```bash
@@ -118,6 +127,9 @@ Open [http://localhost:8080](http://localhost:8080). See [Getting Started](./get
 - [Getting Started](./getting-started): Run your first experiment with server reporting
 - [Configuration](./configuration): Environment variables and settings
 - [Deployment](./deployment): Share with your team or run in production
-- [Authentication](./authentication): Secure write operations
+- [Authentication](./authentication): Secure write operations and scope API keys by role
 - [Client](./client): Reporter client configuration
+- [LLM judge](./llm-judge): Score runs and traces with an LLM as judge
+- [Production traces](./traces): Ingest and evaluate production traffic
+- [Regression alerting](./alerting): Webhook on a quality drop
   

--- a/docs/docs/server/overview.md
+++ b/docs/docs/server/overview.md
@@ -104,6 +104,15 @@ Drill into specific runs to see individual test cases, scores, and evaluation re
 ### Expandable Items
 Click on any item to see full input/output text and detailed evaluation results.
 
+### Server datasets
+Hold your datasets on the server, versioned and shared, and reference a specific version from code by URI. See [Server datasets](./datasets).
+
+### Review and curation
+Review the items evaluators got wrong, annotate them, and promote them into a new dataset version. See [Review and curation](./curation).
+
+### Run comparison
+Compare two runs item by item to see exactly what a change moved. See [Comparing runs](./diff).
+
 ### LLM judge
 Score runs and traces on the server with an LLM as judge, using a stored connection that speaks the Open Responses or Chat Completions API. See [LLM judge](./llm-judge).
 
@@ -129,6 +138,9 @@ Open [http://localhost:8080](http://localhost:8080). See [Getting Started](./get
 - [Deployment](./deployment): Share with your team or run in production
 - [Authentication](./authentication): Secure write operations and scope API keys by role
 - [Client](./client): Reporter client configuration
+- [Server datasets](./datasets): Hold datasets on the server and reference them by URI
+- [Review and curation](./curation): Turn evaluator misses into new dataset versions
+- [Comparing runs](./diff): Diff two runs item by item
 - [LLM judge](./llm-judge): Score runs and traces with an LLM as judge
 - [Production traces](./traces): Ingest and evaluate production traffic
 - [Regression alerting](./alerting): Webhook on a quality drop

--- a/docs/docs/server/traces.md
+++ b/docs/docs/server/traces.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 9
+---
+
+# Production traces
+
+The server can ingest traces from your running application and evaluate them online, so quality monitoring follows the same loop as your offline experiments. Traces are stored on a dedicated path, separate from the experiment store, so high volume ingestion never competes with your experiment data.
+
+## Ingesting traces
+
+Send traces to `POST /api/v1/traces` using the OTLP/HTTP JSON encoding of an `ExportTraceServiceRequest`. This is the standard OpenTelemetry trace export shape, so an OTLP exporter pointed at this endpoint works. (Protobuf encoding is not supported yet; send JSON.)
+
+```bash
+curl -X POST http://localhost:8080/api/v1/traces \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "resourceSpans": [{
+      "resource": { "attributes": [
+        { "key": "dokimos.project", "value": { "stringValue": "my-llm-app" } }
+      ]},
+      "scopeSpans": [{
+        "spans": [{
+          "traceId": "0af7651916cd43dd8448eb211c80319c",
+          "spanId": "b7ad6b7169203331",
+          "name": "llm.generate",
+          "startTimeUnixNano": "1700000000000000000",
+          "endTimeUnixNano": "1700000002000000000",
+          "attributes": [
+            { "key": "input",  "value": { "stringValue": "What is the capital of France?" } },
+            { "key": "output", "value": { "stringValue": "The capital of France is Paris." } }
+          ]
+        }]
+      }]
+    }]
+  }'
+```
+
+The response reports how many spans were accepted, how many were rejected, and how many traces resulted:
+
+```json
+{ "acceptedSpans": 1, "rejectedSpans": 0, "traces": 1 }
+```
+
+A malformed span (missing trace id, span id, or name) is skipped and counted as rejected; one bad span never fails the rest of the batch.
+
+### Derived fields
+
+The server derives a span's input and output text from the first present of these attribute keys, so an online eval has something to score without re-parsing attributes:
+
+- **Input**: `dokimos.input`, `input.value`, `gen_ai.prompt`, `llm.input`, `input`, `prompt`
+- **Output**: `dokimos.output`, `output.value`, `gen_ai.completion`, `llm.output`, `output`, `completion`
+
+A `dokimos.project` (or `dokimos.project.name`) **resource** attribute links the trace to a project so its eval rules apply. Browse ingested traces under **Traces** in the web UI; open one to see its spans, attributes, and online eval results.
+
+### Retention
+
+Each trace is stamped with an expiry and a background sweeper deletes expired traces, cascading to their spans and eval jobs. The retention window and sweep interval are configurable (`DOKIMOS_TRACE_RETENTION_DAYS`, default 30; see [Configuration](./configuration)).
+
+## Online evaluations
+
+A **trace eval rule** runs an LLM judge on matching spans as traces are ingested. Manage rules per project under **Trace eval rules** in the web UI, or through the API. A rule matches a span by its name or by an attribute, and points at an [LLM connection](./llm-judge) and an evaluator.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/projects/{projectId}/trace-eval-rules \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "helpfulness",
+    "enabled": true,
+    "matchType": "SPAN_NAME",
+    "matchValue": "llm.generate",
+    "connectionId": "<llm-connection-id>",
+    "evaluatorName": "helpfulness",
+    "criteria": "The response correctly and helpfully answers the question.",
+    "minScore": 0,
+    "maxScore": 1,
+    "threshold": 0.5
+  }'
+```
+
+`matchType` is `SPAN_NAME` (compare `matchValue` to the span name) or `ATTRIBUTE` (with `matchKey` naming the attribute). When an ingested trace contains a matching span with scorable output, the server enqueues an online evaluation. A background worker scores it through the same judge machinery as run evaluations, so it honors the connection's Responses or Chat Completions protocol, with the same poll and claim, retry ceiling, and credential handling. The result appears on the trace detail page.
+
+## The loop
+
+```
+production trace ingested -> matched by a rule -> online eval enqueued -> scored -> visible
+```
+
+## Next steps
+
+- [LLM judge](./llm-judge): connections and judge configuration
+- [Regression alerting](./alerting): get notified when quality drops

--- a/dokimos-server/src/main/java/dev/dokimos/server/filter/ApiKeyAuthFilter.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/filter/ApiKeyAuthFilter.java
@@ -76,11 +76,12 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
     }
 
     /**
-     * Returns the minimum role a request must carry. API key management requires ADMIN, other writes
-     * require EDITOR, and reads require only VIEWER.
+     * Returns the minimum role a request must carry. API key management requires ADMIN for every
+     * method, including listing, so key names and roles are not readable by an unauthenticated caller.
+     * Other writes require EDITOR, and other reads require only VIEWER.
      */
     private Role requiredRole(String method, String path) {
-        if (path.startsWith(API_KEYS_PATH_PREFIX) && WRITE_METHODS.contains(method)) {
+        if (path.startsWith(API_KEYS_PATH_PREFIX)) {
             return Role.ADMIN;
         }
         if (WRITE_METHODS.contains(method)) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/filter/ApiKeyAuthenticator.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/filter/ApiKeyAuthenticator.java
@@ -47,20 +47,27 @@ public class ApiKeyAuthenticator implements Authenticator {
             return Optional.of(Principal.system());
         }
 
+        Optional<Principal> resolved = resolveBearer(authorizationHeader, legacyKeyConfigured);
+
         if (READ_METHODS.contains(method)) {
-            return Optional.of(Principal.system());
+            // Reads stay open: a valid key is honored at its role, otherwise an anonymous viewer is
+            // returned so open read endpoints still serve, while endpoints that demand a higher role
+            // (API key management) reject the anonymous reader.
+            return Optional.of(resolved.orElseGet(Principal::anonymous));
         }
 
+        // Writes require a valid credential.
+        return resolved;
+    }
+
+    private Optional<Principal> resolveBearer(String authorizationHeader, boolean legacyKeyConfigured) {
         if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
             return Optional.empty();
         }
-
         String providedKey = authorizationHeader.substring(BEARER_PREFIX.length());
-
         if (legacyKeyConfigured && apiKeyProperties.getApiKey().equals(providedKey)) {
             return Optional.of(Principal.system());
         }
-
         String keyHash = ApiKeyHasher.sha256Hex(providedKey);
         return apiKeyRepository.findByKeyHashAndEnabledTrue(keyHash).map(this::toPrincipal);
     }

--- a/dokimos-server/src/main/java/dev/dokimos/server/filter/Principal.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/filter/Principal.java
@@ -20,4 +20,13 @@ public record Principal(String id, Role role, String tenantId) {
     public static Principal system() {
         return new Principal(SYSTEM_ID, Role.ADMIN, null);
     }
+
+    /**
+     * Principal for an unauthenticated reader in an authenticated deployment. Carries the lowest role
+     * so open read endpoints still serve it, while endpoints that require a higher role (such as API
+     * key management) reject it.
+     */
+    public static Principal anonymous() {
+        return new Principal("anonymous", Role.VIEWER, null);
+    }
 }

--- a/dokimos-server/src/test/java/dev/dokimos/server/filter/ApiKeyAuthFilterTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/filter/ApiKeyAuthFilterTest.java
@@ -432,6 +432,30 @@ class ApiKeyAuthFilterTest {
         }
 
         @Test
+        void shouldRejectApiKeyListingFromAnonymousReaderWith403() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/api-keys");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(403);
+            assertThat(filterChain.getRequest()).isNull();
+        }
+
+        @Test
+        void shouldKeepNormalReadsOpenForAnonymousReader() throws Exception {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/llm-connections");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain filterChain = new MockFilterChain();
+
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(filterChain.getRequest()).isNotNull();
+        }
+
+        @Test
         void shouldStampScopedPrincipalWithRoleAndTenant() throws Exception {
             ApiKey key = new ApiKey(ApiKeyHasher.sha256Hex("editor-key"), "k", Role.EDITOR, "tenant-9");
             when(apiKeyRepository.findByKeyHashAndEnabledTrue(ApiKeyHasher.sha256Hex("editor-key")))

--- a/dokimos-server/src/test/java/dev/dokimos/server/filter/ApiKeyAuthenticatorTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/filter/ApiKeyAuthenticatorTest.java
@@ -84,8 +84,10 @@ class ApiKeyAuthenticatorTest {
 
         Optional<Principal> result = authenticator.authenticate("GET", null);
 
+        // A keyless read resolves to an anonymous viewer: open read endpoints still serve it, while
+        // endpoints that demand a higher role (API key management) reject it.
         assertThat(result).isPresent();
-        assertThat(result.get().role()).isEqualTo(Role.ADMIN);
+        assertThat(result.get().role()).isEqualTo(Role.VIEWER);
     }
 
     @Test


### PR DESCRIPTION
Documents the production loop server features and tightens API key access.

New server docs cover the LLM judge (connections, the Open Responses and Chat Completions protocols, judge jobs, judge and human agreement), production traces (OTLP ingestion with an example, the attribute keys input and output are derived from, retention, and online eval rules), and regression alerting webhooks. Authentication gains a section on scoped API keys and roles, Configuration documents the new judge and trace settings, and the overview links them.

Also requires admin to manage API keys, including listing them, so an unauthenticated reader can no longer see key names and roles. Keyless reads in authenticated mode resolve to an anonymous viewer, so every other read stays open exactly as before.
