### PR TITLE
Update versions to 0.17.0-SNAPSHOT

### DIFF
--- a/dokimos-core/pom.xml
+++ b/dokimos-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-core</artifactId>

--- a/dokimos-examples/pom.xml
+++ b/dokimos-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-examples</artifactId>

--- a/dokimos-junit/pom.xml
+++ b/dokimos-junit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-junit</artifactId>

--- a/dokimos-koog/pom.xml
+++ b/dokimos-koog/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dokimos-kotlin/pom.xml
+++ b/dokimos-kotlin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/dokimos-langchain4j/pom.xml
+++ b/dokimos-langchain4j/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-langchain4j</artifactId>

--- a/dokimos-mcp-server/pom.xml
+++ b/dokimos-mcp-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-mcp-server</artifactId>

--- a/dokimos-server-client/pom.xml
+++ b/dokimos-server-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-server-client</artifactId>

--- a/dokimos-server/pom.xml
+++ b/dokimos-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-server</artifactId>

--- a/dokimos-spring-ai/pom.xml
+++ b/dokimos-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.dokimos</groupId>
         <artifactId>dokimos-parent</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
+        <version>0.17.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dokimos-spring-ai</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.dokimos</groupId>
     <artifactId>dokimos-parent</artifactId>
-    <version>0.16.0-SNAPSHOT</version>
+    <version>0.17.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Dokimos :: Parent POM</name>


### PR DESCRIPTION
Bumps all module versions to 0.17.0-SNAPSHOT for the next development cycle. 0.16.0 is released and tag v0.16.0 points at it.