### PR TITLE
Accept protobuf-encoded OTLP traces

### DIFF
--- a/docs/docs/server/traces.md
+++ b/docs/docs/server/traces.md
@@ -8,7 +8,9 @@ The server can ingest traces from your running application and evaluate them onl
 
 ## Ingesting traces
 
-Send traces to `POST /api/v1/traces` using the OTLP/HTTP JSON encoding of an `ExportTraceServiceRequest`. This is the standard OpenTelemetry trace export shape, so an OTLP exporter pointed at this endpoint works. (Protobuf encoding is not supported yet; send JSON.)
+Send traces to `POST /api/v1/traces` using an `ExportTraceServiceRequest`. This is the standard OpenTelemetry trace export shape, so an OTLP exporter pointed at this endpoint works. Both OTLP encodings are accepted: the JSON encoding with `Content-Type: application/json`, and the protobuf binary encoding with `Content-Type: application/x-protobuf` (the OpenTelemetry default). Both encodings produce the same span counts, the same derived input and output text, and the same project link whichever one you send. (The raw stored `kind` and `status.code` strings can differ for a JSON exporter that sends enums as integers rather than symbolic names, but those fields drive neither matching nor the derived fields.)
+
+The JSON example below is the most copy-paste friendly. For protobuf, point an OTLP/HTTP exporter at the endpoint and it will send `application/x-protobuf` automatically.
 
 ```bash
 curl -X POST http://localhost:8080/api/v1/traces \

--- a/dokimos-server/pom.xml
+++ b/dokimos-server/pom.xml
@@ -68,6 +68,12 @@
             <version>2.8.6</version>
         </dependency>
 
+        <!-- Generated OTLP protobuf classes for decoding application/x-protobuf trace exports. -->
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/TraceController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/TraceController.java
@@ -1,15 +1,19 @@
 package dev.dokimos.server.controller.v1;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import dev.dokimos.server.dto.v1.PageResponse;
 import dev.dokimos.server.dto.v1.TraceDetail;
 import dev.dokimos.server.dto.v1.TraceIngestResponse;
 import dev.dokimos.server.dto.v1.TraceSummary;
 import dev.dokimos.server.dto.v1.otlp.OtlpExportTraceServiceRequest;
+import dev.dokimos.server.service.OtlpProtobufConverter;
 import dev.dokimos.server.service.TraceIngestService;
 import dev.dokimos.server.service.TraceQueryService;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,11 +22,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
- * OTLP trace ingestion and read endpoints. Ingestion accepts the OTLP/HTTP JSON encoding of
- * {@code ExportTraceServiceRequest}; the protobuf binary encoding is deferred. Writes (ingestion) pass
- * through the API key auth filter; reads are open.
+ * OTLP trace ingestion and read endpoints. Ingestion accepts both the JSON ({@code application/json}) and
+ * protobuf ({@code application/x-protobuf}) encodings of {@code ExportTraceServiceRequest}, which converge
+ * on the same internal shape, so span counts, derived input/output, and project linking match across them.
+ * Writes pass through the API key auth filter; reads are open.
  */
 @RestController
 @RequestMapping("/api/v1/traces")
@@ -46,6 +52,22 @@ public class TraceController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public TraceIngestResponse ingestTraces(@RequestBody OtlpExportTraceServiceRequest request) {
         return ingestService.ingest(request);
+    }
+
+    /**
+     * Ingests an OTLP protobuf trace export. The binary {@code ExportTraceServiceRequest} body is decoded
+     * and mapped onto the same internal shape the JSON path uses. A body that is not a valid request
+     * yields 400.
+     */
+    @PostMapping(consumes = {"application/x-protobuf", "application/protobuf"})
+    public TraceIngestResponse ingestTracesProtobuf(@RequestBody byte[] body) {
+        ExportTraceServiceRequest message;
+        try {
+            message = ExportTraceServiceRequest.parseFrom(body);
+        } catch (InvalidProtocolBufferException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Malformed OTLP protobuf body", e);
+        }
+        return ingestService.ingest(OtlpProtobufConverter.toDto(message));
     }
 
     /** Lists ingested traces newest first, optionally filtered to a project. */

--- a/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/otlp/OtlpExportTraceServiceRequest.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/dto/v1/otlp/OtlpExportTraceServiceRequest.java
@@ -7,9 +7,9 @@ import java.util.List;
  * The top level of the OTLP/HTTP JSON encoding of {@code ExportTraceServiceRequest}. Only the fields the
  * server consumes are mapped; unknown fields are ignored so newer OTLP exporters do not break ingestion.
  *
- * <p>This is the JSON encoding only. The protobuf binary encoding of the same message is deferred: the
- * endpoint documents and accepts {@code application/json} and we parse with Jackson into these DTOs
- * rather than depending on opentelemetry-proto.
+ * <p>This is the JSON encoding, parsed by Jackson into these DTOs. The protobuf encoding of the same
+ * message is decoded with the generated opentelemetry-proto classes and converted onto this same DTO
+ * tree (see {@code OtlpProtobufConverter}), so both encodings share one ingestion path.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record OtlpExportTraceServiceRequest(List<OtlpResourceSpans> resourceSpans) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/OtlpProtobufConverter.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/OtlpProtobufConverter.java
@@ -1,0 +1,130 @@
+package dev.dokimos.server.service;
+
+import dev.dokimos.server.dto.v1.otlp.OtlpAnyValue;
+import dev.dokimos.server.dto.v1.otlp.OtlpExportTraceServiceRequest;
+import dev.dokimos.server.dto.v1.otlp.OtlpKeyValue;
+import dev.dokimos.server.dto.v1.otlp.OtlpResource;
+import dev.dokimos.server.dto.v1.otlp.OtlpResourceSpans;
+import dev.dokimos.server.dto.v1.otlp.OtlpScopeSpans;
+import dev.dokimos.server.dto.v1.otlp.OtlpSpan;
+import dev.dokimos.server.dto.v1.otlp.OtlpStatus;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Translates the protobuf {@code ExportTraceServiceRequest} into the same DTO tree Jackson produces for
+ * the OTLP/HTTP JSON encoding, so both encodings share one parser and persistence path. Normalizes the
+ * wire differences: ids to lowercase hex, uint64 nanos to decimal strings, enums to their symbolic names,
+ * and unset defaults to null, matching what a JSON exporter sends.
+ */
+public final class OtlpProtobufConverter {
+
+    private static final HexFormat HEX = HexFormat.of();
+
+    private OtlpProtobufConverter() {}
+
+    /**
+     * Converts a decoded protobuf request into the common OTLP request DTO.
+     *
+     * @param request the protobuf message parsed from the request body
+     * @return the equivalent DTO, ready for the shared ingestion path
+     */
+    public static OtlpExportTraceServiceRequest toDto(ExportTraceServiceRequest request) {
+        List<OtlpResourceSpans> resourceSpans = new ArrayList<>();
+        for (ResourceSpans rs : request.getResourceSpansList()) {
+            resourceSpans.add(toResourceSpans(rs));
+        }
+        return new OtlpExportTraceServiceRequest(resourceSpans);
+    }
+
+    private static OtlpResourceSpans toResourceSpans(ResourceSpans rs) {
+        OtlpResource resource = null;
+        if (rs.hasResource()) {
+            resource = new OtlpResource(toKeyValues(rs.getResource().getAttributesList()));
+        }
+        List<OtlpScopeSpans> scopeSpans = new ArrayList<>();
+        for (ScopeSpans ss : rs.getScopeSpansList()) {
+            List<OtlpSpan> spans = new ArrayList<>();
+            for (Span span : ss.getSpansList()) {
+                spans.add(toSpan(span));
+            }
+            scopeSpans.add(new OtlpScopeSpans(spans));
+        }
+        return new OtlpResourceSpans(resource, scopeSpans);
+    }
+
+    private static OtlpSpan toSpan(Span span) {
+        OtlpStatus status = null;
+        if (span.hasStatus()) {
+            status = new OtlpStatus(
+                    statusCode(span.getStatus()), nullIfEmpty(span.getStatus().getMessage()));
+        }
+        return new OtlpSpan(
+                hex(span.getTraceId()),
+                hex(span.getSpanId()),
+                hex(span.getParentSpanId()),
+                nullIfEmpty(span.getName()),
+                spanKind(span.getKind()),
+                unixNano(span.getStartTimeUnixNano()),
+                unixNano(span.getEndTimeUnixNano()),
+                status,
+                toKeyValues(span.getAttributesList()));
+    }
+
+    private static List<OtlpKeyValue> toKeyValues(List<KeyValue> attributes) {
+        List<OtlpKeyValue> result = new ArrayList<>();
+        for (KeyValue kv : attributes) {
+            result.add(new OtlpKeyValue(kv.getKey(), toAnyValue(kv.getValue())));
+        }
+        return result;
+    }
+
+    private static OtlpAnyValue toAnyValue(AnyValue value) {
+        return switch (value.getValueCase()) {
+            case STRING_VALUE -> new OtlpAnyValue(value.getStringValue(), null, null, null);
+            case BOOL_VALUE -> new OtlpAnyValue(null, value.getBoolValue(), null, null);
+            case INT_VALUE -> new OtlpAnyValue(null, null, Long.toString(value.getIntValue()), null);
+            case DOUBLE_VALUE -> new OtlpAnyValue(null, null, null, value.getDoubleValue());
+            // Array, kvlist, and bytes map to null, matching the JSON DTO's scalar-only unwrap.
+            default -> new OtlpAnyValue(null, null, null, null);
+        };
+    }
+
+    private static String spanKind(Span.SpanKind kind) {
+        if (kind == Span.SpanKind.SPAN_KIND_UNSPECIFIED || kind == Span.SpanKind.UNRECOGNIZED) {
+            return null;
+        }
+        return kind.name();
+    }
+
+    private static String statusCode(Status status) {
+        Status.StatusCode code = status.getCode();
+        if (code == Status.StatusCode.STATUS_CODE_UNSET || code == Status.StatusCode.UNRECOGNIZED) {
+            return null;
+        }
+        return code.name();
+    }
+
+    private static String hex(com.google.protobuf.ByteString bytes) {
+        if (bytes == null || bytes.isEmpty()) {
+            return null;
+        }
+        return HEX.formatHex(bytes.toByteArray());
+    }
+
+    private static String unixNano(long value) {
+        return value == 0 ? null : Long.toString(value);
+    }
+
+    private static String nullIfEmpty(String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/TraceControllerProtobufTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/TraceControllerProtobufTest.java
@@ -1,0 +1,199 @@
+package dev.dokimos.server.controller.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import dev.dokimos.server.controller.GlobalExceptionHandler;
+import dev.dokimos.server.dto.v1.TraceIngestResponse;
+import dev.dokimos.server.dto.v1.otlp.OtlpExportTraceServiceRequest;
+import dev.dokimos.server.service.OtlpProtobufConverter;
+import dev.dokimos.server.service.OtlpTraceParser;
+import dev.dokimos.server.service.OtlpTraceParser.ParsedSpan;
+import dev.dokimos.server.service.OtlpTraceParser.Result;
+import dev.dokimos.server.service.TraceIngestService;
+import dev.dokimos.server.service.TraceQueryService;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import java.util.HexFormat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Web layer coverage for the protobuf ingestion path. Proves a protobuf encoded request maps onto the
+ * same internal DTO the JSON docs example produces, so the shared parser derives identical span count,
+ * input/output text, and project link. The ingest service is mocked, so no database is required.
+ */
+@ExtendWith(MockitoExtension.class)
+class TraceControllerProtobufTest extends AbstractControllerTest {
+
+    @Mock
+    private TraceIngestService ingestService;
+
+    @Mock
+    private TraceQueryService queryService;
+
+    private final OtlpTraceParser parser = new OtlpTraceParser();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * The OTLP/HTTP JSON encoding of the same example, copied from docs/docs/server/traces.md. The JSON
+     * endpoint feeds this through Jackson into the same DTO the protobuf converter targets.
+     */
+    private static final String DOCS_EXAMPLE_JSON = """
+            {
+              "resourceSpans": [{
+                "resource": { "attributes": [
+                  { "key": "dokimos.project", "value": { "stringValue": "my-llm-app" } }
+                ]},
+                "scopeSpans": [{
+                  "spans": [{
+                    "traceId": "0af7651916cd43dd8448eb211c80319c",
+                    "spanId": "b7ad6b7169203331",
+                    "name": "llm.generate",
+                    "startTimeUnixNano": "1700000000000000000",
+                    "endTimeUnixNano": "1700000002000000000",
+                    "attributes": [
+                      { "key": "input",  "value": { "stringValue": "What is the capital of France?" } },
+                      { "key": "output", "value": { "stringValue": "The capital of France is Paris." } }
+                    ]
+                  }]
+                }]
+              }]
+            }
+            """;
+
+    @BeforeEach
+    void setUp() {
+        TraceController controller = new TraceController(ingestService, queryService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    /** Mirrors the OTLP span in docs/docs/server/traces.md, encoded as protobuf instead of JSON. */
+    private byte[] docsExampleProtobuf() {
+        Span span = Span.newBuilder()
+                .setTraceId(hexToBytes("0af7651916cd43dd8448eb211c80319c"))
+                .setSpanId(hexToBytes("b7ad6b7169203331"))
+                .setName("llm.generate")
+                .setStartTimeUnixNano(1700000000000000000L)
+                .setEndTimeUnixNano(1700000002000000000L)
+                .addAttributes(stringAttr("input", "What is the capital of France?"))
+                .addAttributes(stringAttr("output", "The capital of France is Paris."))
+                .build();
+        Resource resource = Resource.newBuilder()
+                .addAttributes(stringAttr("dokimos.project", "my-llm-app"))
+                .build();
+        ResourceSpans resourceSpans = ResourceSpans.newBuilder()
+                .setResource(resource)
+                .addScopeSpans(ScopeSpans.newBuilder().addSpans(span))
+                .build();
+        return ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(resourceSpans)
+                .build()
+                .toByteArray();
+    }
+
+    @Test
+    void protobufBodyReachesIngestWithSameParsedShapeAsDocsJson() throws Exception {
+        when(ingestService.ingest(any(OtlpExportTraceServiceRequest.class)))
+                .thenReturn(new TraceIngestResponse(1, 0, 1));
+
+        mockMvc.perform(post("/api/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(docsExampleProtobuf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.acceptedSpans").value(1))
+                .andExpect(jsonPath("$.rejectedSpans").value(0))
+                .andExpect(jsonPath("$.traces").value(1));
+
+        ArgumentCaptor<OtlpExportTraceServiceRequest> captor =
+                ArgumentCaptor.forClass(OtlpExportTraceServiceRequest.class);
+        org.mockito.Mockito.verify(ingestService).ingest(captor.capture());
+
+        Result parsed = parser.parse(captor.getValue());
+        assertThat(parsed.rejected()).isZero();
+        assertThat(parsed.spans()).hasSize(1);
+        ParsedSpan span = parsed.spans().get(0);
+        assertThat(span.traceId()).isEqualTo("0af7651916cd43dd8448eb211c80319c");
+        assertThat(span.spanId()).isEqualTo("b7ad6b7169203331");
+        assertThat(span.name()).isEqualTo("llm.generate");
+        assertThat(span.startTimeUnixNano()).isEqualTo(1700000000000000000L);
+        assertThat(span.endTimeUnixNano()).isEqualTo(1700000002000000000L);
+        assertThat(span.inputText()).isEqualTo("What is the capital of France?");
+        assertThat(span.outputText()).isEqualTo("The capital of France is Paris.");
+        assertThat(span.projectName()).isEqualTo("my-llm-app");
+    }
+
+    @Test
+    void protobufAndJsonEncodingsParseToTheSameSpan() throws Exception {
+        OtlpExportTraceServiceRequest fromProtobuf =
+                OtlpProtobufConverter.toDto(ExportTraceServiceRequest.parseFrom(docsExampleProtobuf()));
+        OtlpExportTraceServiceRequest fromJson =
+                objectMapper.readValue(DOCS_EXAMPLE_JSON, OtlpExportTraceServiceRequest.class);
+
+        Result protobufResult = parser.parse(fromProtobuf);
+        Result jsonResult = parser.parse(fromJson);
+
+        assertThat(protobufResult.spans()).hasSize(1);
+        assertThat(jsonResult.spans()).hasSize(1);
+        assertThat(protobufResult.rejected()).isEqualTo(jsonResult.rejected()).isZero();
+
+        ParsedSpan fromProto = protobufResult.spans().get(0);
+        ParsedSpan fromJsonSpan = jsonResult.spans().get(0);
+
+        assertThat(fromProto.traceId()).isEqualTo(fromJsonSpan.traceId()).isEqualTo("0af7651916cd43dd8448eb211c80319c");
+        assertThat(fromProto.spanId()).isEqualTo(fromJsonSpan.spanId()).isEqualTo("b7ad6b7169203331");
+        assertThat(fromProto.startTimeUnixNano())
+                .isEqualTo(fromJsonSpan.startTimeUnixNano())
+                .isEqualTo(1700000000000000000L);
+        assertThat(fromProto.endTimeUnixNano())
+                .isEqualTo(fromJsonSpan.endTimeUnixNano())
+                .isEqualTo(1700000002000000000L);
+        assertThat(fromProto.inputText())
+                .isEqualTo(fromJsonSpan.inputText())
+                .isEqualTo("What is the capital of France?");
+        assertThat(fromProto.outputText())
+                .isEqualTo(fromJsonSpan.outputText())
+                .isEqualTo("The capital of France is Paris.");
+        assertThat(fromProto.projectName())
+                .isEqualTo(fromJsonSpan.projectName())
+                .isEqualTo("my-llm-app");
+    }
+
+    @Test
+    void malformedProtobufBodyYields400() throws Exception {
+        byte[] notProtobuf = "this is not a valid protobuf message".getBytes();
+        mockMvc.perform(post("/api/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(notProtobuf))
+                .andExpect(status().isBadRequest());
+    }
+
+    private static KeyValue stringAttr(String key, String value) {
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value))
+                .build();
+    }
+
+    private static ByteString hexToBytes(String hex) {
+        return ByteString.copyFrom(HexFormat.of().parseHex(hex));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.proto</groupId>
+                <artifactId>opentelemetry-proto</artifactId>
+                <version>1.7.0-alpha</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Adds protobuf support to trace ingestion. `POST /api/v1/traces` previously accepted only the OTLP/HTTP JSON encoding; a standard OpenTelemetry SDK or collector defaults to `application/x-protobuf`.

A second handler decodes the protobuf `ExportTraceServiceRequest` and maps it onto the same DTO the JSON path uses, so both encodings share one ingest path. Accepted/rejected counting, the derived input and output keys, and project linking are identical across encodings.
