### PR TITLE
Add changelog and frame the production eval loop

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 20
+title: Changelog
+description: What shipped and when.
+---
+
+# Changelog
+
+What shipped and when. For exact version diffs, see the
+[GitHub releases](https://github.com/dokimos-dev/dokimos/releases).
+
+## 0.16.0 (2026-05-30)
+
+- **Server datasets.** Hold datasets on the server, versioned and shared, and
+  pin a test to an exact version with a `dataset://name@version` URI. The SDK
+  resolver caches offline, so a pinned version still resolves when the server
+  is briefly unreachable.
+- **CI regression gate and run diff.** The server fails your build when a run
+  regresses against its baseline, significance-gated so a noisy judge does not
+  flake the pipeline, with an item-by-item diff view and a reusable GitHub
+  Action.
+- **Server LLM judge.** Score runs and traces on the server with a stored
+  connection that speaks the vendor-neutral Open Responses API (Chat
+  Completions as fallback), plus a judge-vs-human alignment metric.
+- **Production traces and online evals.** Ingest OTLP traces from your running
+  app and score matching spans as they arrive, using the same judge as offline
+  experiments.
+- **Regression alerting.** Get a signed webhook when a run regresses, on the
+  same comparison the CI gate acts on.
+- **Review and curation.** Review the items evaluators got wrong, annotate
+  them, and promote them into a new dataset version.
+- **Role-scoped API keys.** Issue VIEWER / EDITOR / ADMIN keys alongside the
+  single-key mode. Reads stay open, writes need EDITOR, key management needs
+  ADMIN.
+- **Per-item cost, token, and latency metrics.** Track spend and speed next to
+  quality on every item result.

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -17,15 +17,17 @@ Read the **[Getting started Guide](./getting-started/installation)**.
 
 Lean more about what you can build with `dokimos` by exploring the [examples module](https://github.com/dokimos-dev/dokimos/tree/master/dokimos-examples).
 
+## The production eval loop
+
+The optional **[server](./server/overview)** closes the loop from a single run to a system that holds quality steady over time. You hold datasets on the server and pin tests to a version with [server datasets](./server/datasets), fail a build when a run regresses against its baseline with the [CI regression gate](./server/ci-gate), score runs and traces with the [server LLM judge](./server/llm-judge), evaluate [production traces](./server/traces) online as they arrive, get a webhook on a quality drop with [regression alerting](./server/alerting), and turn the items evaluators got wrong into new dataset versions through [review and curation](./server/curation). See the [server overview](./server/overview) for how the pieces fit together.
+
 ## What's Next
 
 We're actively working on expanding Dokimos with features that make evaluation in Java easier and more powerful:
 
 - **More built-in evaluators**: Additional evaluators for common patterns like misuse detection and more
 - **Test Data Generation**: Use LLMs to generate synthetic test datasets for evaluation
-- **Server-side datasets**: Store and version datasets centrally, making them easier to share across teams
 - **SPI (Service Provider Interface)**: Plug in custom implementations for storage, metrics, and reporting
 - **CLI**: Command-line tools for running experiments, managing datasets, and generating reports
-- **Framework integrations**: Bridges for Java AI frameworks so you can use dokimos with your existing stack
 
 Want to see something else? [Open an issue](https://github.com/dokimos-dev/dokimos/issues) or contribute!

--- a/docs/docs/server/ci-gate.md
+++ b/docs/docs/server/ci-gate.md
@@ -63,3 +63,9 @@ A composite action under `.github/actions/eval-gate` calls the endpoint, writes 
 ```
 
 `candidate-run-id` is the run id returned when your test job reported results through `DokimosServerReporter`. Set `fail-on-regression: "false"` to comment without blocking the merge, or `comment: "false"` to skip the PR comment.
+
+## Next steps
+
+- [Comparing runs](./diff): read the same comparison item by item in the web UI
+- [Regression alerting](./alerting): get a webhook on the same regression the gate fails on
+- [Server datasets](./datasets): pin a run to a dataset version so the gate compares like for like

--- a/docs/docs/server/getting-started.md
+++ b/docs/docs/server/getting-started.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Get the Dokimos server running in under a minute. No building, no cloning—just Docker.
+Get the Dokimos server running in under a minute. No building, no cloning, just Docker.
 
 ## Start the Server
 
@@ -164,9 +164,19 @@ docker compose down -v
 
 ## Next Steps
 
+You have reported one run. The server is built to close the loop around it, so quality holds steady as your app changes:
+
+- [Server datasets](./datasets): hold this dataset on the server and pin the test to an exact version
+- [CI regression gate](./ci-gate): fail the build when a run regresses against its baseline
+- [LLM judge](./llm-judge): score runs and traces on the server with an LLM as judge
+- [Production traces](./traces): ingest OTLP traces from your running app and evaluate them online
+- [Review and curation](./curation): turn the items evaluators got wrong into the next dataset version
+
+Operating the server:
+
 - [Configuration](./configuration): Customize settings and environment variables
 - [Deployment](./deployment): Share with your team or run in production
-- [Authentication](./authentication): Secure write operations with an API key
+- [Authentication](./authentication): Secure write operations and scope API keys by role
 - [Client](./client): Advanced reporter configuration
 
 ---

--- a/docs/docs/server/llm-judge.md
+++ b/docs/docs/server/llm-judge.md
@@ -46,9 +46,10 @@ Jobs are processed by a background worker that claims one job at a time, calls t
 
 ## Judge and human agreement
 
-When you annotate items with a human verdict (correct, incorrect, unsure), the run page shows per evaluator agreement between the judge and the human. It is the share of annotated items where the judge's pass or fail matched the human verdict, with unsure annotations excluded. Use it to see where a judge is reliable and where it is not before you trust it on unlabeled data.
+When you annotate items with a human verdict (correct, incorrect, unsure), the run page shows per evaluator agreement between the judge and the human. It is the share of annotated items where the judge's pass or fail matched the human verdict, with unsure annotations excluded. Use it to see where a judge is reliable and where it is not before you trust it on unlabeled data. Annotating is part of the [review and curation](./curation) flow.
 
 ## Next steps
 
 - [Production traces](./traces): evaluate production traces as they arrive
+- [Review and curation](./curation): annotate items and check the judge against human verdicts
 - [Configuration](./configuration): judge and encryption settings

--- a/docs/docs/server/overview.md
+++ b/docs/docs/server/overview.md
@@ -4,7 +4,9 @@ sidebar_position: 1
 
 # Server Overview
 
-The Dokimos server stores your experiment results and provides a web UI to view, compare, and track quality over time.
+The Dokimos server is the production eval loop around your experiments. It stores run results and provides a web UI to view, compare, and track quality over time, and it closes the loop: hold datasets centrally and pin tests to a version, fail a build when a run regresses, score runs and production traces with an LLM judge, and turn evaluator misses back into new dataset versions.
+
+The loop, end to end: pin a test to a [server dataset](./datasets) version, report the run, [gate it](./ci-gate) against its baseline in CI, [score](./llm-judge) runs and [production traces](./traces) with a judge, get [alerted](./alerting) on a regression, then [review and curate](./curation) the misses into the next dataset version.
 
 ## How It Works
 


### PR DESCRIPTION
Adds a Changelog page to the docs and frames the server as the production eval loop.

The new changelog page collects what shipped and when, seeded with the 0.16.0 entry, and links out to the GitHub releases for exact diffs. New entries get appended per ship.

The refinement pass adds a production-loop framing to both overview pages, points the server getting-started at the loop rather than just storing results, and makes the cross-links between datasets, the gate, the judge, traces, alerting, and curation consistent. Docusaurus build is green with no broken links.
