### PR TITLE
Isolate data by tenant for scoped API keys

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -9,6 +9,17 @@ description: What shipped and when.
 What shipped and when. For exact version diffs, see the
 [GitHub releases](https://github.com/dokimos-dev/dokimos/releases).
 
+## 0.17.0 (2026-05-31)
+
+- **Tenant data isolation.** A scoped API key can carry a tenant and then reads
+  and writes only its own tenant's data plus shared rows. Tenant repositories
+  expose only scoped finders, so an unscoped load does not compile, and a
+  keyless read sees shared rows only. No-key and legacy single-key deployments
+  are unchanged.
+- **Protobuf OTLP traces.** `POST /api/v1/traces` accepts the
+  `application/x-protobuf` encoding alongside JSON, so a standard OpenTelemetry
+  SDK or collector works without reconfiguring its exporter.
+
 ## 0.16.0 (2026-05-30)
 
 - **Server datasets.** Hold datasets on the server, versioned and shared, and

--- a/docs/docs/server/authentication.md
+++ b/docs/docs/server/authentication.md
@@ -98,6 +98,18 @@ Backward compatibility is preserved. When no key is configured at all, the serve
 Because key management requires `ADMIN`, keep at least one admin credential available (the legacy `DOKIMOS_API_KEY`, or an admin scoped key). Otherwise, after you create only non admin scoped keys, no one can manage keys through the API.
 :::
 
+## Tenant isolation
+
+A scoped key can carry a `tenantId`. When it does, that key reads and writes only its own tenant's data plus shared (untenanted) rows, and new rows it creates are stamped with its tenant. Keys without a tenant, the legacy `DOKIMOS_API_KEY`, and no-key mode are unscoped and see everything, so single-tenant and existing deployments are unaffected.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/api-keys \
+  -H "Authorization: Bearer $ADMIN_KEY" \
+  -d '{ "name": "team-acme", "role": "EDITOR", "tenantId": "acme" }'
+```
+
+Tenant management (creating or administering tenants) is not a separate feature yet. A tenant exists implicitly as soon as a key is scoped to it, and shared rows (those written by an unscoped key) stay visible to every tenant.
+
 ## UI Authentication with Reverse Proxy
 
 For restricting access to the web UI, the server can be placed behind a reverse proxy that handles authentication.

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AlertWebhookController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AlertWebhookController.java
@@ -4,6 +4,8 @@ import dev.dokimos.server.dto.v1.AlertWebhookView;
 import dev.dokimos.server.dto.v1.CreateAlertWebhookRequest;
 import dev.dokimos.server.dto.v1.UpdateAlertWebhookRequest;
 import dev.dokimos.server.service.AlertWebhookService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -37,37 +39,42 @@ public class AlertWebhookController {
     /** Registers a webhook for the project. Returns 201 with a {@code Location} header. */
     @PostMapping
     public ResponseEntity<AlertWebhookView> createAlertWebhook(
-            @PathVariable UUID projectId, @Valid @RequestBody CreateAlertWebhookRequest request) {
-        AlertWebhookView view = webhookService.create(projectId, request);
+            @PathVariable UUID projectId,
+            @Valid @RequestBody CreateAlertWebhookRequest request,
+            HttpServletRequest http) {
+        AlertWebhookView view = webhookService.create(projectId, request, TenantScopeResolver.scope(http));
         return ResponseEntity.created(URI.create("/api/v1/projects/" + projectId + "/alert-webhooks/" + view.id()))
                 .body(view);
     }
 
     /** Lists the project's webhooks. The signing secret is never included. */
     @GetMapping
-    public List<AlertWebhookView> listAlertWebhooks(@PathVariable UUID projectId) {
-        return webhookService.list(projectId);
+    public List<AlertWebhookView> listAlertWebhooks(@PathVariable UUID projectId, HttpServletRequest http) {
+        return webhookService.list(projectId, TenantScopeResolver.scope(http));
     }
 
-    /** Returns one webhook, or 404 if the project or webhook does not exist. */
+    /** Returns one webhook, or 404 if the project or webhook does not exist or belongs to another tenant. */
     @GetMapping("/{webhookId}")
-    public AlertWebhookView getAlertWebhook(@PathVariable UUID projectId, @PathVariable UUID webhookId) {
-        return webhookService.get(projectId, webhookId);
+    public AlertWebhookView getAlertWebhook(
+            @PathVariable UUID projectId, @PathVariable UUID webhookId, HttpServletRequest http) {
+        return webhookService.get(projectId, webhookId, TenantScopeResolver.scope(http));
     }
 
-    /** Updates a webhook. Returns 404 if the project or webhook does not exist. */
+    /** Updates a webhook. Returns 404 if the project or webhook does not exist or belongs to another tenant. */
     @PutMapping("/{webhookId}")
     public AlertWebhookView updateAlertWebhook(
             @PathVariable UUID projectId,
             @PathVariable UUID webhookId,
-            @Valid @RequestBody UpdateAlertWebhookRequest request) {
-        return webhookService.update(projectId, webhookId, request);
+            @Valid @RequestBody UpdateAlertWebhookRequest request,
+            HttpServletRequest http) {
+        return webhookService.update(projectId, webhookId, request, TenantScopeResolver.scope(http));
     }
 
-    /** Deletes a webhook. Returns 404 if the project or webhook does not exist. */
+    /** Deletes a webhook. Returns 404 if the project or webhook does not exist or belongs to another tenant. */
     @DeleteMapping("/{webhookId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteAlertWebhook(@PathVariable UUID projectId, @PathVariable UUID webhookId) {
-        webhookService.delete(projectId, webhookId);
+    public void deleteAlertWebhook(
+            @PathVariable UUID projectId, @PathVariable UUID webhookId, HttpServletRequest http) {
+        webhookService.delete(projectId, webhookId, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AlignmentController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AlignmentController.java
@@ -2,6 +2,8 @@ package dev.dokimos.server.controller.v1;
 
 import dev.dokimos.server.dto.v1.AlignmentView;
 import dev.dokimos.server.service.AlignmentService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,7 +32,7 @@ public class AlignmentController {
      * @return HTTP 200 with the per-evaluator agreement breakdown; 404 when the run does not exist
      */
     @GetMapping("/{runId}/alignment")
-    public AlignmentView alignment(@PathVariable UUID runId) {
-        return alignmentService.getAlignment(runId);
+    public AlignmentView alignment(@PathVariable UUID runId, HttpServletRequest http) {
+        return alignmentService.getAlignment(runId, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AnnotationController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/AnnotationController.java
@@ -2,9 +2,8 @@ package dev.dokimos.server.controller.v1;
 
 import dev.dokimos.server.dto.v1.AnnotationRequest;
 import dev.dokimos.server.dto.v1.AnnotationView;
-import dev.dokimos.server.filter.ApiKeyAuthFilter;
-import dev.dokimos.server.filter.Principal;
 import dev.dokimos.server.service.AnnotationService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -30,8 +29,9 @@ public class AnnotationController {
 
     /**
      * Creates or updates the annotation for the item result and returns it. Responds 200 on success,
-     * 404 if the item result does not exist or does not belong to the run, and 400 if the verdict is
-     * missing. The {@code created_by} field is taken from the authenticated principal when present.
+     * 404 if the run is not visible to the caller, or the item result does not exist or does not belong
+     * to the run, and 400 if the verdict is missing. The {@code created_by} field is taken from the
+     * authenticated principal when present.
      */
     @PutMapping
     public AnnotationView upsert(
@@ -39,30 +39,27 @@ public class AnnotationController {
             @PathVariable UUID itemResultId,
             @Valid @RequestBody AnnotationRequest request,
             HttpServletRequest http) {
-        return annotationService.upsert(runId, itemResultId, request, currentPrincipalId(http));
+        return annotationService.upsert(
+                runId, itemResultId, request, TenantScopeResolver.principalId(http), TenantScopeResolver.scope(http));
     }
 
     /**
-     * Returns the annotation for the item result. Responds 200 on success, or 404 if the item result
-     * does not belong to the run or has no annotation.
+     * Returns the annotation for the item result. Responds 200 on success, or 404 if the run is not
+     * visible to the caller, the item result does not belong to the run, or it has no annotation.
      */
     @GetMapping
-    public AnnotationView get(@PathVariable UUID runId, @PathVariable UUID itemResultId) {
-        return annotationService.get(runId, itemResultId);
+    public AnnotationView get(@PathVariable UUID runId, @PathVariable UUID itemResultId, HttpServletRequest http) {
+        return annotationService.get(runId, itemResultId, TenantScopeResolver.scope(http));
     }
 
     /**
-     * Removes the annotation for the item result. Responds 204 on success, or 404 if the item result
-     * does not belong to the run.
+     * Removes the annotation for the item result. Responds 204 on success, or 404 if the run is not
+     * visible to the caller or the item result does not belong to the run.
      */
     @DeleteMapping
-    public ResponseEntity<Void> delete(@PathVariable UUID runId, @PathVariable UUID itemResultId) {
-        annotationService.delete(runId, itemResultId);
+    public ResponseEntity<Void> delete(
+            @PathVariable UUID runId, @PathVariable UUID itemResultId, HttpServletRequest http) {
+        annotationService.delete(runId, itemResultId, TenantScopeResolver.scope(http));
         return ResponseEntity.noContent().build();
-    }
-
-    private static String currentPrincipalId(HttpServletRequest request) {
-        Object attr = request.getAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE);
-        return attr instanceof Principal principal ? principal.id() : null;
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/DatasetController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/DatasetController.java
@@ -11,9 +11,9 @@ import dev.dokimos.server.dto.v1.PromoteRequest;
 import dev.dokimos.server.entity.Dataset;
 import dev.dokimos.server.entity.DatasetItem;
 import dev.dokimos.server.entity.DatasetVersion;
-import dev.dokimos.server.filter.ApiKeyAuthFilter;
-import dev.dokimos.server.filter.Principal;
 import dev.dokimos.server.service.DatasetService;
+import dev.dokimos.server.tenant.TenantScope;
+import dev.dokimos.server.tenant.TenantScopeResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -42,10 +42,10 @@ public class DatasetController {
         this.datasetService = datasetService;
     }
 
-    /** Lists every dataset on the server with its latest version number and item count. */
+    /** Lists the datasets visible to the caller with their latest version number and item count. */
     @GetMapping
-    public List<DatasetSummary> listDatasets() {
-        return datasetService.listDatasets();
+    public List<DatasetSummary> listDatasets(HttpServletRequest http) {
+        return datasetService.listDatasets(TenantScopeResolver.scope(http));
     }
 
     /**
@@ -53,8 +53,10 @@ public class DatasetController {
      * at the new dataset.
      */
     @PostMapping
-    public ResponseEntity<DatasetSummary> createDataset(@Valid @RequestBody CreateDatasetRequest request) {
-        Dataset dataset = datasetService.createDataset(request.name(), request.description());
+    public ResponseEntity<DatasetSummary> createDataset(
+            @Valid @RequestBody CreateDatasetRequest request, HttpServletRequest http) {
+        Dataset dataset =
+                datasetService.createDataset(request.name(), request.description(), TenantScopeResolver.scope(http));
         DatasetSummary summary = new DatasetSummary(
                 dataset.getId(),
                 dataset.getName(),
@@ -69,14 +71,14 @@ public class DatasetController {
 
     /** Returns the dataset and every one of its versions, newest first. */
     @GetMapping("/{name}")
-    public DatasetDetails getDataset(@PathVariable String name) {
-        return datasetService.getDatasetDetails(name);
+    public DatasetDetails getDataset(@PathVariable String name, HttpServletRequest http) {
+        return datasetService.getDatasetDetails(name, TenantScopeResolver.scope(http));
     }
 
     /** Deletes a dataset and its versions; runs that referenced any version become unlinked. */
     @DeleteMapping("/{name}")
-    public ResponseEntity<Void> deleteDataset(@PathVariable String name) {
-        datasetService.deleteDataset(name);
+    public ResponseEntity<Void> deleteDataset(@PathVariable String name, HttpServletRequest http) {
+        datasetService.deleteDataset(name, TenantScopeResolver.scope(http));
         return ResponseEntity.noContent().build();
     }
 
@@ -87,8 +89,10 @@ public class DatasetController {
     @PostMapping("/{name}/versions")
     public ResponseEntity<DatasetVersionDetails> createVersion(
             @PathVariable String name, @Valid @RequestBody CreateVersionRequest request, HttpServletRequest http) {
-        String createdBy = currentPrincipalId(http);
-        DatasetVersion version = datasetService.createVersion(name, request.description(), request.items(), createdBy);
+        TenantScope scope = TenantScopeResolver.scope(http);
+        String createdBy = TenantScopeResolver.principalId(http);
+        DatasetVersion version =
+                datasetService.createVersion(name, request.description(), request.items(), createdBy, scope);
         return ResponseEntity.status(org.springframework.http.HttpStatus.CREATED)
                 .body(toDetails(version, name));
     }
@@ -101,7 +105,8 @@ public class DatasetController {
     @PostMapping("/promote")
     public ResponseEntity<DatasetVersionDetails> promote(
             @Valid @RequestBody PromoteRequest request, HttpServletRequest http) {
-        DatasetVersionDetails details = datasetService.promote(request, currentPrincipalId(http));
+        DatasetVersionDetails details =
+                datasetService.promote(request, TenantScopeResolver.principalId(http), TenantScopeResolver.scope(http));
         return ResponseEntity.created(
                         URI.create("/api/v1/datasets/" + details.datasetName() + "/versions/" + details.version()))
                 .body(details);
@@ -112,23 +117,27 @@ public class DatasetController {
      * highest existing version; numeric paths are parsed as the explicit version number.
      */
     @GetMapping("/{name}/versions/{version}")
-    public DatasetVersionDetails getVersion(@PathVariable String name, @PathVariable String version) {
-        DatasetVersion datasetVersion = resolveVersion(name, version);
+    public DatasetVersionDetails getVersion(
+            @PathVariable String name, @PathVariable String version, HttpServletRequest http) {
+        DatasetVersion datasetVersion = resolveVersion(name, version, TenantScopeResolver.scope(http));
         return toDetails(datasetVersion, name);
     }
 
     /** Returns the items of a dataset version ordered by ordinal, paginated. */
     @GetMapping("/{name}/versions/{version}/items")
     public PageResponse<DatasetItemView> listItems(
-            @PathVariable String name, @PathVariable String version, @PageableDefault(size = 50) Pageable pageable) {
-        DatasetVersion datasetVersion = resolveVersion(name, version);
+            @PathVariable String name,
+            @PathVariable String version,
+            @PageableDefault(size = 50) Pageable pageable,
+            HttpServletRequest http) {
+        DatasetVersion datasetVersion = resolveVersion(name, version, TenantScopeResolver.scope(http));
         return PageResponse.of(
                 datasetService.listItems(datasetVersion, pageable).map(DatasetController::toItemView));
     }
 
-    private DatasetVersion resolveVersion(String name, String version) {
+    private DatasetVersion resolveVersion(String name, String version, TenantScope scope) {
         if (LATEST_VERSION.equalsIgnoreCase(version)) {
-            return datasetService.getLatestVersion(name);
+            return datasetService.getLatestVersion(name, scope);
         }
         int versionNumber;
         try {
@@ -136,7 +145,7 @@ public class DatasetController {
         } catch (NumberFormatException ex) {
             throw new IllegalArgumentException("Invalid version: " + version);
         }
-        return datasetService.getVersion(name, versionNumber);
+        return datasetService.getVersion(name, versionNumber, scope);
     }
 
     private static DatasetVersionDetails toDetails(DatasetVersion version, String datasetName) {
@@ -153,10 +162,5 @@ public class DatasetController {
     private static DatasetItemView toItemView(DatasetItem item) {
         return new DatasetItemView(
                 item.getId(), item.getOrdinal(), item.getInputs(), item.getExpectedOutputs(), item.getMetadata());
-    }
-
-    private static String currentPrincipalId(HttpServletRequest request) {
-        Object attr = request.getAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE);
-        return attr instanceof Principal principal ? principal.id() : null;
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/DiffController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/DiffController.java
@@ -2,6 +2,8 @@ package dev.dokimos.server.controller.v1;
 
 import dev.dokimos.server.dto.v1.DiffView;
 import dev.dokimos.server.service.DiffService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -49,12 +51,14 @@ public class DiffController {
             @PathVariable UUID candidateRunId,
             @RequestParam UUID baselineRunId,
             @RequestParam(required = false, defaultValue = "ALL") String status,
-            Pageable pageable) {
+            Pageable pageable,
+            HttpServletRequest http) {
         if (status != null && !ALLOWED_STATUS.contains(status.trim().toUpperCase())) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "Unknown status filter: " + status + " (expected ALL, REGRESSED, IMPROVED, or CHANGED)");
         }
-        return diffService.listDiff(experimentId, candidateRunId, baselineRunId, status, pageable);
+        return diffService.listDiff(
+                experimentId, candidateRunId, baselineRunId, status, pageable, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/EvalJobController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/EvalJobController.java
@@ -3,6 +3,8 @@ package dev.dokimos.server.controller.v1;
 import dev.dokimos.server.dto.v1.EnqueueJudgeRequest;
 import dev.dokimos.server.dto.v1.EvalJobView;
 import dev.dokimos.server.service.EvalJobService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -28,15 +30,15 @@ public class EvalJobController {
     /** Enqueues server-side scoring for a run. Returns 201 with the created job. */
     @PostMapping
     public ResponseEntity<EvalJobView> enqueue(
-            @PathVariable UUID runId, @Valid @RequestBody EnqueueJudgeRequest request) {
-        EvalJobView view = jobService.enqueue(runId, request);
+            @PathVariable UUID runId, @Valid @RequestBody EnqueueJudgeRequest request, HttpServletRequest http) {
+        EvalJobView view = jobService.enqueue(runId, request, TenantScopeResolver.scope(http));
         return ResponseEntity.created(URI.create("/api/v1/runs/" + runId + "/judge-jobs/" + view.id()))
                 .body(view);
     }
 
     /** Lists the judge jobs registered for a run, oldest first. */
     @GetMapping
-    public List<EvalJobView> list(@PathVariable UUID runId) {
-        return jobService.getJobsForRun(runId);
+    public List<EvalJobView> list(@PathVariable UUID runId, HttpServletRequest http) {
+        return jobService.getJobsForRun(runId, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/ExperimentController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/ExperimentController.java
@@ -5,6 +5,9 @@ import dev.dokimos.server.dto.v1.TrendData;
 import dev.dokimos.server.entity.Experiment;
 import dev.dokimos.server.service.ExperimentService;
 import dev.dokimos.server.service.RunService;
+import dev.dokimos.server.tenant.TenantScope;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
@@ -29,19 +32,21 @@ public class ExperimentController {
     }
 
     @GetMapping("/{experimentId}/runs")
-    public List<RunSummary> listRuns(@PathVariable UUID experimentId) {
-        Experiment experiment = experimentService.getExperiment(experimentId);
-        return runService.listRuns(experiment);
+    public List<RunSummary> listRuns(@PathVariable UUID experimentId, HttpServletRequest http) {
+        TenantScope scope = TenantScopeResolver.scope(http);
+        Experiment experiment = experimentService.getExperiment(experimentId, scope);
+        return runService.listRuns(experiment, scope);
     }
 
     @GetMapping("/{experimentId}/trends")
-    public TrendData getTrends(@PathVariable UUID experimentId, @RequestParam(defaultValue = "20") int limit) {
-        return experimentService.getTrends(experimentId, limit);
+    public TrendData getTrends(
+            @PathVariable UUID experimentId, @RequestParam(defaultValue = "20") int limit, HttpServletRequest http) {
+        return experimentService.getTrends(experimentId, limit, TenantScopeResolver.scope(http));
     }
 
     @DeleteMapping("/{experimentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteExperiment(@PathVariable UUID experimentId) {
-        experimentService.deleteExperiment(experimentId);
+    public void deleteExperiment(@PathVariable UUID experimentId, HttpServletRequest http) {
+        experimentService.deleteExperiment(experimentId, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/GateController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/GateController.java
@@ -3,6 +3,8 @@ package dev.dokimos.server.controller.v1;
 import dev.dokimos.server.dto.v1.GateRequest;
 import dev.dokimos.server.dto.v1.GateResult;
 import dev.dokimos.server.service.GateService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +40,8 @@ public class GateController {
      *     is not terminal, 400 when {@code candidateRunId} is absent
      */
     @PostMapping("/{experimentId}/gate")
-    public GateResult evaluateGate(@PathVariable UUID experimentId, @Valid @RequestBody GateRequest request) {
-        return gateService.evaluateGate(experimentId, request);
+    public GateResult evaluateGate(
+            @PathVariable UUID experimentId, @Valid @RequestBody GateRequest request, HttpServletRequest http) {
+        return gateService.evaluateGate(experimentId, request, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/LlmConnectionController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/LlmConnectionController.java
@@ -4,6 +4,8 @@ import dev.dokimos.server.dto.v1.CreateLlmConnectionRequest;
 import dev.dokimos.server.dto.v1.LlmConnectionView;
 import dev.dokimos.server.dto.v1.UpdateLlmConnectionRequest;
 import dev.dokimos.server.service.LlmConnectionService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -32,34 +34,36 @@ public class LlmConnectionController {
 
     /** Registers an LLM connection. Returns 201 with a {@code Location} header pointing at the connection. */
     @PostMapping
-    public ResponseEntity<LlmConnectionView> create(@Valid @RequestBody CreateLlmConnectionRequest request) {
-        LlmConnectionView view = connectionService.create(request);
+    public ResponseEntity<LlmConnectionView> create(
+            @Valid @RequestBody CreateLlmConnectionRequest request, HttpServletRequest http) {
+        LlmConnectionView view = connectionService.create(request, TenantScopeResolver.scope(http));
         return ResponseEntity.created(URI.create("/api/v1/llm-connections/" + view.id()))
                 .body(view);
     }
 
-    /** Lists every registered connection. Key material is never included. */
+    /** Lists the connections visible to the caller. Key material is never included. */
     @GetMapping
-    public List<LlmConnectionView> list() {
-        return connectionService.list();
+    public List<LlmConnectionView> list(HttpServletRequest http) {
+        return connectionService.list(TenantScopeResolver.scope(http));
     }
 
-    /** Returns a single connection by id, or 404 if it does not exist. */
+    /** Returns a single connection by id, or 404 if it does not exist or belongs to another tenant. */
     @GetMapping("/{id}")
-    public LlmConnectionView get(@PathVariable UUID id) {
-        return connectionService.get(id);
+    public LlmConnectionView get(@PathVariable UUID id, HttpServletRequest http) {
+        return connectionService.get(id, TenantScopeResolver.scope(http));
     }
 
-    /** Updates a connection. Returns 404 if it does not exist, 409 if the new name is taken. */
+    /** Updates a connection. Returns 404 if it does not exist or belongs to another tenant, 409 if the new name is taken. */
     @PutMapping("/{id}")
-    public LlmConnectionView update(@PathVariable UUID id, @Valid @RequestBody UpdateLlmConnectionRequest request) {
-        return connectionService.update(id, request);
+    public LlmConnectionView update(
+            @PathVariable UUID id, @Valid @RequestBody UpdateLlmConnectionRequest request, HttpServletRequest http) {
+        return connectionService.update(id, request, TenantScopeResolver.scope(http));
     }
 
-    /** Deletes a connection. Returns 404 if it does not exist, 409 if a judge job still references it. */
+    /** Deletes a connection. Returns 404 if it does not exist or belongs to another tenant, 409 if a judge job still references it. */
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID id) {
-        connectionService.delete(id);
+    public void delete(@PathVariable UUID id, HttpServletRequest http) {
+        connectionService.delete(id, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/ProjectController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/ProjectController.java
@@ -10,6 +10,9 @@ import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.service.ExperimentService;
 import dev.dokimos.server.service.ProjectService;
 import dev.dokimos.server.service.RunService;
+import dev.dokimos.server.tenant.TenantScope;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -38,28 +41,31 @@ public class ProjectController {
     }
 
     @GetMapping
-    public List<ProjectSummary> listProjects() {
-        return projectService.listProjects();
+    public List<ProjectSummary> listProjects(HttpServletRequest http) {
+        return projectService.listProjects(TenantScopeResolver.scope(http));
     }
 
     @GetMapping("/{projectName}/experiments")
-    public List<ExperimentSummary> listExperiments(@PathVariable String projectName) {
-        Project project = projectService.getProject(projectName);
-        return experimentService.listExperiments(project);
+    public List<ExperimentSummary> listExperiments(@PathVariable String projectName, HttpServletRequest http) {
+        TenantScope scope = TenantScopeResolver.scope(http);
+        Project project = projectService.getProject(projectName, scope);
+        return experimentService.listExperiments(project, scope);
     }
 
     @PostMapping("/{projectName}/runs")
     @ResponseStatus(HttpStatus.CREATED)
-    public CreateRunResponse createRun(@PathVariable String projectName, @Valid @RequestBody CreateRunRequest request) {
-        Project project = projectService.getOrCreateProject(projectName);
-        Experiment experiment = experimentService.getOrCreateExperiment(project, request.experimentName());
-        ExperimentRun run = runService.createRun(experiment, request);
+    public CreateRunResponse createRun(
+            @PathVariable String projectName, @Valid @RequestBody CreateRunRequest request, HttpServletRequest http) {
+        TenantScope scope = TenantScopeResolver.scope(http);
+        Project project = projectService.getOrCreateProject(projectName, scope);
+        Experiment experiment = experimentService.getOrCreateExperiment(project, request.experimentName(), scope);
+        ExperimentRun run = runService.createRun(experiment, request, scope);
         return new CreateRunResponse(run.getId());
     }
 
     @DeleteMapping("/{projectName}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteProject(@PathVariable String projectName) {
-        projectService.deleteProject(projectName);
+    public void deleteProject(@PathVariable String projectName, HttpServletRequest http) {
+        projectService.deleteProject(projectName, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/ReviewQueueController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/ReviewQueueController.java
@@ -2,6 +2,8 @@ package dev.dokimos.server.controller.v1;
 
 import dev.dokimos.server.dto.v1.ReviewQueueItem;
 import dev.dokimos.server.service.ReviewQueueService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,14 +25,16 @@ public class ReviewQueueController {
 
     /**
      * Lists run items still awaiting a human verdict, oldest first. The optional filters narrow the
-     * queue to a project, experiment, or run; omitting all three returns the global queue.
+     * queue to a project, experiment, or run; omitting all three returns the global queue. The queue is
+     * scoped to the caller's tenant so a reviewer only sees items of their own tenant plus shared items.
      */
     @GetMapping
     public Page<ReviewQueueItem> list(
             @RequestParam(required = false) String projectName,
             @RequestParam(required = false) UUID experimentId,
             @RequestParam(required = false) UUID runId,
-            @PageableDefault(size = 50) Pageable pageable) {
-        return reviewQueueService.list(projectName, experimentId, runId, pageable);
+            @PageableDefault(size = 50) Pageable pageable,
+            HttpServletRequest http) {
+        return reviewQueueService.list(projectName, experimentId, runId, pageable, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/RunController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/RunController.java
@@ -4,6 +4,8 @@ import dev.dokimos.server.dto.v1.AddItemsRequest;
 import dev.dokimos.server.dto.v1.RunDetails;
 import dev.dokimos.server.dto.v1.UpdateRunRequest;
 import dev.dokimos.server.service.RunService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.Map;
 import java.util.UUID;
@@ -32,8 +34,9 @@ public class RunController {
     }
 
     @GetMapping("/{runId}")
-    public RunDetails getRunDetails(@PathVariable UUID runId, @PageableDefault(size = 50) Pageable pageable) {
-        return runService.getRunDetails(runId, pageable);
+    public RunDetails getRunDetails(
+            @PathVariable UUID runId, @PageableDefault(size = 50) Pageable pageable, HttpServletRequest http) {
+        return runService.getRunDetails(runId, pageable, TenantScopeResolver.scope(http));
     }
 
     @PostMapping("/{runId}/items")
@@ -41,20 +44,22 @@ public class RunController {
     public Map<String, String> addItems(
             @PathVariable UUID runId,
             @Valid @RequestBody AddItemsRequest request,
-            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey) {
-        runService.addItems(runId, request, idempotencyKey);
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+            HttpServletRequest http) {
+        runService.addItems(runId, request, idempotencyKey, TenantScopeResolver.scope(http));
         return Map.of("status", "ok");
     }
 
     @PatchMapping("/{runId}")
-    public Map<String, String> updateRun(@PathVariable UUID runId, @Valid @RequestBody UpdateRunRequest request) {
-        runService.updateRun(runId, request);
+    public Map<String, String> updateRun(
+            @PathVariable UUID runId, @Valid @RequestBody UpdateRunRequest request, HttpServletRequest http) {
+        runService.updateRun(runId, request, TenantScopeResolver.scope(http));
         return Map.of("status", "updated");
     }
 
     @DeleteMapping("/{runId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteRun(@PathVariable UUID runId) {
-        runService.deleteRun(runId);
+    public void deleteRun(@PathVariable UUID runId, HttpServletRequest http) {
+        runService.deleteRun(runId, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/TraceController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/TraceController.java
@@ -9,7 +9,9 @@ import dev.dokimos.server.dto.v1.otlp.OtlpExportTraceServiceRequest;
 import dev.dokimos.server.service.OtlpProtobufConverter;
 import dev.dokimos.server.service.TraceIngestService;
 import dev.dokimos.server.service.TraceQueryService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -75,15 +77,16 @@ public class TraceController {
     public PageResponse<TraceSummary> listTraces(
             @RequestParam(required = false) UUID projectId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "50") int size) {
+            @RequestParam(defaultValue = "50") int size,
+            HttpServletRequest http) {
         Pageable pageable = PageRequest.of(Math.max(page, 0), clampSize(size));
-        return PageResponse.of(queryService.listTraces(projectId, pageable));
+        return PageResponse.of(queryService.listTraces(projectId, pageable, TenantScopeResolver.scope(http)));
     }
 
-    /** Returns a single trace with its spans and online eval jobs, or 404 if it does not exist. */
+    /** Returns a single trace with its spans and online eval jobs, or 404 if it does not exist or belongs to another tenant. */
     @GetMapping("/{id}")
-    public TraceDetail getTrace(@PathVariable UUID id) {
-        return queryService.getTrace(id);
+    public TraceDetail getTrace(@PathVariable UUID id, HttpServletRequest http) {
+        return queryService.getTrace(id, TenantScopeResolver.scope(http));
     }
 
     private static int clampSize(int size) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/TraceEvalRuleController.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/controller/v1/TraceEvalRuleController.java
@@ -3,6 +3,8 @@ package dev.dokimos.server.controller.v1;
 import dev.dokimos.server.dto.v1.CreateTraceEvalRuleRequest;
 import dev.dokimos.server.dto.v1.TraceEvalRuleView;
 import dev.dokimos.server.service.TraceEvalRuleService;
+import dev.dokimos.server.tenant.TenantScopeResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -33,31 +35,34 @@ public class TraceEvalRuleController {
     /** Creates a rule. Returns 201 with a {@code Location} header pointing at the rule. */
     @PostMapping
     public ResponseEntity<TraceEvalRuleView> createTraceEvalRule(
-            @PathVariable UUID projectId, @Valid @RequestBody CreateTraceEvalRuleRequest request) {
-        TraceEvalRuleView view = ruleService.create(projectId, request);
+            @PathVariable UUID projectId,
+            @Valid @RequestBody CreateTraceEvalRuleRequest request,
+            HttpServletRequest http) {
+        TraceEvalRuleView view = ruleService.create(projectId, request, TenantScopeResolver.scope(http));
         return ResponseEntity.created(URI.create("/api/v1/projects/" + projectId + "/trace-eval-rules/" + view.id()))
                 .body(view);
     }
 
     /** Lists the rules of a project, oldest first. */
     @GetMapping
-    public List<TraceEvalRuleView> listTraceEvalRules(@PathVariable UUID projectId) {
-        return ruleService.list(projectId);
+    public List<TraceEvalRuleView> listTraceEvalRules(@PathVariable UUID projectId, HttpServletRequest http) {
+        return ruleService.list(projectId, TenantScopeResolver.scope(http));
     }
 
-    /** Replaces a rule. Returns 404 if it does not exist, 409 if the new name is taken in the project. */
+    /** Replaces a rule. Returns 404 if it does not exist or belongs to another tenant, 409 if the new name is taken. */
     @PutMapping("/{ruleId}")
     public TraceEvalRuleView updateTraceEvalRule(
             @PathVariable UUID projectId,
             @PathVariable UUID ruleId,
-            @Valid @RequestBody CreateTraceEvalRuleRequest request) {
-        return ruleService.update(projectId, ruleId, request);
+            @Valid @RequestBody CreateTraceEvalRuleRequest request,
+            HttpServletRequest http) {
+        return ruleService.update(projectId, ruleId, request, TenantScopeResolver.scope(http));
     }
 
-    /** Deletes a rule. Returns 404 if it does not exist. */
+    /** Deletes a rule. Returns 404 if it does not exist or belongs to another tenant. */
     @DeleteMapping("/{ruleId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteTraceEvalRule(@PathVariable UUID projectId, @PathVariable UUID ruleId) {
-        ruleService.delete(projectId, ruleId);
+    public void deleteTraceEvalRule(@PathVariable UUID projectId, @PathVariable UUID ruleId, HttpServletRequest http) {
+        ruleService.delete(projectId, ruleId, TenantScopeResolver.scope(http));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/Dataset.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/Dataset.java
@@ -6,22 +6,31 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.UUID;
 
 /**
- * A named container that owns one or more immutable {@link DatasetVersion}s. The {@code name} is
- * unique across the server and is the human-facing identifier used by API callers.
+ * A named container that owns one or more immutable {@link DatasetVersion}s. The {@code name} is unique
+ * per tenant rather than globally, so two tenants can each own a dataset of the same name. The matching
+ * DB constraint plus a partial unique on the shared (null-tenant) rows lives in migration V14; the
+ * {@code (name, tenant_id)} unique here keeps the Hibernate-generated test schema consistent with it.
  */
 @Entity
-@Table(name = "datasets")
+@Table(
+        name = "datasets",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uq_dataset_name_tenant",
+                    columnNames = {"name", "tenant_id"})
+        })
 public class Dataset {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(columnDefinition = "text")

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/DatasetItem.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/DatasetItem.java
@@ -55,6 +55,9 @@ public class DatasetItem {
     @Column(columnDefinition = "jsonb")
     private Map<String, Object> metadata;
 
+    @Column(name = "tenant_id")
+    private String tenantId;
+
     protected DatasetItem() {}
 
     public DatasetItem(
@@ -76,6 +79,14 @@ public class DatasetItem {
 
     public DatasetVersion getDatasetVersion() {
         return datasetVersion;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public int getOrdinal() {

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/DatasetVersion.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/DatasetVersion.java
@@ -52,6 +52,9 @@ public class DatasetVersion {
     @Column(name = "item_count", nullable = false)
     private int itemCount;
 
+    @Column(name = "tenant_id")
+    private String tenantId;
+
     protected DatasetVersion() {}
 
     public DatasetVersion(Dataset dataset, int version, String description, String createdBy, int itemCount) {
@@ -69,6 +72,14 @@ public class DatasetVersion {
 
     public Dataset getDataset() {
         return dataset;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public int getVersion() {

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/EvalResult.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/EvalResult.java
@@ -44,6 +44,9 @@ public class EvalResult {
     @Column(columnDefinition = "jsonb")
     private Map<String, Object> metadata;
 
+    @Column(name = "tenant_id")
+    private String tenantId;
+
     protected EvalResult() {}
 
     public EvalResult(String evaluatorName, double score, Double threshold, boolean success, String reason) {
@@ -64,6 +67,14 @@ public class EvalResult {
 
     void setItemResult(ItemResult itemResult) {
         this.itemResult = itemResult;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public String getEvaluatorName() {

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/ItemResult.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/ItemResult.java
@@ -67,6 +67,9 @@ public class ItemResult {
     @Column(name = "latency_ms")
     private Long latencyMs;
 
+    @Column(name = "tenant_id")
+    private String tenantId;
+
     @Column(nullable = false)
     private Instant createdAt;
 
@@ -103,6 +106,14 @@ public class ItemResult {
 
     public void setDatasetItem(DatasetItem datasetItem) {
         this.datasetItem = datasetItem;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public Map<String, Object> getInput() {

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/LlmConnection.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/LlmConnection.java
@@ -46,6 +46,9 @@ public class LlmConnection {
     @Column(name = "encrypted_api_key", columnDefinition = "text")
     private String encryptedApiKey;
 
+    @Column(name = "tenant_id")
+    private String tenantId;
+
     @Column(nullable = false)
     private Instant createdAt;
 
@@ -118,6 +121,14 @@ public class LlmConnection {
 
     public void setEncryptedApiKey(String encryptedApiKey) {
         this.encryptedApiKey = encryptedApiKey;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     /** Returns true when an inline encrypted key is stored rather than an external credential reference. */

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/LlmConnection.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/LlmConnection.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -17,17 +18,25 @@ import java.util.UUID;
  * one credential source is set: {@code credentialRef} names an environment variable
  * (or external path) that holds the key, or {@code encryptedApiKey} carries an inline key encrypted at
  * rest. The entity never exposes raw key material; decryption is the responsibility of the credential
- * service.
+ * service. The {@code name} is unique per tenant rather than globally, so two tenants can each own a
+ * connection of the same name; the matching DB constraint plus a partial unique on the shared
+ * (null-tenant) rows lives in migration V14.
  */
 @Entity
-@Table(name = "llm_connections")
+@Table(
+        name = "llm_connections",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uq_llm_connection_name_tenant",
+                    columnNames = {"name", "tenant_id"})
+        })
 public class LlmConnection {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(name = "base_url", nullable = false, length = 512)

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/Project.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/Project.java
@@ -7,20 +7,33 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * A project groups experiments. The name is unique per tenant rather than globally, so two tenants can
+ * each own a project of the same name (for example "default"). The matching DB constraint plus a partial
+ * unique on the shared (null-tenant) rows lives in migration V14; the {@code (name, tenant_id)} unique
+ * here keeps the Hibernate-generated test schema consistent with it.
+ */
 @Entity
-@Table(name = "projects")
+@Table(
+        name = "projects",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uq_project_name_tenant",
+                    columnNames = {"name", "tenant_id"})
+        })
 public class Project {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(nullable = false)

--- a/dokimos-server/src/main/java/dev/dokimos/server/entity/TraceSpan.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/entity/TraceSpan.java
@@ -66,6 +66,9 @@ public class TraceSpan {
     @Column(name = "output_text", columnDefinition = "text")
     private String outputText;
 
+    @Column(name = "tenant_id")
+    private String tenantId;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
@@ -84,6 +87,14 @@ public class TraceSpan {
 
     public Trace getTrace() {
         return trace;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public void setTrace(Trace trace) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/filter/Principal.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/filter/Principal.java
@@ -1,5 +1,7 @@
 package dev.dokimos.server.filter;
 
+import dev.dokimos.server.tenant.TenantScope;
+
 /**
  * Authenticated caller.
  *
@@ -28,5 +30,31 @@ public record Principal(String id, Role role, String tenantId) {
      */
     public static Principal anonymous() {
         return new Principal("anonymous", Role.VIEWER, null);
+    }
+
+    /**
+     * Returns whether this is the system principal. The system principal (no-key mode and the legacy
+     * single {@code DOKIMOS_API_KEY}) is the only principal that maps to an unrestricted tenant scope, so
+     * existing single-tenant and no-key deployments keep seeing and stamping every row exactly as before.
+     *
+     * <p>This is identified by the system id rather than {@code tenantId == null}, because an anonymous
+     * keyless reader also carries a null tenant yet must resolve to shared-only, not unrestricted.
+     *
+     * @return true when this is the system principal
+     */
+    public boolean isSystem() {
+        return SYSTEM_ID.equals(id);
+    }
+
+    /**
+     * Resolves the {@link TenantScope} this principal reads and writes under. The system principal maps
+     * to {@link TenantScope#unrestricted()} (every row, null stamp); every other principal (a scoped key
+     * or an anonymous keyless reader) maps to {@link TenantScope#scoped(String)} on its own tenant, which
+     * for a null tenant collapses to shared-only.
+     *
+     * @return the tenant scope for this principal
+     */
+    public TenantScope tenantScope() {
+        return isSystem() ? TenantScope.unrestricted() : TenantScope.scoped(tenantId);
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepository.java
@@ -1,15 +1,12 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.AlertWebhook;
-import dev.dokimos.server.entity.Project;
-import java.util.List;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface AlertWebhookRepository extends JpaRepository<AlertWebhook, UUID> {
-
-    List<AlertWebhook> findByProjectOrderByCreatedAtAsc(Project project);
-
-    /** Resolves the enabled webhooks of a project, the set dispatched to on a regressing run. */
-    List<AlertWebhook> findByProjectIdAndEnabledTrue(UUID projectId);
-}
+/**
+ * Tenant-scoped repository for {@link AlertWebhook}. Extends only the empty {@link Repository} plus the
+ * scoped fragments, so every read takes a {@code TenantScope}. The dispatcher path lists a project's
+ * enabled webhooks unrestricted (a regression alert fires regardless of the caller's tenant).
+ */
+public interface AlertWebhookRepository extends Repository<AlertWebhook, UUID>, AlertWebhookRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepositoryFragment.java
@@ -1,0 +1,30 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.AlertWebhook;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.UUID;
+
+/** Entity-specific scoped finders for {@link AlertWebhook}. */
+public interface AlertWebhookRepositoryFragment extends ScopedRepository<AlertWebhook> {
+
+    /**
+     * Lists a project's webhooks in creation order, within the scope.
+     *
+     * @param project the owning project
+     * @param scope the tenant scope
+     * @return the visible webhooks, oldest first
+     */
+    List<AlertWebhook> findByProject(Project project, TenantScope scope);
+
+    /**
+     * Resolves the enabled webhooks of a project regardless of tenant, the set dispatched to on a
+     * regressing run. The dispatcher runs off the request thread, so it lists unrestricted.
+     *
+     * @param projectId the owning project id
+     * @return the project's enabled webhooks
+     */
+    List<AlertWebhook> findByProjectIdAndEnabledTrue(UUID projectId);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepositoryFragment.java
@@ -10,21 +10,12 @@ import java.util.UUID;
 /** Entity-specific scoped finders for {@link AlertWebhook}. */
 public interface AlertWebhookRepositoryFragment extends ScopedRepository<AlertWebhook> {
 
-    /**
-     * Lists a project's webhooks in creation order, within the scope.
-     *
-     * @param project the owning project
-     * @param scope the tenant scope
-     * @return the visible webhooks, oldest first
-     */
+    /** Lists a project's webhooks oldest first, within the scope. */
     List<AlertWebhook> findByProject(Project project, TenantScope scope);
 
     /**
-     * Resolves the enabled webhooks of a project regardless of tenant, the set dispatched to on a
-     * regressing run. The dispatcher runs off the request thread, so it lists unrestricted.
-     *
-     * @param projectId the owning project id
-     * @return the project's enabled webhooks
+     * Enabled webhooks of a project regardless of tenant, the set dispatched to on a regressing run. The
+     * dispatcher runs off the request thread, so it lists unrestricted.
      */
     List<AlertWebhook> findByProjectIdAndEnabledTrue(UUID projectId);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/AlertWebhookRepositoryFragmentImpl.java
@@ -1,0 +1,38 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.AlertWebhook;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import java.util.UUID;
+
+/** Tenant-scoped implementation of the {@link AlertWebhook} finders. */
+public class AlertWebhookRepositoryFragmentImpl extends AbstractScopedRepository<AlertWebhook>
+        implements AlertWebhookRepositoryFragment {
+
+    public AlertWebhookRepositoryFragmentImpl() {
+        super(AlertWebhook.class);
+    }
+
+    @Override
+    public List<AlertWebhook> findByProject(Project project, TenantScope scope) {
+        return finder().findWhere(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("project"), project),
+                        (cb, root) -> List.of(cb.asc(root.get("createdAt"))));
+    }
+
+    @Override
+    public List<AlertWebhook> findByProjectIdAndEnabledTrue(UUID projectId) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<AlertWebhook> query = cb.createQuery(AlertWebhook.class);
+        Root<AlertWebhook> root = query.from(AlertWebhook.class);
+        query.select(root)
+                .where(cb.and(cb.equal(root.get("project").get("id"), projectId), cb.isTrue(root.get("enabled"))));
+        return entityManager.createQuery(query).getResultList();
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.Repository;
 
 /**
  * Tenant-scoped repository for {@link Dataset}. Extends only the empty {@link Repository} plus the scoped
- * fragments, so every read takes a {@code TenantScope}. Dataset names stay globally unique (the DB
- * constraint is unchanged), so the create guard uses {@code existsByName} which ignores scope.
+ * fragments, so every read takes a {@code TenantScope}. Dataset names are unique per tenant, so the
+ * create guard uses {@code existsByName} scoped to the caller.
  */
 public interface DatasetRepository extends Repository<Dataset, UUID>, DatasetRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepository.java
@@ -1,36 +1,12 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.Dataset;
-import jakarta.persistence.LockModeType;
-import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.Repository;
 
-public interface DatasetRepository extends JpaRepository<Dataset, UUID> {
-
-    Optional<Dataset> findByName(String name);
-
-    boolean existsByName(String name);
-
-    /**
-     * Loads a dataset while acquiring a pessimistic write lock on its row. Used to serialize new
-     * version creation so the {@code next = max(version) + 1} computation cannot race two callers
-     * onto the same version number. The {@code (dataset_id, version)} unique constraint is the
-     * backstop if the lock is bypassed.
-     */
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select d from Dataset d where d.id = :id")
-    Optional<Dataset> findByIdForUpdate(@Param("id") UUID id);
-
-    /**
-     * Locking lookup by name; equivalent to {@link #findByIdForUpdate} but resolved in a single
-     * round trip when the caller only has the dataset name. Used by version creation so the
-     * pessimistic write lock is acquired atomically with the lookup.
-     */
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select d from Dataset d where d.name = :name")
-    Optional<Dataset> findByNameForUpdate(@Param("name") String name);
-}
+/**
+ * Tenant-scoped repository for {@link Dataset}. Extends only the empty {@link Repository} plus the scoped
+ * fragments, so every read takes a {@code TenantScope}. Dataset names stay globally unique (the DB
+ * constraint is unchanged), so the create guard uses {@code existsByName} which ignores scope.
+ */
+public interface DatasetRepository extends Repository<Dataset, UUID>, DatasetRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragment.java
@@ -37,11 +37,13 @@ public interface DatasetRepositoryFragment extends ScopedRepository<Dataset> {
     List<Dataset> findAllOrdered(TenantScope scope);
 
     /**
-     * Returns whether any dataset has the given name, ignoring tenant. Dataset names are globally unique
-     * (the DB constraint is unchanged), so the create guard checks globally.
+     * Returns whether a dataset with the given name exists within the scope. Dataset names are unique
+     * per tenant, so the create guard checks within the caller's scope rather than globally, and a
+     * scoped existence check is not a cross-tenant oracle.
      *
      * @param name the candidate name
-     * @return true when a dataset with that name already exists in any tenant
+     * @param scope the tenant scope
+     * @return true when a dataset with that name is visible under the scope
      */
-    boolean existsByName(String name);
+    boolean existsByName(String name, TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragment.java
@@ -1,0 +1,47 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Dataset;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Optional;
+
+/** Entity-specific scoped finders for {@link Dataset}. */
+public interface DatasetRepositoryFragment extends ScopedRepository<Dataset> {
+
+    /**
+     * Finds a dataset by name within the scope.
+     *
+     * @param name the dataset name
+     * @param scope the tenant scope
+     * @return the dataset if visible, otherwise empty
+     */
+    Optional<Dataset> findByName(String name, TenantScope scope);
+
+    /**
+     * Finds a dataset by name within the scope, under a pessimistic write lock. Used by version creation
+     * so the lock is acquired atomically with the scoped lookup.
+     *
+     * @param name the dataset name
+     * @param scope the tenant scope
+     * @return the locked dataset if visible, otherwise empty
+     */
+    Optional<Dataset> findByNameForUpdate(String name, TenantScope scope);
+
+    /**
+     * Lists datasets visible under the scope, newest first.
+     *
+     * @param scope the tenant scope
+     * @return the visible datasets
+     */
+    List<Dataset> findAllOrdered(TenantScope scope);
+
+    /**
+     * Returns whether any dataset has the given name, ignoring tenant. Dataset names are globally unique
+     * (the DB constraint is unchanged), so the create guard checks globally.
+     *
+     * @param name the candidate name
+     * @return true when a dataset with that name already exists in any tenant
+     */
+    boolean existsByName(String name);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragment.java
@@ -9,41 +9,18 @@ import java.util.Optional;
 /** Entity-specific scoped finders for {@link Dataset}. */
 public interface DatasetRepositoryFragment extends ScopedRepository<Dataset> {
 
-    /**
-     * Finds a dataset by name within the scope.
-     *
-     * @param name the dataset name
-     * @param scope the tenant scope
-     * @return the dataset if visible, otherwise empty
-     */
+    /** Finds a dataset by name within the scope. */
     Optional<Dataset> findByName(String name, TenantScope scope);
 
-    /**
-     * Finds a dataset by name within the scope, under a pessimistic write lock. Used by version creation
-     * so the lock is acquired atomically with the scoped lookup.
-     *
-     * @param name the dataset name
-     * @param scope the tenant scope
-     * @return the locked dataset if visible, otherwise empty
-     */
+    /** Finds a dataset by name within the scope under a pessimistic write lock, for version creation. */
     Optional<Dataset> findByNameForUpdate(String name, TenantScope scope);
 
-    /**
-     * Lists datasets visible under the scope, newest first.
-     *
-     * @param scope the tenant scope
-     * @return the visible datasets
-     */
+    /** Lists datasets visible under the scope, newest first. */
     List<Dataset> findAllOrdered(TenantScope scope);
 
     /**
-     * Returns whether a dataset with the given name exists within the scope. Dataset names are unique
-     * per tenant, so the create guard checks within the caller's scope rather than globally, and a
-     * scoped existence check is not a cross-tenant oracle.
-     *
-     * @param name the candidate name
-     * @param scope the tenant scope
-     * @return true when a dataset with that name is visible under the scope
+     * Returns whether a dataset with the name exists within the scope. Names are unique per tenant, so
+     * the create guard checks within the caller's scope and is not a cross-tenant oracle.
      */
     boolean existsByName(String name, TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragmentImpl.java
@@ -1,0 +1,43 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Dataset;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import java.util.Optional;
+
+/** Tenant-scoped implementation of the {@link Dataset} finders. */
+public class DatasetRepositoryFragmentImpl extends AbstractScopedRepository<Dataset>
+        implements DatasetRepositoryFragment {
+
+    public DatasetRepositoryFragmentImpl() {
+        super(Dataset.class);
+    }
+
+    @Override
+    public Optional<Dataset> findByName(String name, TenantScope scope) {
+        return finder().findFirst(scope, (cb, root) -> cb.equal(root.get("name"), name), null);
+    }
+
+    @Override
+    public Optional<Dataset> findByNameForUpdate(String name, TenantScope scope) {
+        return finder().findFirstForUpdate(scope, (cb, root) -> cb.equal(root.get("name"), name));
+    }
+
+    @Override
+    public List<Dataset> findAllOrdered(TenantScope scope) {
+        return finder().findAll(scope, (cb, root) -> List.of(cb.desc(root.get("createdAt"))));
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<Dataset> root = query.from(Dataset.class);
+        query.select(cb.count(root)).where(cb.equal(root.get("name"), name));
+        return entityManager.createQuery(query).getSingleResult() > 0;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/DatasetRepositoryFragmentImpl.java
@@ -3,9 +3,6 @@ package dev.dokimos.server.repository;
 import dev.dokimos.server.entity.Dataset;
 import dev.dokimos.server.tenant.AbstractScopedRepository;
 import dev.dokimos.server.tenant.TenantScope;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Root;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,11 +30,8 @@ public class DatasetRepositoryFragmentImpl extends AbstractScopedRepository<Data
     }
 
     @Override
-    public boolean existsByName(String name) {
-        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Long> query = cb.createQuery(Long.class);
-        Root<Dataset> root = query.from(Dataset.class);
-        query.select(cb.count(root)).where(cb.equal(root.get("name"), name));
-        return entityManager.createQuery(query).getSingleResult() > 0;
+    public boolean existsByName(String name, TenantScope scope) {
+        return finder().findFirst(scope, (cb, root) -> cb.equal(root.get("name"), name), null)
+                .isPresent();
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepository.java
@@ -1,15 +1,12 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.Experiment;
-import dev.dokimos.server.entity.Project;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface ExperimentRepository extends JpaRepository<Experiment, UUID> {
-
-    Optional<Experiment> findByProjectAndName(Project project, String name);
-
-    List<Experiment> findByProjectOrderByCreatedAtDesc(Project project);
-}
+/**
+ * Tenant-scoped repository for {@link Experiment}. Extends only the empty {@link Repository} plus the
+ * scoped fragments, so every read takes a {@code TenantScope} and the inherited unscoped finders do not
+ * exist.
+ */
+public interface ExperimentRepository extends Repository<Experiment, UUID>, ExperimentRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepositoryFragment.java
@@ -10,22 +10,9 @@ import java.util.Optional;
 /** Entity-specific scoped finders for {@link Experiment}. */
 public interface ExperimentRepositoryFragment extends ScopedRepository<Experiment> {
 
-    /**
-     * Finds an experiment of a project by name within the scope.
-     *
-     * @param project the owning project
-     * @param name the experiment name
-     * @param scope the tenant scope
-     * @return the experiment if visible, otherwise empty
-     */
+    /** Finds an experiment of a project by name within the scope. */
     Optional<Experiment> findByProjectAndName(Project project, String name, TenantScope scope);
 
-    /**
-     * Lists a project's experiments newest first, within the scope.
-     *
-     * @param project the owning project
-     * @param scope the tenant scope
-     * @return the visible experiments, newest first
-     */
+    /** Lists a project's experiments newest first, within the scope. */
     List<Experiment> findByProject(Project project, TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepositoryFragment.java
@@ -1,0 +1,31 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Optional;
+
+/** Entity-specific scoped finders for {@link Experiment}. */
+public interface ExperimentRepositoryFragment extends ScopedRepository<Experiment> {
+
+    /**
+     * Finds an experiment of a project by name within the scope.
+     *
+     * @param project the owning project
+     * @param name the experiment name
+     * @param scope the tenant scope
+     * @return the experiment if visible, otherwise empty
+     */
+    Optional<Experiment> findByProjectAndName(Project project, String name, TenantScope scope);
+
+    /**
+     * Lists a project's experiments newest first, within the scope.
+     *
+     * @param project the owning project
+     * @param scope the tenant scope
+     * @return the visible experiments, newest first
+     */
+    List<Experiment> findByProject(Project project, TenantScope scope);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRepositoryFragmentImpl.java
@@ -1,0 +1,33 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Optional;
+
+/** Tenant-scoped implementation of the {@link Experiment} finders. */
+public class ExperimentRepositoryFragmentImpl extends AbstractScopedRepository<Experiment>
+        implements ExperimentRepositoryFragment {
+
+    public ExperimentRepositoryFragmentImpl() {
+        super(Experiment.class);
+    }
+
+    @Override
+    public Optional<Experiment> findByProjectAndName(Project project, String name, TenantScope scope) {
+        return finder().findFirst(
+                        scope,
+                        (cb, root) -> cb.and(cb.equal(root.get("project"), project), cb.equal(root.get("name"), name)),
+                        null);
+    }
+
+    @Override
+    public List<Experiment> findByProject(Project project, TenantScope scope) {
+        return finder().findWhere(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("project"), project),
+                        (cb, root) -> List.of(cb.desc(root.get("createdAt"))));
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepository.java
@@ -1,81 +1,12 @@
 package dev.dokimos.server.repository;
 
-import dev.dokimos.server.entity.Experiment;
 import dev.dokimos.server.entity.ExperimentRun;
-import jakarta.persistence.LockModeType;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.Repository;
 
-public interface ExperimentRunRepository extends JpaRepository<ExperimentRun, UUID> {
-
-    List<ExperimentRun> findByExperimentOrderByStartedAtDesc(Experiment experiment);
-
-    List<ExperimentRun> findByExperimentOrderByStartedAtDesc(Experiment experiment, Pageable pageable);
-
-    Optional<ExperimentRun> findFirstByExperimentOrderByStartedAtDesc(Experiment experiment);
-
-    /**
-     * Loads a run while acquiring a pessimistic write lock on its row. Used to serialize item
-     * ingestion ({@link dev.dokimos.server.service.RunService#addItems}) against run completion
-     * ({@link dev.dokimos.server.service.RunService#updateRun}) so the materialized counts written at
-     * completion cannot be left stale by a concurrent in-flight item batch.
-     *
-     * @param id the run id
-     * @return the run, if present, with its row locked for the remainder of the transaction
-     */
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select r from ExperimentRun r where r.id = :id")
-    Optional<ExperimentRun> findByIdForUpdate(@Param("id") UUID id);
-
-    @Query("""
-            SELECT r FROM ExperimentRun r
-            WHERE r.experiment = :experiment
-            AND r.status IN ('SUCCESS', 'FAILED')
-            ORDER BY r.startedAt DESC
-            """)
-    List<ExperimentRun> findCompletedRunsByExperiment(Experiment experiment, Pageable pageable);
-
-    /**
-     * Resolves the most recent SUCCESS run of an experiment to serve as a gate baseline under
-     * automatic resolution. Excludes the candidate run, requires the same dataset version (the
-     * {@code IS NULL} branch allows ad-hoc runs to baseline against other ad-hoc runs), and when
-     * {@code branch} is non-null restricts to that git branch. Ordered by {@code startedAt}
-     * descending; callers pass a one-row {@link Pageable}.
-     *
-     * <p>FAILED runs are excluded from automatic resolution: a FAILED run may have a truncated item
-     * set and a 0 or null materialized pass rate, which would distort the comparison. A caller may
-     * still pass an explicit {@code baselineRunId} pointing at a FAILED run, as long as that run is
-     * terminal; that path does not go through this query.
-     *
-     * @param experiment       the experiment to scope to
-     * @param candidateId      the candidate run id to exclude
-     * @param datasetVersionId the candidate's dataset version id, or null for ad-hoc runs
-     * @param branch           a git branch to filter by, or null to ignore branch
-     * @param pageable         a one-row page request
-     * @return matching SUCCESS baseline candidates, newest first
-     */
-    @Query("""
-            SELECT r FROM ExperimentRun r
-            WHERE r.experiment = :experiment
-            AND r.id <> :candidateId
-            AND r.status = 'SUCCESS'
-            AND (
-                (:datasetVersionId IS NULL AND r.datasetVersion IS NULL)
-                OR r.datasetVersion.id = :datasetVersionId
-            )
-            AND (:branch IS NULL OR r.gitBranch = :branch)
-            ORDER BY r.startedAt DESC
-            """)
-    List<ExperimentRun> findBaselineCandidates(
-            @Param("experiment") Experiment experiment,
-            @Param("candidateId") UUID candidateId,
-            @Param("datasetVersionId") UUID datasetVersionId,
-            @Param("branch") String branch,
-            Pageable pageable);
-}
+/**
+ * Tenant-scoped repository for {@link ExperimentRun}. Extends only the empty {@link Repository} plus the
+ * scoped fragments. Background workers (baseline resolution, judge finalization) pass {@code
+ * TenantScope.unrestricted()} explicitly; request paths pass the principal's scope.
+ */
+public interface ExperimentRunRepository extends Repository<ExperimentRun, UUID>, ExperimentRunRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepositoryFragment.java
@@ -12,56 +12,22 @@ import org.springframework.data.domain.Pageable;
 /** Entity-specific scoped finders for {@link ExperimentRun}. */
 public interface ExperimentRunRepositoryFragment extends ScopedRepository<ExperimentRun> {
 
-    /**
-     * Lists an experiment's runs newest first, within the scope.
-     *
-     * @param experiment the owning experiment
-     * @param scope the tenant scope
-     * @return the visible runs, newest first
-     */
+    /** Lists an experiment's runs newest first, within the scope. */
     List<ExperimentRun> findByExperiment(Experiment experiment, TenantScope scope);
 
-    /**
-     * Returns the most recent run of an experiment within the scope.
-     *
-     * @param experiment the owning experiment
-     * @param scope the tenant scope
-     * @return the latest visible run, or empty
-     */
+    /** Returns the most recent run of an experiment within the scope. */
     Optional<ExperimentRun> findFirstByExperiment(Experiment experiment, TenantScope scope);
 
-    /**
-     * Loads a run by id under a pessimistic write lock, within the scope. Used to serialize ingestion
-     * against completion.
-     *
-     * @param id the run id
-     * @param scope the tenant scope
-     * @return the locked run if visible, otherwise empty
-     */
+    /** Loads a run by id within the scope under a write lock, to serialize ingestion against completion. */
     Optional<ExperimentRun> findByIdForUpdate(UUID id, TenantScope scope);
 
-    /**
-     * Returns an experiment's terminal (SUCCESS or FAILED) runs newest first, within the scope.
-     *
-     * @param experiment the owning experiment
-     * @param pageable the page request
-     * @param scope the tenant scope
-     * @return the terminal runs, newest first, bounded by the page
-     */
+    /** Returns an experiment's terminal (SUCCESS or FAILED) runs newest first, within the scope. */
     List<ExperimentRun> findCompletedRunsByExperiment(Experiment experiment, Pageable pageable, TenantScope scope);
 
     /**
-     * Resolves SUCCESS baseline candidates for automatic gate resolution, within the scope. Excludes the
-     * candidate run, requires the same dataset version (the null branch matches ad-hoc to ad-hoc), and
-     * filters by git branch when non-null. Ordered by start time descending.
-     *
-     * @param experiment the experiment to scope to
-     * @param candidateId the candidate run id to exclude
-     * @param datasetVersionId the candidate's dataset version id, or null for ad-hoc runs
-     * @param branch a git branch to filter by, or null to ignore branch
-     * @param pageable a one-row page request
-     * @param scope the tenant scope
-     * @return matching SUCCESS baseline candidates, newest first
+     * SUCCESS baseline candidates for automatic gate resolution, within the scope, newest first. Excludes
+     * the candidate run, requires the same dataset version (a null {@code datasetVersionId} matches
+     * ad-hoc to ad-hoc), and filters by {@code branch} when non-null.
      */
     List<ExperimentRun> findBaselineCandidates(
             Experiment experiment,

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepositoryFragment.java
@@ -1,0 +1,73 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+
+/** Entity-specific scoped finders for {@link ExperimentRun}. */
+public interface ExperimentRunRepositoryFragment extends ScopedRepository<ExperimentRun> {
+
+    /**
+     * Lists an experiment's runs newest first, within the scope.
+     *
+     * @param experiment the owning experiment
+     * @param scope the tenant scope
+     * @return the visible runs, newest first
+     */
+    List<ExperimentRun> findByExperiment(Experiment experiment, TenantScope scope);
+
+    /**
+     * Returns the most recent run of an experiment within the scope.
+     *
+     * @param experiment the owning experiment
+     * @param scope the tenant scope
+     * @return the latest visible run, or empty
+     */
+    Optional<ExperimentRun> findFirstByExperiment(Experiment experiment, TenantScope scope);
+
+    /**
+     * Loads a run by id under a pessimistic write lock, within the scope. Used to serialize ingestion
+     * against completion.
+     *
+     * @param id the run id
+     * @param scope the tenant scope
+     * @return the locked run if visible, otherwise empty
+     */
+    Optional<ExperimentRun> findByIdForUpdate(UUID id, TenantScope scope);
+
+    /**
+     * Returns an experiment's terminal (SUCCESS or FAILED) runs newest first, within the scope.
+     *
+     * @param experiment the owning experiment
+     * @param pageable the page request
+     * @param scope the tenant scope
+     * @return the terminal runs, newest first, bounded by the page
+     */
+    List<ExperimentRun> findCompletedRunsByExperiment(Experiment experiment, Pageable pageable, TenantScope scope);
+
+    /**
+     * Resolves SUCCESS baseline candidates for automatic gate resolution, within the scope. Excludes the
+     * candidate run, requires the same dataset version (the null branch matches ad-hoc to ad-hoc), and
+     * filters by git branch when non-null. Ordered by start time descending.
+     *
+     * @param experiment the experiment to scope to
+     * @param candidateId the candidate run id to exclude
+     * @param datasetVersionId the candidate's dataset version id, or null for ad-hoc runs
+     * @param branch a git branch to filter by, or null to ignore branch
+     * @param pageable a one-row page request
+     * @param scope the tenant scope
+     * @return matching SUCCESS baseline candidates, newest first
+     */
+    List<ExperimentRun> findBaselineCandidates(
+            Experiment experiment,
+            UUID candidateId,
+            UUID datasetVersionId,
+            String branch,
+            Pageable pageable,
+            TenantScope scope);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ExperimentRunRepositoryFragmentImpl.java
@@ -1,0 +1,99 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.RunStatus;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantPredicate;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+
+/** Tenant-scoped implementation of the {@link ExperimentRun} finders. */
+public class ExperimentRunRepositoryFragmentImpl extends AbstractScopedRepository<ExperimentRun>
+        implements ExperimentRunRepositoryFragment {
+
+    public ExperimentRunRepositoryFragmentImpl() {
+        super(ExperimentRun.class);
+    }
+
+    @Override
+    public List<ExperimentRun> findByExperiment(Experiment experiment, TenantScope scope) {
+        return finder().findWhere(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("experiment"), experiment),
+                        (cb, root) -> List.of(cb.desc(root.get("startedAt"))));
+    }
+
+    @Override
+    public Optional<ExperimentRun> findFirstByExperiment(Experiment experiment, TenantScope scope) {
+        return finder().findFirst(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("experiment"), experiment),
+                        (cb, root) -> List.of(cb.desc(root.get("startedAt"))));
+    }
+
+    @Override
+    public Optional<ExperimentRun> findByIdForUpdate(UUID id, TenantScope scope) {
+        return finder().findByIdForUpdate(id, scope);
+    }
+
+    @Override
+    public List<ExperimentRun> findCompletedRunsByExperiment(
+            Experiment experiment, Pageable pageable, TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<ExperimentRun> query = cb.createQuery(ExperimentRun.class);
+        Root<ExperimentRun> root = query.from(ExperimentRun.class);
+        Predicate terminal = root.get("status").in(RunStatus.SUCCESS, RunStatus.FAILED);
+        query.select(root)
+                .where(cb.and(
+                        cb.equal(root.get("experiment"), experiment),
+                        terminal,
+                        TenantPredicate.forScope(cb, root.get("tenantId"), scope)))
+                .orderBy(cb.desc(root.get("startedAt")));
+        return entityManager
+                .createQuery(query)
+                .setMaxResults(pageable.isUnpaged() ? Integer.MAX_VALUE : pageable.getPageSize())
+                .getResultList();
+    }
+
+    @Override
+    public List<ExperimentRun> findBaselineCandidates(
+            Experiment experiment,
+            UUID candidateId,
+            UUID datasetVersionId,
+            String branch,
+            Pageable pageable,
+            TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<ExperimentRun> query = cb.createQuery(ExperimentRun.class);
+        Root<ExperimentRun> root = query.from(ExperimentRun.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(root.get("experiment"), experiment));
+        predicates.add(cb.notEqual(root.get("id"), candidateId));
+        predicates.add(cb.equal(root.get("status"), RunStatus.SUCCESS));
+        if (datasetVersionId == null) {
+            predicates.add(cb.isNull(root.get("datasetVersion")));
+        } else {
+            predicates.add(cb.equal(root.get("datasetVersion").get("id"), datasetVersionId));
+        }
+        if (branch != null) {
+            predicates.add(cb.equal(root.get("gitBranch"), branch));
+        }
+        predicates.add(TenantPredicate.forScope(cb, root.get("tenantId"), scope));
+
+        query.select(root).where(cb.and(predicates.toArray(new Predicate[0]))).orderBy(cb.desc(root.get("startedAt")));
+        return entityManager
+                .createQuery(query)
+                .setMaxResults(pageable.isUnpaged() ? Integer.MAX_VALUE : pageable.getPageSize())
+                .getResultList();
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ItemResultRepository.java
@@ -128,11 +128,15 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
      * {@code NOT EXISTS} clause treats a {@code CORRECT}/{@code INCORRECT} annotation as resolved (there
      * is at most one annotation per item). Run, experiment, and project are fetch-joined so the queue can
      * render each item's context without a per-row lookup, and the null-guarded filters let the one query
-     * serve both the global queue and the scoped views.
+     * serve both the global queue and the scoped views. The tenant predicate filters on the item's own
+     * stamped tenant so a reviewer only sees items of their own tenant plus shared (null-tenant) items;
+     * it is applied to both the page query and the count query so paging metadata stays consistent.
      *
      * @param projectName  restrict to this project, or null for any
      * @param experimentId restrict to this experiment, or null for any
      * @param runId        restrict to this run, or null for any
+     * @param restricted   whether the tenant predicate applies; false sees every tenant
+     * @param tenantId     the tenant to filter by when restricted, or null for shared-only
      * @param pageable     the page to return, ordered oldest-first
      * @return the matching items, each with run, experiment, and project initialized
      */
@@ -144,6 +148,7 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
                     WHERE (:projectName IS NULL OR p.name = :projectName)
                     AND (:experimentId IS NULL OR e.id = :experimentId)
                     AND (:runId IS NULL OR r.id = :runId)
+                    AND (:restricted = false OR i.tenantId = :tenantId OR i.tenantId IS NULL)
                     AND NOT EXISTS (
                         SELECT a FROM Annotation a
                         WHERE a.itemResult = i AND a.verdict <> dev.dokimos.server.entity.AnnotationVerdict.UNSURE
@@ -154,6 +159,7 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
                     WHERE (:projectName IS NULL OR i.run.experiment.project.name = :projectName)
                     AND (:experimentId IS NULL OR i.run.experiment.id = :experimentId)
                     AND (:runId IS NULL OR i.run.id = :runId)
+                    AND (:restricted = false OR i.tenantId = :tenantId OR i.tenantId IS NULL)
                     AND NOT EXISTS (
                         SELECT a FROM Annotation a
                         WHERE a.itemResult = i AND a.verdict <> dev.dokimos.server.entity.AnnotationVerdict.UNSURE
@@ -163,6 +169,8 @@ public interface ItemResultRepository extends JpaRepository<ItemResult, UUID> {
             @Param("projectName") String projectName,
             @Param("experimentId") UUID experimentId,
             @Param("runId") UUID runId,
+            @Param("restricted") boolean restricted,
+            @Param("tenantId") String tenantId,
             Pageable pageable);
 
     /**

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.Repository;
 
 /**
  * Tenant-scoped repository for {@link LlmConnection}. Extends only the empty {@link Repository} plus the
- * scoped fragments, so every read takes a {@code TenantScope}. Connection names stay globally unique (the
- * DB constraint is unchanged), so the uniqueness guard uses {@code existsByName} which ignores scope.
+ * scoped fragments, so every read takes a {@code TenantScope}. Connection names are unique per tenant, so
+ * the uniqueness guard uses {@code existsByName} scoped to the caller.
  */
 public interface LlmConnectionRepository extends Repository<LlmConnection, UUID>, LlmConnectionRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepository.java
@@ -1,13 +1,12 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.LlmConnection;
-import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface LlmConnectionRepository extends JpaRepository<LlmConnection, UUID> {
-
-    Optional<LlmConnection> findByName(String name);
-
-    boolean existsByName(String name);
-}
+/**
+ * Tenant-scoped repository for {@link LlmConnection}. Extends only the empty {@link Repository} plus the
+ * scoped fragments, so every read takes a {@code TenantScope}. Connection names stay globally unique (the
+ * DB constraint is unchanged), so the uniqueness guard uses {@code existsByName} which ignores scope.
+ */
+public interface LlmConnectionRepository extends Repository<LlmConnection, UUID>, LlmConnectionRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragment.java
@@ -1,0 +1,37 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Optional;
+
+/** Entity-specific scoped finders for {@link LlmConnection}. */
+public interface LlmConnectionRepositoryFragment extends ScopedRepository<LlmConnection> {
+
+    /**
+     * Finds a connection by name within the scope.
+     *
+     * @param name the connection name
+     * @param scope the tenant scope
+     * @return the connection if visible, otherwise empty
+     */
+    Optional<LlmConnection> findByName(String name, TenantScope scope);
+
+    /**
+     * Lists connections visible under the scope, newest first.
+     *
+     * @param scope the tenant scope
+     * @return the visible connections
+     */
+    List<LlmConnection> findAllOrdered(TenantScope scope);
+
+    /**
+     * Returns whether any connection has the given name, ignoring tenant. Connection names are globally
+     * unique (the DB constraint is unchanged), so the create and rename guards check globally.
+     *
+     * @param name the candidate name
+     * @return true when a connection with that name already exists in any tenant
+     */
+    boolean existsByName(String name);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragment.java
@@ -9,31 +9,15 @@ import java.util.Optional;
 /** Entity-specific scoped finders for {@link LlmConnection}. */
 public interface LlmConnectionRepositoryFragment extends ScopedRepository<LlmConnection> {
 
-    /**
-     * Finds a connection by name within the scope.
-     *
-     * @param name the connection name
-     * @param scope the tenant scope
-     * @return the connection if visible, otherwise empty
-     */
+    /** Finds a connection by name within the scope. */
     Optional<LlmConnection> findByName(String name, TenantScope scope);
 
-    /**
-     * Lists connections visible under the scope, newest first.
-     *
-     * @param scope the tenant scope
-     * @return the visible connections
-     */
+    /** Lists connections visible under the scope, newest first. */
     List<LlmConnection> findAllOrdered(TenantScope scope);
 
     /**
-     * Returns whether a connection with the given name exists within the scope. Connection names are
-     * unique per tenant, so the create and rename guards check within the caller's scope rather than
-     * globally, and a scoped existence check is not a cross-tenant oracle.
-     *
-     * @param name the candidate name
-     * @param scope the tenant scope
-     * @return true when a connection with that name is visible under the scope
+     * Returns whether a connection with the name exists within the scope. Names are unique per tenant, so
+     * the create and rename guards check within the caller's scope and are not a cross-tenant oracle.
      */
     boolean existsByName(String name, TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragment.java
@@ -27,11 +27,13 @@ public interface LlmConnectionRepositoryFragment extends ScopedRepository<LlmCon
     List<LlmConnection> findAllOrdered(TenantScope scope);
 
     /**
-     * Returns whether any connection has the given name, ignoring tenant. Connection names are globally
-     * unique (the DB constraint is unchanged), so the create and rename guards check globally.
+     * Returns whether a connection with the given name exists within the scope. Connection names are
+     * unique per tenant, so the create and rename guards check within the caller's scope rather than
+     * globally, and a scoped existence check is not a cross-tenant oracle.
      *
      * @param name the candidate name
-     * @return true when a connection with that name already exists in any tenant
+     * @param scope the tenant scope
+     * @return true when a connection with that name is visible under the scope
      */
-    boolean existsByName(String name);
+    boolean existsByName(String name, TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragmentImpl.java
@@ -3,9 +3,6 @@ package dev.dokimos.server.repository;
 import dev.dokimos.server.entity.LlmConnection;
 import dev.dokimos.server.tenant.AbstractScopedRepository;
 import dev.dokimos.server.tenant.TenantScope;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Root;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,11 +25,8 @@ public class LlmConnectionRepositoryFragmentImpl extends AbstractScopedRepositor
     }
 
     @Override
-    public boolean existsByName(String name) {
-        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Long> query = cb.createQuery(Long.class);
-        Root<LlmConnection> root = query.from(LlmConnection.class);
-        query.select(cb.count(root)).where(cb.equal(root.get("name"), name));
-        return entityManager.createQuery(query).getSingleResult() > 0;
+    public boolean existsByName(String name, TenantScope scope) {
+        return finder().findFirst(scope, (cb, root) -> cb.equal(root.get("name"), name), null)
+                .isPresent();
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/LlmConnectionRepositoryFragmentImpl.java
@@ -1,0 +1,38 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import java.util.Optional;
+
+/** Tenant-scoped implementation of the {@link LlmConnection} finders. */
+public class LlmConnectionRepositoryFragmentImpl extends AbstractScopedRepository<LlmConnection>
+        implements LlmConnectionRepositoryFragment {
+
+    public LlmConnectionRepositoryFragmentImpl() {
+        super(LlmConnection.class);
+    }
+
+    @Override
+    public Optional<LlmConnection> findByName(String name, TenantScope scope) {
+        return finder().findFirst(scope, (cb, root) -> cb.equal(root.get("name"), name), null);
+    }
+
+    @Override
+    public List<LlmConnection> findAllOrdered(TenantScope scope) {
+        return finder().findAll(scope, (cb, root) -> List.of(cb.desc(root.get("createdAt"))));
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<LlmConnection> root = query.from(LlmConnection.class);
+        query.select(cb.count(root)).where(cb.equal(root.get("name"), name));
+        return entityManager.createQuery(query).getSingleResult() > 0;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepository.java
@@ -1,22 +1,11 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.Project;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
 
-public interface ProjectRepository extends JpaRepository<Project, UUID> {
-
-    Optional<Project> findByName(String name);
-
-    @Query("""
-            SELECT p, COUNT(e) as experimentCount
-            FROM Project p
-            LEFT JOIN p.experiments e
-            GROUP BY p
-            ORDER BY p.createdAt DESC
-            """)
-    List<Object[]> findAllWithExperimentCount();
-}
+/**
+ * Tenant-scoped repository for {@link Project}. Extends only the empty {@link Repository} plus the scoped
+ * fragments, so the dangerous inherited finders do not exist and every read takes a {@code TenantScope}.
+ */
+public interface ProjectRepository extends Repository<Project, UUID>, ProjectRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragment.java
@@ -11,20 +11,13 @@ public interface ProjectRepositoryFragment extends ScopedRepository<Project> {
 
     /**
      * Looks up a project by name within the scope. A name owned by another tenant is invisible, so two
-     * tenants can each own a project with the same name.
-     *
-     * @param name the project name
-     * @param scope the tenant scope
-     * @return the project if visible, otherwise empty
+     * tenants can each own a project of the same name.
      */
     Optional<Project> findByName(String name, TenantScope scope);
 
     /**
-     * Returns each visible project paired with its experiment count, newest first. The aggregate honors
-     * the scope so a tenant only counts and lists its own and shared projects.
-     *
-     * @param scope the tenant scope
-     * @return rows of {@code [Project, Long]} ordered by creation time descending
+     * Returns each visible project paired with its experiment count, newest first, as {@code [Project,
+     * Long]} rows. The aggregate honors the scope.
      */
     List<Object[]> findAllWithExperimentCount(TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragment.java
@@ -1,0 +1,30 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Optional;
+
+/** Entity-specific scoped finders for {@link Project}, implemented over the tenant-scoped query helper. */
+public interface ProjectRepositoryFragment extends ScopedRepository<Project> {
+
+    /**
+     * Looks up a project by name within the scope. A name owned by another tenant is invisible, so two
+     * tenants can each own a project with the same name.
+     *
+     * @param name the project name
+     * @param scope the tenant scope
+     * @return the project if visible, otherwise empty
+     */
+    Optional<Project> findByName(String name, TenantScope scope);
+
+    /**
+     * Returns each visible project paired with its experiment count, newest first. The aggregate honors
+     * the scope so a tenant only counts and lists its own and shared projects.
+     *
+     * @param scope the tenant scope
+     * @return rows of {@code [Project, Long]} ordered by creation time descending
+     */
+    List<Object[]> findAllWithExperimentCount(TenantScope scope);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragmentImpl.java
@@ -22,9 +22,8 @@ public class ProjectRepositoryFragmentImpl extends AbstractScopedRepository<Proj
 
     @Override
     public Optional<Project> findByName(String name, TenantScope scope) {
-        // Order so an own-tenant row wins over a shared (null-tenant) row of the same name: a scoped
-        // read can match both, and without an ordering the single row returned would be arbitrary. The
-        // case expression sorts non-null (own-tenant) rows ahead of null-tenant rows.
+        // A scoped read can match both an own-tenant and a shared row of the same name; sort the
+        // own-tenant (non-null) row first so it wins deterministically.
         return finder().findFirst(
                         scope,
                         (cb, root) -> cb.equal(root.get("name"), name),

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragmentImpl.java
@@ -1,0 +1,52 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantPredicate;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.List;
+import java.util.Optional;
+
+/** Tenant-scoped implementation of the {@link Project} finders. */
+public class ProjectRepositoryFragmentImpl extends AbstractScopedRepository<Project>
+        implements ProjectRepositoryFragment {
+
+    public ProjectRepositoryFragmentImpl() {
+        super(Project.class);
+    }
+
+    @Override
+    public Optional<Project> findByName(String name, TenantScope scope) {
+        return finder().findFirst(scope, (cb, root) -> cb.equal(root.get("name"), name), null);
+    }
+
+    @Override
+    public List<Object[]> findAllWithExperimentCount(TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Object[]> query = cb.createQuery(Object[].class);
+        Root<Project> project = query.from(Project.class);
+
+        // Correlated count of the project's experiments. A subquery keeps the projection a clean
+        // [Project, Long] without the GROUP BY a join-and-count would require.
+        Subquery<Long> countSub = query.subquery(Long.class);
+        Root<Experiment> experiment = countSub.from(Experiment.class);
+        countSub.select(cb.count(experiment))
+                .where(cb.equal(experiment.get("project").get("id"), project.get("id")));
+
+        query.multiselect(project, countSub.getSelection())
+                .where(TenantPredicate.forScope(cb, project.get("tenantId"), scope))
+                .orderBy(cb.desc(project.get("createdAt")));
+
+        return entityManager.createQuery(query).getResultList();
+    }
+
+    @Override
+    public List<Project> findAll(TenantScope scope) {
+        return finder().findAll(scope, (cb, root) -> List.of(cb.desc(root.get("createdAt"))));
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/ProjectRepositoryFragmentImpl.java
@@ -22,7 +22,15 @@ public class ProjectRepositoryFragmentImpl extends AbstractScopedRepository<Proj
 
     @Override
     public Optional<Project> findByName(String name, TenantScope scope) {
-        return finder().findFirst(scope, (cb, root) -> cb.equal(root.get("name"), name), null);
+        // Order so an own-tenant row wins over a shared (null-tenant) row of the same name: a scoped
+        // read can match both, and without an ordering the single row returned would be arbitrary. The
+        // case expression sorts non-null (own-tenant) rows ahead of null-tenant rows.
+        return finder().findFirst(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("name"), name),
+                        (cb, root) -> List.of(cb.asc(cb.selectCase()
+                                .when(cb.isNull(root.get("tenantId")), 1)
+                                .otherwise(0))));
     }
 
     @Override

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepository.java
@@ -1,18 +1,12 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.TraceEvalRule;
-import java.util.List;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface TraceEvalRuleRepository extends JpaRepository<TraceEvalRule, UUID> {
-
-    List<TraceEvalRule> findByProjectIdOrderByCreatedAtAsc(UUID projectId);
-
-    /** Enabled rules for a project, used by ingestion to decide which spans to enqueue. */
-    List<TraceEvalRule> findByProjectIdAndEnabledTrue(UUID projectId);
-
-    boolean existsByProjectIdAndName(UUID projectId, String name);
-
-    boolean existsByConnection_Id(UUID connectionId);
-}
+/**
+ * Tenant-scoped repository for {@link TraceEvalRule}. Extends only the empty {@link Repository} plus the
+ * scoped fragments, so every read takes a {@code TenantScope}. Ingestion (off the request thread) lists a
+ * project's enabled rules unrestricted.
+ */
+public interface TraceEvalRuleRepository extends Repository<TraceEvalRule, UUID>, TraceEvalRuleRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepositoryFragment.java
@@ -9,32 +9,15 @@ import java.util.UUID;
 /** Entity-specific scoped finders for {@link TraceEvalRule}. */
 public interface TraceEvalRuleRepositoryFragment extends ScopedRepository<TraceEvalRule> {
 
-    /**
-     * Lists a project's rules oldest first, within the scope.
-     *
-     * @param projectId the owning project id
-     * @param scope the tenant scope
-     * @return the visible rules, oldest first
-     */
+    /** Lists a project's rules oldest first, within the scope. */
     List<TraceEvalRule> findByProjectId(UUID projectId, TenantScope scope);
 
     /**
      * Enabled rules for a project regardless of tenant, used by ingestion to decide which spans to
      * enqueue. Ingestion runs off the request thread, so it lists unrestricted.
-     *
-     * @param projectId the owning project id
-     * @return the project's enabled rules
      */
     List<TraceEvalRule> findByProjectIdAndEnabledTrue(UUID projectId);
 
-    /**
-     * Returns whether a rule with the given name already exists in the project, within the scope. Rule
-     * names are unique per project, so the uniqueness guard is scoped like the rest of the rule surface.
-     *
-     * @param projectId the owning project id
-     * @param name the candidate rule name
-     * @param scope the tenant scope
-     * @return true when a visible rule of that name exists in the project
-     */
+    /** Returns whether a rule of the name already exists in the project, within the scope. */
     boolean existsByProjectIdAndName(UUID projectId, String name, TenantScope scope);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepositoryFragment.java
@@ -1,0 +1,40 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.TraceEvalRule;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.UUID;
+
+/** Entity-specific scoped finders for {@link TraceEvalRule}. */
+public interface TraceEvalRuleRepositoryFragment extends ScopedRepository<TraceEvalRule> {
+
+    /**
+     * Lists a project's rules oldest first, within the scope.
+     *
+     * @param projectId the owning project id
+     * @param scope the tenant scope
+     * @return the visible rules, oldest first
+     */
+    List<TraceEvalRule> findByProjectId(UUID projectId, TenantScope scope);
+
+    /**
+     * Enabled rules for a project regardless of tenant, used by ingestion to decide which spans to
+     * enqueue. Ingestion runs off the request thread, so it lists unrestricted.
+     *
+     * @param projectId the owning project id
+     * @return the project's enabled rules
+     */
+    List<TraceEvalRule> findByProjectIdAndEnabledTrue(UUID projectId);
+
+    /**
+     * Returns whether a rule with the given name already exists in the project, within the scope. Rule
+     * names are unique per project, so the uniqueness guard is scoped like the rest of the rule surface.
+     *
+     * @param projectId the owning project id
+     * @param name the candidate rule name
+     * @param scope the tenant scope
+     * @return true when a visible rule of that name exists in the project
+     */
+    boolean existsByProjectIdAndName(UUID projectId, String name, TenantScope scope);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceEvalRuleRepositoryFragmentImpl.java
@@ -1,0 +1,50 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.TraceEvalRule;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantPredicate;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import java.util.List;
+import java.util.UUID;
+
+/** Tenant-scoped implementation of the {@link TraceEvalRule} finders. */
+public class TraceEvalRuleRepositoryFragmentImpl extends AbstractScopedRepository<TraceEvalRule>
+        implements TraceEvalRuleRepositoryFragment {
+
+    public TraceEvalRuleRepositoryFragmentImpl() {
+        super(TraceEvalRule.class);
+    }
+
+    @Override
+    public List<TraceEvalRule> findByProjectId(UUID projectId, TenantScope scope) {
+        return finder().findWhere(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("projectId"), projectId),
+                        (cb, root) -> List.of(cb.asc(root.get("createdAt"))));
+    }
+
+    @Override
+    public List<TraceEvalRule> findByProjectIdAndEnabledTrue(UUID projectId) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<TraceEvalRule> query = cb.createQuery(TraceEvalRule.class);
+        Root<TraceEvalRule> root = query.from(TraceEvalRule.class);
+        query.select(root).where(cb.and(cb.equal(root.get("projectId"), projectId), cb.isTrue(root.get("enabled"))));
+        return entityManager.createQuery(query).getResultList();
+    }
+
+    @Override
+    public boolean existsByProjectIdAndName(UUID projectId, String name, TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<TraceEvalRule> root = query.from(TraceEvalRule.class);
+        query.select(cb.count(root))
+                .where(cb.and(
+                        cb.equal(root.get("projectId"), projectId),
+                        cb.equal(root.get("name"), name),
+                        TenantPredicate.forScope(cb, root.get("tenantId"), scope)));
+        return entityManager.createQuery(query).getSingleResult() > 0;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepository.java
@@ -1,37 +1,12 @@
 package dev.dokimos.server.repository;
 
 import dev.dokimos.server.entity.Trace;
-import java.time.Instant;
-import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.Repository;
 
-public interface TraceRepository extends JpaRepository<Trace, UUID> {
-
-    Optional<Trace> findByTraceId(String traceId);
-
-    Page<Trace> findAllByOrderByCreatedAtDesc(Pageable pageable);
-
-    Page<Trace> findByProjectIdOrderByCreatedAtDesc(UUID projectId, Pageable pageable);
-
-    /**
-     * Deletes traces whose retention window has closed. Spans and trace eval jobs cascade via their
-     * foreign keys, so a single delete clears the whole expired subtree.
-     *
-     * <p>{@code flushAutomatically} and {@code clearAutomatically} keep the persistence context
-     * consistent with this database-level cascade: the context is flushed before the delete and cleared
-     * after it, so managed spans (whose JSONB attribute map Hibernate treats as perpetually dirty) are
-     * detached rather than re-flushed as updates against rows the cascade has already removed.
-     *
-     * @param cutoff traces with an expiry at or before this instant are removed
-     * @return the number of traces deleted
-     */
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("DELETE FROM Trace t WHERE t.expiresAt <= :cutoff")
-    int deleteExpired(@Param("cutoff") Instant cutoff);
-}
+/**
+ * Tenant-scoped repository for {@link Trace}. Extends only the empty {@link Repository} plus the scoped
+ * fragments, so the read surface (by-id and the paginated lists) is tenant-scoped. Ingestion looks up by
+ * the OTLP trace id unrestricted, and the retention sweeper deletes expired rows across all tenants.
+ */
+public interface TraceRepository extends Repository<Trace, UUID>, TraceRepositoryFragment {}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepositoryFragment.java
@@ -1,0 +1,51 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Trace;
+import dev.dokimos.server.tenant.ScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/** Entity-specific scoped finders for {@link Trace} plus the unrestricted ingestion and sweeper paths. */
+public interface TraceRepositoryFragment extends ScopedRepository<Trace> {
+
+    /**
+     * Looks up a trace by its OTLP trace id regardless of tenant. Ingestion reuses an existing trace row
+     * so spans accumulate across batches, so this lookup is unrestricted.
+     *
+     * @param traceId the OTLP trace id
+     * @return the trace if present, otherwise empty
+     */
+    Optional<Trace> findByTraceId(String traceId);
+
+    /**
+     * Lists traces newest first within the scope, paginated.
+     *
+     * @param pageable the page request
+     * @param scope the tenant scope
+     * @return the page of visible traces
+     */
+    Page<Trace> findAllOrdered(Pageable pageable, TenantScope scope);
+
+    /**
+     * Lists a project's traces newest first within the scope, paginated.
+     *
+     * @param projectId the owning project id
+     * @param pageable the page request
+     * @param scope the tenant scope
+     * @return the page of visible traces for the project
+     */
+    Page<Trace> findByProjectId(UUID projectId, Pageable pageable, TenantScope scope);
+
+    /**
+     * Deletes traces whose retention window has closed, across all tenants. Spans and trace eval jobs
+     * cascade via their foreign keys. Runs off the request thread, so it is unrestricted.
+     *
+     * @param cutoff traces with an expiry at or before this instant are removed
+     * @return the number of traces deleted
+     */
+    int deleteExpired(Instant cutoff);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepositoryFragment.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepositoryFragment.java
@@ -15,37 +15,18 @@ public interface TraceRepositoryFragment extends ScopedRepository<Trace> {
     /**
      * Looks up a trace by its OTLP trace id regardless of tenant. Ingestion reuses an existing trace row
      * so spans accumulate across batches, so this lookup is unrestricted.
-     *
-     * @param traceId the OTLP trace id
-     * @return the trace if present, otherwise empty
      */
     Optional<Trace> findByTraceId(String traceId);
 
-    /**
-     * Lists traces newest first within the scope, paginated.
-     *
-     * @param pageable the page request
-     * @param scope the tenant scope
-     * @return the page of visible traces
-     */
+    /** Lists traces newest first within the scope, paginated. */
     Page<Trace> findAllOrdered(Pageable pageable, TenantScope scope);
 
-    /**
-     * Lists a project's traces newest first within the scope, paginated.
-     *
-     * @param projectId the owning project id
-     * @param pageable the page request
-     * @param scope the tenant scope
-     * @return the page of visible traces for the project
-     */
+    /** Lists a project's traces newest first within the scope, paginated. */
     Page<Trace> findByProjectId(UUID projectId, Pageable pageable, TenantScope scope);
 
     /**
-     * Deletes traces whose retention window has closed, across all tenants. Spans and trace eval jobs
-     * cascade via their foreign keys. Runs off the request thread, so it is unrestricted.
-     *
-     * @param cutoff traces with an expiry at or before this instant are removed
-     * @return the number of traces deleted
+     * Deletes traces whose retention window has closed, across all tenants; spans and trace eval jobs
+     * cascade. Runs off the request thread, so it is unrestricted.
      */
     int deleteExpired(Instant cutoff);
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepositoryFragmentImpl.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/repository/TraceRepositoryFragmentImpl.java
@@ -1,0 +1,62 @@
+package dev.dokimos.server.repository;
+
+import dev.dokimos.server.entity.Trace;
+import dev.dokimos.server.tenant.AbstractScopedRepository;
+import dev.dokimos.server.tenant.TenantScope;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/** Tenant-scoped implementation of the {@link Trace} finders plus the unrestricted ingestion paths. */
+public class TraceRepositoryFragmentImpl extends AbstractScopedRepository<Trace> implements TraceRepositoryFragment {
+
+    public TraceRepositoryFragmentImpl() {
+        super(Trace.class);
+    }
+
+    @Override
+    public Optional<Trace> findByTraceId(String traceId) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Trace> query = cb.createQuery(Trace.class);
+        Root<Trace> root = query.from(Trace.class);
+        query.select(root).where(cb.equal(root.get("traceId"), traceId));
+        return entityManager.createQuery(query).setMaxResults(1).getResultList().stream()
+                .findFirst();
+    }
+
+    @Override
+    public Page<Trace> findAllOrdered(Pageable pageable, TenantScope scope) {
+        return finder().findPage(scope, null, (cb, root) -> List.of(cb.desc(root.get("createdAt"))), pageable);
+    }
+
+    @Override
+    public Page<Trace> findByProjectId(UUID projectId, Pageable pageable, TenantScope scope) {
+        return finder().findPage(
+                        scope,
+                        (cb, root) -> cb.equal(root.get("projectId"), projectId),
+                        (cb, root) -> List.of(cb.desc(root.get("createdAt"))),
+                        pageable);
+    }
+
+    @Override
+    public int deleteExpired(Instant cutoff) {
+        // Flush then delete then clear, mirroring the prior @Modifying(flushAutomatically,
+        // clearAutomatically) so managed spans (with their perpetually dirty JSONB maps) are not
+        // re-flushed against rows the cascade has already removed.
+        entityManager.flush();
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaDelete<Trace> delete = cb.createCriteriaDelete(Trace.class);
+        Root<Trace> root = delete.from(Trace.class);
+        delete.where(cb.lessThanOrEqualTo(root.get("expiresAt"), cutoff));
+        int removed = entityManager.createQuery(delete).executeUpdate();
+        entityManager.clear();
+        return removed;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/AlertWebhookService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/AlertWebhookService.java
@@ -7,6 +7,7 @@ import dev.dokimos.server.entity.AlertWebhook;
 import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.repository.AlertWebhookRepository;
 import dev.dokimos.server.repository.ProjectRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -15,7 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Manages a project's regression-alert webhooks. Responses never carry the signing secret; only
  * whether one is configured is exposed. All operations are scoped to a project so a webhook can only
- * be read or mutated through its owning project.
+ * be read or mutated through its owning project, and every load is tenant-scoped so a cross-tenant id
+ * surfaces as a 404.
  */
 @Service
 public class AlertWebhookService {
@@ -29,31 +31,33 @@ public class AlertWebhookService {
     }
 
     /**
-     * Registers a webhook for a project.
+     * Registers a webhook for a project, stamped with the project's tenant.
      *
      * @param projectId the project to attach the webhook to
      * @param request the webhook definition
+     * @param scope the tenant scope of the caller
      * @return the public view of the saved webhook
-     * @throws IllegalArgumentException if the project does not exist (mapped to 404)
+     * @throws IllegalArgumentException if the project does not exist under the scope (mapped to 404)
      */
     @Transactional
-    public AlertWebhookView create(UUID projectId, CreateAlertWebhookRequest request) {
-        Project project = loadProject(projectId);
+    public AlertWebhookView create(UUID projectId, CreateAlertWebhookRequest request, TenantScope scope) {
+        Project project = loadProject(projectId, scope);
         boolean enabled = request.enabled() == null || request.enabled();
         String secret = blankToNull(request.secret());
         AlertWebhook webhook = new AlertWebhook(project, request.url(), secret, enabled);
+        webhook.setTenantId(project.getTenantId());
         return AlertWebhookView.from(webhookRepository.save(webhook));
     }
 
     /**
      * Lists a project's webhooks in creation order.
      *
-     * @throws IllegalArgumentException if the project does not exist (mapped to 404)
+     * @throws IllegalArgumentException if the project does not exist under the scope (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public List<AlertWebhookView> list(UUID projectId) {
-        Project project = loadProject(projectId);
-        return webhookRepository.findByProjectOrderByCreatedAtAsc(project).stream()
+    public List<AlertWebhookView> list(UUID projectId, TenantScope scope) {
+        Project project = loadProject(projectId, scope);
+        return webhookRepository.findByProject(project, scope).stream()
                 .map(AlertWebhookView::from)
                 .toList();
     }
@@ -61,24 +65,25 @@ public class AlertWebhookService {
     /**
      * Returns one of a project's webhooks.
      *
-     * @throws IllegalArgumentException if the project or webhook does not exist, or the webhook
-     *     belongs to another project (mapped to 404)
+     * @throws IllegalArgumentException if the project or webhook does not exist under the scope, or the
+     *     webhook belongs to another project (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public AlertWebhookView get(UUID projectId, UUID webhookId) {
-        return AlertWebhookView.from(loadWebhookInProject(projectId, webhookId));
+    public AlertWebhookView get(UUID projectId, UUID webhookId, TenantScope scope) {
+        return AlertWebhookView.from(loadWebhookInProject(projectId, webhookId, scope));
     }
 
     /**
      * Replaces a webhook's url and enabled flag, and optionally its secret. A blank secret keeps the
      * existing secret so a receiver never loses a configured secret by accident.
      *
-     * @throws IllegalArgumentException if the project or webhook does not exist, or the webhook
-     *     belongs to another project (mapped to 404)
+     * @throws IllegalArgumentException if the project or webhook does not exist under the scope, or the
+     *     webhook belongs to another project (mapped to 404)
      */
     @Transactional
-    public AlertWebhookView update(UUID projectId, UUID webhookId, UpdateAlertWebhookRequest request) {
-        AlertWebhook webhook = loadWebhookInProject(projectId, webhookId);
+    public AlertWebhookView update(
+            UUID projectId, UUID webhookId, UpdateAlertWebhookRequest request, TenantScope scope) {
+        AlertWebhook webhook = loadWebhookInProject(projectId, webhookId, scope);
         webhook.setUrl(request.url());
         webhook.setEnabled(request.enabled() == null || request.enabled());
         String secret = blankToNull(request.secret());
@@ -92,19 +97,19 @@ public class AlertWebhookService {
     /**
      * Deletes one of a project's webhooks.
      *
-     * @throws IllegalArgumentException if the project or webhook does not exist, or the webhook
-     *     belongs to another project (mapped to 404)
+     * @throws IllegalArgumentException if the project or webhook does not exist under the scope, or the
+     *     webhook belongs to another project (mapped to 404)
      */
     @Transactional
-    public void delete(UUID projectId, UUID webhookId) {
-        AlertWebhook webhook = loadWebhookInProject(projectId, webhookId);
+    public void delete(UUID projectId, UUID webhookId, TenantScope scope) {
+        AlertWebhook webhook = loadWebhookInProject(projectId, webhookId, scope);
         webhookRepository.delete(webhook);
     }
 
-    private AlertWebhook loadWebhookInProject(UUID projectId, UUID webhookId) {
-        loadProject(projectId);
+    private AlertWebhook loadWebhookInProject(UUID projectId, UUID webhookId, TenantScope scope) {
+        loadProject(projectId, scope);
         AlertWebhook webhook = webhookRepository
-                .findById(webhookId)
+                .findById(webhookId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Webhook not found: " + webhookId));
         if (!webhook.getProject().getId().equals(projectId)) {
             throw new IllegalArgumentException("Webhook does not belong to project " + projectId);
@@ -112,12 +117,12 @@ public class AlertWebhookService {
         return webhook;
     }
 
-    private Project loadProject(UUID projectId) {
+    private Project loadProject(UUID projectId, TenantScope scope) {
         if (projectId == null) {
             throw new IllegalArgumentException("Project ID cannot be null");
         }
         return projectRepository
-                .findById(projectId)
+                .findById(projectId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Project not found: " + projectId));
     }
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/AlignmentService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/AlignmentService.java
@@ -8,6 +8,7 @@ import dev.dokimos.server.entity.ItemResult;
 import dev.dokimos.server.repository.AnnotationRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
 import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -50,11 +51,11 @@ public class AlignmentService {
      * @throws IllegalArgumentException if {@code runId} is null or the run does not exist
      */
     @Transactional(readOnly = true)
-    public AlignmentView getAlignment(UUID runId) {
+    public AlignmentView getAlignment(UUID runId, TenantScope scope) {
         if (runId == null) {
             throw new IllegalArgumentException("Run ID cannot be null");
         }
-        if (!runRepository.existsById(runId)) {
+        if (runRepository.findById(runId, scope).isEmpty()) {
             throw new IllegalArgumentException("Run not found: " + runId);
         }
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/AnnotationService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/AnnotationService.java
@@ -3,9 +3,12 @@ package dev.dokimos.server.service;
 import dev.dokimos.server.dto.v1.AnnotationRequest;
 import dev.dokimos.server.dto.v1.AnnotationView;
 import dev.dokimos.server.entity.Annotation;
+import dev.dokimos.server.entity.ExperimentRun;
 import dev.dokimos.server.entity.ItemResult;
 import dev.dokimos.server.repository.AnnotationRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
 import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,30 +19,41 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Service for human review annotations on run item results. Each item result holds at most one
  * annotation; {@link #upsert} creates it on first call and updates the same row thereafter.
+ *
+ * <p>The run-membership gate is tenant-scoped. {@link #requireItemResultInRun} loads the run through the
+ * scoped run finder rather than trusting the URL {@code runId}, so a tenant cannot annotate another
+ * tenant's item by presenting a (foreign-run, foreign-item) pair: the foreign run is invisible and the
+ * gate returns a 404.
  */
 @Service
 public class AnnotationService {
 
     private final AnnotationRepository annotationRepository;
     private final ItemResultRepository itemResultRepository;
+    private final ExperimentRunRepository runRepository;
 
-    public AnnotationService(AnnotationRepository annotationRepository, ItemResultRepository itemResultRepository) {
+    public AnnotationService(
+            AnnotationRepository annotationRepository,
+            ItemResultRepository itemResultRepository,
+            ExperimentRunRepository runRepository) {
         this.annotationRepository = annotationRepository;
         this.itemResultRepository = itemResultRepository;
+        this.runRepository = runRepository;
     }
 
     /**
-     * Creates or updates the single annotation for the given item result. The item result must exist
-     * and belong to the given run. On an existing annotation this overwrites its fields and stamps
-     * {@code updatedAt}; the {@code createdBy} principal is recorded only when the annotation is first
-     * created.
+     * Creates or updates the single annotation for the given item result. The run must be visible under
+     * the scope and the item result must belong to it. On an existing annotation this overwrites its
+     * fields and stamps {@code updatedAt}; the {@code createdBy} principal is recorded only when the
+     * annotation is first created. The new annotation is stamped with the run's tenant.
      *
-     * @throws IllegalArgumentException if the item result does not exist or does not belong to the run
-     *     (mapped to 404)
+     * @throws IllegalArgumentException if the run is not visible under the scope, or the item result does
+     *     not exist or does not belong to the run (mapped to 404)
      */
     @Transactional
-    public AnnotationView upsert(UUID runId, UUID itemResultId, AnnotationRequest req, String principalId) {
-        requireItemResultInRun(runId, itemResultId);
+    public AnnotationView upsert(
+            UUID runId, UUID itemResultId, AnnotationRequest req, String principalId, TenantScope scope) {
+        ExperimentRun run = requireItemResultInRun(runId, itemResultId, scope);
 
         Annotation annotation = annotationRepository
                 .findByItemResultId(itemResultId)
@@ -47,6 +61,7 @@ public class AnnotationService {
                     ItemResult itemResult = itemResultRepository.getReferenceById(itemResultId);
                     Annotation created = new Annotation(itemResult, req.verdict());
                     created.setCreatedBy(principalId);
+                    created.setTenantId(run.getTenantId());
                     return created;
                 });
 
@@ -59,14 +74,14 @@ public class AnnotationService {
     }
 
     /**
-     * Returns the annotation for the given run item result.
+     * Returns the annotation for the given run item result, scoped to the caller's tenant.
      *
-     * @throws IllegalArgumentException if the item result does not belong to the run, or has no
-     *     annotation (mapped to 404)
+     * @throws IllegalArgumentException if the run is not visible under the scope, the item result does
+     *     not belong to the run, or it has no annotation (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public AnnotationView get(UUID runId, UUID itemResultId) {
-        requireItemResultInRun(runId, itemResultId);
+    public AnnotationView get(UUID runId, UUID itemResultId, TenantScope scope) {
+        requireItemResultInRun(runId, itemResultId, scope);
         return annotationRepository
                 .findByItemResultId(itemResultId)
                 .map(AnnotationView::from)
@@ -78,11 +93,12 @@ public class AnnotationService {
      * Removes the annotation for the given run item result if one exists. No-op when the item result
      * is un-annotated.
      *
-     * @throws IllegalArgumentException if the item result does not belong to the run (mapped to 404)
+     * @throws IllegalArgumentException if the run is not visible under the scope or the item result does
+     *     not belong to the run (mapped to 404)
      */
     @Transactional
-    public void delete(UUID runId, UUID itemResultId) {
-        requireItemResultInRun(runId, itemResultId);
+    public void delete(UUID runId, UUID itemResultId, TenantScope scope) {
+        requireItemResultInRun(runId, itemResultId, scope);
         annotationRepository.deleteByItemResultId(itemResultId);
     }
 
@@ -94,12 +110,24 @@ public class AnnotationService {
         return map == null ? null : Collections.unmodifiableMap(new LinkedHashMap<>(map));
     }
 
-    private void requireItemResultInRun(UUID runId, UUID itemResultId) {
+    /**
+     * Loads the run through the tenant-scoped finder, then verifies the item result belongs to it. The
+     * scoped run load is the trust boundary: an item is reachable only through a run the caller can
+     * actually see, closing the circular gate where the URL {@code runId} was trusted without a tenant
+     * check.
+     *
+     * @return the loaded, visible run
+     */
+    private ExperimentRun requireItemResultInRun(UUID runId, UUID itemResultId, TenantScope scope) {
+        ExperimentRun run = runRepository
+                .findById(runId, scope)
+                .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
         ItemResult itemResult = itemResultRepository
                 .findById(itemResultId)
                 .orElseThrow(() -> new IllegalArgumentException("Item result not found: " + itemResultId));
         if (!itemResult.getRun().getId().equals(runId)) {
             throw new IllegalArgumentException("Item result " + itemResultId + " does not belong to run " + runId);
         }
+        return run;
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/AnnotationService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/AnnotationService.java
@@ -111,12 +111,8 @@ public class AnnotationService {
     }
 
     /**
-     * Loads the run through the tenant-scoped finder, then verifies the item result belongs to it. The
-     * scoped run load is the trust boundary: an item is reachable only through a run the caller can
-     * actually see, closing the circular gate where the URL {@code runId} was trusted without a tenant
-     * check.
-     *
-     * @return the loaded, visible run
+     * Loads the run through the scoped finder, then checks the item belongs to it. The scoped run load is
+     * the trust boundary: the URL {@code runId} alone is never trusted.
      */
     private ExperimentRun requireItemResultInRun(UUID runId, UUID itemResultId, TenantScope scope) {
         ExperimentRun run = runRepository

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/ComparisonSupport.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/ComparisonSupport.java
@@ -185,6 +185,7 @@ public class ComparisonSupport {
      * @param experiment the experiment the run must belong to
      * @param label      a human-readable label for the run, used in error messages
      * @param runRepository the run repository
+     * @param scope the tenant scope; a run of another tenant is invisible and surfaces as not found
      * @return the loaded run
      * @throws IllegalArgumentException if the run does not exist or belongs to another experiment
      */
@@ -192,12 +193,13 @@ public class ComparisonSupport {
             UUID runId,
             Experiment experiment,
             String label,
-            dev.dokimos.server.repository.ExperimentRunRepository runRepository) {
+            dev.dokimos.server.repository.ExperimentRunRepository runRepository,
+            dev.dokimos.server.tenant.TenantScope scope) {
         if (runId == null) {
             throw new IllegalArgumentException(label + " ID cannot be null");
         }
         ExperimentRun run = runRepository
-                .findById(runId)
+                .findById(runId, scope)
                 .orElseThrow(() -> new IllegalArgumentException(label + " not found: " + runId));
         UUID runExperimentId =
                 Optional.ofNullable(run.getExperiment()).map(Experiment::getId).orElse(null);

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/DatasetService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/DatasetService.java
@@ -13,6 +13,7 @@ import dev.dokimos.server.repository.DatasetItemRepository;
 import dev.dokimos.server.repository.DatasetRepository;
 import dev.dokimos.server.repository.DatasetVersionRepository;
 import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,39 +45,40 @@ public class DatasetService {
     }
 
     /**
-     * Creates a dataset with a globally unique name. Has no versions until {@link #createVersion} is
-     * called.
+     * Creates a dataset with a globally unique name, stamped with the scope's tenant. Has no versions
+     * until {@link #createVersion} is called.
      *
      * @throws IllegalStateException if a dataset with the same name already exists (mapped to 409)
      */
     @Transactional
-    public Dataset createDataset(String name, String description) {
+    public Dataset createDataset(String name, String description, TenantScope scope) {
         if (datasetRepository.existsByName(name)) {
             throw new IllegalStateException("Dataset already exists: " + name);
         }
-        return datasetRepository.save(new Dataset(name, description));
+        Dataset dataset = new Dataset(name, description);
+        dataset.setTenantId(scope.stampTenantId());
+        return datasetRepository.save(dataset);
     }
 
     /**
-     * Returns the dataset with the given name.
+     * Returns the dataset with the given name, visible under the scope.
      *
-     * @throws IllegalArgumentException if no such dataset exists (mapped to 404)
+     * @throws IllegalArgumentException if no such dataset exists under the scope (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public Dataset getDataset(String name) {
+    public Dataset getDataset(String name, TenantScope scope) {
         return datasetRepository
-                .findByName(name)
+                .findByName(name, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Dataset not found: " + name));
     }
 
     /**
-     * Returns dataset summaries with the latest version number and item count for each. Collapses
-     * to two queries (one for datasets, one for the latest version row per dataset) regardless of
-     * dataset count.
+     * Returns dataset summaries visible under the scope with the latest version number and item count
+     * for each. Collapses to two queries regardless of dataset count.
      */
     @Transactional(readOnly = true)
-    public List<DatasetSummary> listDatasets() {
-        List<Dataset> datasets = datasetRepository.findAll();
+    public List<DatasetSummary> listDatasets(TenantScope scope) {
+        List<Dataset> datasets = datasetRepository.findAllOrdered(scope);
         if (datasets.isEmpty()) {
             return List.of();
         }
@@ -106,8 +108,8 @@ public class DatasetService {
 
     /** Returns full dataset details including the version list, newest first. */
     @Transactional(readOnly = true)
-    public DatasetDetails getDatasetDetails(String name) {
-        Dataset dataset = getDataset(name);
+    public DatasetDetails getDatasetDetails(String name, TenantScope scope) {
+        Dataset dataset = getDataset(name, scope);
         List<DatasetDetails.VersionSummary> versions =
                 versionRepository.findByDatasetOrderByVersionDesc(dataset).stream()
                         .map(v -> new DatasetDetails.VersionSummary(
@@ -128,43 +130,46 @@ public class DatasetService {
     }
 
     /**
-     * Deletes a dataset. The FK cascade removes its versions and items; runs that referenced any of
-     * those versions have their {@code dataset_version_id} set to NULL via the SET NULL FK so the
-     * historical run is preserved unlinked.
+     * Deletes a dataset visible under the scope. The FK cascade removes its versions and items; runs
+     * that referenced any of those versions have their {@code dataset_version_id} set to NULL via the
+     * SET NULL FK so the historical run is preserved unlinked.
      *
-     * @throws IllegalArgumentException if no such dataset exists (mapped to 404)
+     * @throws IllegalArgumentException if no such dataset exists under the scope (mapped to 404)
      */
     @Transactional
-    public void deleteDataset(String name) {
-        Dataset dataset = getDataset(name);
+    public void deleteDataset(String name, TenantScope scope) {
+        Dataset dataset = getDataset(name, scope);
         datasetRepository.delete(dataset);
     }
 
     /**
-     * Creates a new immutable version of the dataset and inserts all items in one transaction. The
-     * pessimistic write lock on the parent dataset row serializes concurrent version creations so the
-     * {@code next = max(version) + 1} read is consistent; the {@code (dataset_id, version)} unique
-     * constraint is the backstop if the lock is bypassed. Item ordinals follow the input order
-     * (0..N-1).
+     * Creates a new immutable version of the dataset visible under the scope and inserts all items in
+     * one transaction. The version and its items are stamped from the dataset's tenant so a scoped
+     * parent and child query agree. The pessimistic write lock on the parent dataset row serializes
+     * concurrent version creations.
      *
-     * @throws IllegalArgumentException if no such dataset exists or items is empty (the latter is
-     *     also caught by bean validation, but the service enforces it for non-controller callers)
+     * @throws IllegalArgumentException if no such dataset exists under the scope or items is empty
      */
     @Transactional
     public DatasetVersion createVersion(
-            String datasetName, String description, List<CreateVersionRequest.ItemPayload> items, String createdBy) {
+            String datasetName,
+            String description,
+            List<CreateVersionRequest.ItemPayload> items,
+            String createdBy,
+            TenantScope scope) {
         if (items == null || items.isEmpty()) {
             throw new IllegalArgumentException("Dataset version must contain at least one item");
         }
 
         Dataset dataset = datasetRepository
-                .findByNameForUpdate(datasetName)
+                .findByNameForUpdate(datasetName, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Dataset not found: " + datasetName));
 
         Integer currentMax = versionRepository.findMaxVersion(dataset);
         int nextVersion = currentMax == null ? 1 : currentMax + 1;
 
         DatasetVersion version = new DatasetVersion(dataset, nextVersion, description, createdBy, items.size());
+        version.setTenantId(dataset.getTenantId());
         versionRepository.save(version);
 
         List<DatasetItem> rows = new ArrayList<>(items.size());
@@ -173,7 +178,10 @@ public class DatasetService {
             if (payload.inputs() == null) {
                 throw new IllegalArgumentException("Item " + i + " is missing required 'inputs'");
             }
-            rows.add(new DatasetItem(version, i, payload.inputs(), payload.expectedOutputs(), payload.metadata()));
+            DatasetItem datasetItem =
+                    new DatasetItem(version, i, payload.inputs(), payload.expectedOutputs(), payload.metadata());
+            datasetItem.setTenantId(dataset.getTenantId());
+            rows.add(datasetItem);
         }
         itemRepository.saveAll(rows);
 
@@ -184,21 +192,22 @@ public class DatasetService {
     }
 
     /**
-     * Promotes run item results into a new version of an existing dataset. Each item's inputs become
-     * the new dataset item's inputs, its metadata is carried over, and its expected output is used
-     * unless the request supplies an override. Item order is preserved. Delegates to {@link
-     * #createVersion} so the version-numbering and locking semantics are identical to a direct create.
+     * Promotes run item results into a new version of an existing dataset. Each referenced item result
+     * must be visible under the scope, so a tenant cannot promote another tenant's items. Delegates to
+     * {@link #createVersion} so the version-numbering and locking semantics are identical to a direct
+     * create.
      *
-     * @throws IllegalArgumentException if any referenced item result or the dataset is missing (mapped
-     *     to 404)
+     * @throws IllegalArgumentException if any referenced item result or the dataset is missing or not
+     *     visible under the scope (mapped to 404)
      */
     @Transactional
-    public DatasetVersionDetails promote(PromoteRequest req, String createdBy) {
+    public DatasetVersionDetails promote(PromoteRequest req, String createdBy, TenantScope scope) {
         List<CreateVersionRequest.ItemPayload> payloads =
                 new ArrayList<>(req.items().size());
         for (PromoteRequest.PromoteItem item : req.items()) {
             ItemResult itemResult = itemResultRepository
                     .findById(item.itemResultId())
+                    .filter(loaded -> visibleUnder(loaded, scope))
                     .orElseThrow(() -> new IllegalArgumentException("Item result not found: " + item.itemResultId()));
 
             Map<String, Object> expectedOutputs = item.overriddenExpectedOutput() != null
@@ -209,7 +218,7 @@ public class DatasetService {
                     itemResult.getInput(), expectedOutputs, itemResult.getMetadata()));
         }
 
-        DatasetVersion version = createVersion(req.datasetName(), req.description(), payloads, createdBy);
+        DatasetVersion version = createVersion(req.datasetName(), req.description(), payloads, createdBy, scope);
         return new DatasetVersionDetails(
                 version.getId(),
                 req.datasetName(),
@@ -221,13 +230,26 @@ public class DatasetService {
     }
 
     /**
-     * Returns a specific version of the dataset.
+     * Returns whether an item result is visible under the scope, applying the same own-plus-shared rule
+     * the scoped repositories use. Used by {@code promote}, whose item lookup is by id straight from the
+     * request and therefore must be tenant checked.
+     */
+    private static boolean visibleUnder(ItemResult item, TenantScope scope) {
+        if (!scope.restricted()) {
+            return true;
+        }
+        String tenant = item.getTenantId();
+        return tenant == null || tenant.equals(scope.tenantId());
+    }
+
+    /**
+     * Returns a specific version of the dataset, visible under the scope.
      *
-     * @throws IllegalArgumentException if the dataset or version is missing
+     * @throws IllegalArgumentException if the dataset or version is missing under the scope
      */
     @Transactional(readOnly = true)
-    public DatasetVersion getVersion(String datasetName, int version) {
-        Dataset dataset = getDataset(datasetName);
+    public DatasetVersion getVersion(String datasetName, int version, TenantScope scope) {
+        Dataset dataset = getDataset(datasetName, scope);
         return versionRepository
                 .findByDatasetAndVersion(dataset, version)
                 .orElseThrow(() ->
@@ -235,13 +257,13 @@ public class DatasetService {
     }
 
     /**
-     * Returns the latest version of the dataset.
+     * Returns the latest version of the dataset, visible under the scope.
      *
-     * @throws IllegalArgumentException if the dataset has no versions
+     * @throws IllegalArgumentException if the dataset has no versions under the scope
      */
     @Transactional(readOnly = true)
-    public DatasetVersion getLatestVersion(String datasetName) {
-        Dataset dataset = getDataset(datasetName);
+    public DatasetVersion getLatestVersion(String datasetName, TenantScope scope) {
+        Dataset dataset = getDataset(datasetName, scope);
         return versionRepository
                 .findFirstByDatasetOrderByVersionDesc(dataset)
                 .orElseThrow(() -> new IllegalArgumentException("Dataset has no versions: " + datasetName));
@@ -249,8 +271,8 @@ public class DatasetService {
 
     /** Returns items for the given version ordered by ordinal, paginated. */
     @Transactional(readOnly = true)
-    public Page<DatasetItem> listItems(String datasetName, int version, Pageable pageable) {
-        DatasetVersion datasetVersion = getVersion(datasetName, version);
+    public Page<DatasetItem> listItems(String datasetName, int version, Pageable pageable, TenantScope scope) {
+        DatasetVersion datasetVersion = getVersion(datasetName, version, scope);
         return listItems(datasetVersion, pageable);
     }
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/DatasetService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/DatasetService.java
@@ -230,11 +230,7 @@ public class DatasetService {
                 version.getCreatedBy());
     }
 
-    /**
-     * Returns whether an item result is visible under the scope, applying the same own-plus-shared rule
-     * the scoped repositories use. Used by {@code promote}, whose item lookup is by id straight from the
-     * request and therefore must be tenant checked.
-     */
+    /** Applies the own-plus-shared rule to an item looked up by id from the request, so {@code promote} stays scoped. */
     private static boolean visibleUnder(ItemResult item, TenantScope scope) {
         if (!scope.restricted()) {
             return true;

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/DatasetService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/DatasetService.java
@@ -45,14 +45,15 @@ public class DatasetService {
     }
 
     /**
-     * Creates a dataset with a globally unique name, stamped with the scope's tenant. Has no versions
-     * until {@link #createVersion} is called.
+     * Creates a dataset whose name is unique within the scope, stamped with the scope's tenant. Has no
+     * versions until {@link #createVersion} is called.
      *
-     * @throws IllegalStateException if a dataset with the same name already exists (mapped to 409)
+     * @throws IllegalStateException if a dataset with the same name already exists in the scope (mapped
+     *     to 409)
      */
     @Transactional
     public Dataset createDataset(String name, String description, TenantScope scope) {
-        if (datasetRepository.existsByName(name)) {
+        if (datasetRepository.existsByName(name, scope)) {
             throw new IllegalStateException("Dataset already exists: " + name);
         }
         Dataset dataset = new Dataset(name, description);

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/DiffService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/DiffService.java
@@ -13,6 +13,7 @@ import dev.dokimos.server.entity.ExperimentRun;
 import dev.dokimos.server.entity.ItemResult;
 import dev.dokimos.server.repository.ExperimentRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -80,15 +81,20 @@ public class DiffService {
      */
     @Transactional(readOnly = true)
     public DiffView listDiff(
-            UUID experimentId, UUID candidateRunId, UUID baselineRunId, String statusFilter, Pageable pageable) {
+            UUID experimentId,
+            UUID candidateRunId,
+            UUID baselineRunId,
+            String statusFilter,
+            Pageable pageable,
+            TenantScope scope) {
         StatusFilter filter = StatusFilter.parse(statusFilter);
 
-        Experiment experiment = getExperiment(experimentId);
+        Experiment experiment = getExperiment(experimentId, scope);
         ExperimentRun candidate =
-                comparisonSupport.getRunInExperiment(candidateRunId, experiment, "Candidate run", runRepository);
+                comparisonSupport.getRunInExperiment(candidateRunId, experiment, "Candidate run", runRepository, scope);
         comparisonSupport.requireTerminal(candidate, "Candidate run");
         ExperimentRun baseline =
-                comparisonSupport.getRunInExperiment(baselineRunId, experiment, "Baseline run", runRepository);
+                comparisonSupport.getRunInExperiment(baselineRunId, experiment, "Baseline run", runRepository, scope);
         comparisonSupport.requireTerminal(baseline, "Baseline run");
 
         ComparisonSupport.ComparisonOutcome outcome = comparisonSupport.compare(baseline, candidate);
@@ -202,12 +208,12 @@ public class DiffService {
         return new org.springframework.data.domain.PageImpl<>(content, pageable, cases.size());
     }
 
-    private Experiment getExperiment(UUID experimentId) {
+    private Experiment getExperiment(UUID experimentId, TenantScope scope) {
         if (experimentId == null) {
             throw new IllegalArgumentException("Experiment ID cannot be null");
         }
         return experimentRepository
-                .findById(experimentId)
+                .findById(experimentId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Experiment not found: " + experimentId));
     }
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/EvalJobService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/EvalJobService.java
@@ -9,6 +9,7 @@ import dev.dokimos.server.entity.RunStatus;
 import dev.dokimos.server.repository.EvalJobRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
 import dev.dokimos.server.repository.LlmConnectionRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -46,13 +47,13 @@ public class EvalJobService {
      * @throws IllegalStateException if the run already has a job for this evaluator (mapped to 409)
      */
     @Transactional
-    public EvalJobView enqueue(UUID runId, EnqueueJudgeRequest request) {
+    public EvalJobView enqueue(UUID runId, EnqueueJudgeRequest request, TenantScope scope) {
         ExperimentRun run = runRepository
-                .findByIdForUpdate(runId)
+                .findByIdForUpdate(runId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
 
         LlmConnection connection = connectionRepository
-                .findById(request.connectionId())
+                .findById(request.connectionId(), scope)
                 .orElseThrow(() -> new IllegalArgumentException("Connection not found: " + request.connectionId()));
 
         if (jobRepository.existsByRunAndEvaluatorName(run, request.evaluatorName())) {
@@ -79,9 +80,9 @@ public class EvalJobService {
      * @throws IllegalArgumentException if the run does not exist (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public List<EvalJobView> getJobsForRun(UUID runId) {
+    public List<EvalJobView> getJobsForRun(UUID runId, TenantScope scope) {
         ExperimentRun run = runRepository
-                .findById(runId)
+                .findById(runId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
         return jobRepository.findByRunOrderByCreatedAtAsc(run).stream()
                 .map(EvalJobView::from)

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/ExperimentService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/ExperimentService.java
@@ -8,7 +8,7 @@ import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.entity.RunStatus;
 import dev.dokimos.server.repository.ExperimentRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
-import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,34 +23,41 @@ public class ExperimentService {
 
     private final ExperimentRepository experimentRepository;
     private final ExperimentRunRepository runRepository;
-    private final ItemResultRepository itemResultRepository;
 
-    public ExperimentService(
-            ExperimentRepository experimentRepository,
-            ExperimentRunRepository runRepository,
-            ItemResultRepository itemResultRepository) {
+    public ExperimentService(ExperimentRepository experimentRepository, ExperimentRunRepository runRepository) {
         this.experimentRepository = experimentRepository;
         this.runRepository = runRepository;
-        this.itemResultRepository = itemResultRepository;
     }
 
+    /**
+     * Resolves an experiment of the project by name within the scope, creating it stamped with the
+     * scope's tenant when absent. The parent project was already loaded scoped, so this never reaches a
+     * foreign tenant.
+     *
+     * @param project the owning project
+     * @param name the experiment name
+     * @param scope the tenant scope of the caller
+     * @return the existing or newly created experiment
+     */
     @Transactional
-    public Experiment getOrCreateExperiment(@NonNull Project project, @NonNull String name) {
-        return experimentRepository
-                .findByProjectAndName(project, name)
-                .orElseGet(() -> experimentRepository.save(new Experiment(project, name)));
+    public Experiment getOrCreateExperiment(@NonNull Project project, @NonNull String name, TenantScope scope) {
+        return experimentRepository.findByProjectAndName(project, name, scope).orElseGet(() -> {
+            Experiment experiment = new Experiment(project, name);
+            experiment.setTenantId(scope.stampTenantId());
+            return experimentRepository.save(experiment);
+        });
     }
 
     @Transactional(readOnly = true)
     @NonNull
-    public List<ExperimentSummary> listExperiments(Project project) {
-        List<Experiment> experiments = experimentRepository.findByProjectOrderByCreatedAtDesc(project);
+    public List<ExperimentSummary> listExperiments(Project project, TenantScope scope) {
+        List<Experiment> experiments = experimentRepository.findByProject(project, scope);
         List<ExperimentSummary> summaries = new ArrayList<>();
 
         for (Experiment experiment : experiments) {
             ExperimentSummary.LatestRunInfo latestRunInfo = null;
 
-            var latestRun = runRepository.findFirstByExperimentOrderByStartedAtDesc(experiment);
+            var latestRun = runRepository.findFirstByExperiment(experiment, scope);
             if (latestRun.isPresent()) {
                 ExperimentRun run = latestRun.get();
                 Double passRate = calculatePassRate(run);
@@ -66,26 +73,27 @@ public class ExperimentService {
     }
 
     @Transactional(readOnly = true)
-    public Experiment getExperiment(UUID experimentId) {
+    public Experiment getExperiment(UUID experimentId, TenantScope scope) {
         if (experimentId == null) {
             throw new IllegalArgumentException("Experiment ID cannot be null");
         }
         return experimentRepository
-                .findById(experimentId)
+                .findById(experimentId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Experiment not found: " + experimentId));
     }
 
-    /** Deletes an experiment; FKs cascade to its runs, items, and evals. */
+    /** Deletes an experiment visible under the scope; FKs cascade to its runs, items, and evals. */
     @Transactional
-    public void deleteExperiment(UUID experimentId) {
-        Experiment experiment = getExperiment(experimentId);
+    public void deleteExperiment(UUID experimentId, TenantScope scope) {
+        Experiment experiment = getExperiment(experimentId, scope);
         experimentRepository.delete(experiment);
     }
 
     @Transactional(readOnly = true)
-    public TrendData getTrends(UUID experimentId, int limit) {
-        Experiment experiment = getExperiment(experimentId);
-        List<ExperimentRun> runs = runRepository.findCompletedRunsByExperiment(experiment, PageRequest.of(0, limit));
+    public TrendData getTrends(UUID experimentId, int limit, TenantScope scope) {
+        Experiment experiment = getExperiment(experimentId, scope);
+        List<ExperimentRun> runs =
+                runRepository.findCompletedRunsByExperiment(experiment, PageRequest.of(0, limit), scope);
 
         List<TrendData.RunPoint> points = new ArrayList<>();
         for (ExperimentRun run : runs) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/GateService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/GateService.java
@@ -10,6 +10,7 @@ import dev.dokimos.server.entity.Experiment;
 import dev.dokimos.server.entity.ExperimentRun;
 import dev.dokimos.server.repository.ExperimentRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -67,14 +68,14 @@ public class GateService {
      *     (surfaces as 409)
      */
     @Transactional(readOnly = true)
-    public GateResult evaluateGate(UUID experimentId, GateRequest request) {
-        Experiment experiment = getExperiment(experimentId);
+    public GateResult evaluateGate(UUID experimentId, GateRequest request, TenantScope scope) {
+        Experiment experiment = getExperiment(experimentId, scope);
 
         ExperimentRun candidate = comparisonSupport.getRunInExperiment(
-                request.candidateRunId(), experiment, "Candidate run", runRepository);
+                request.candidateRunId(), experiment, "Candidate run", runRepository, scope);
         comparisonSupport.requireTerminal(candidate, "Candidate run");
 
-        ExperimentRun baseline = resolveBaseline(experiment, candidate, request);
+        ExperimentRun baseline = resolveBaseline(experiment, candidate, request, scope);
         if (baseline == null) {
             return noBaseline(candidate);
         }
@@ -83,10 +84,11 @@ public class GateService {
         return toGateResult(outcome.result(), candidate, baseline, outcome.pairing());
     }
 
-    private ExperimentRun resolveBaseline(Experiment experiment, ExperimentRun candidate, GateRequest request) {
+    private ExperimentRun resolveBaseline(
+            Experiment experiment, ExperimentRun candidate, GateRequest request, TenantScope scope) {
         if (request.baselineRunId() != null) {
             ExperimentRun baseline = comparisonSupport.getRunInExperiment(
-                    request.baselineRunId(), experiment, "Baseline run", runRepository);
+                    request.baselineRunId(), experiment, "Baseline run", runRepository, scope);
             comparisonSupport.requireTerminal(baseline, "Baseline run");
             return baseline;
         }
@@ -96,7 +98,8 @@ public class GateService {
                 candidate.getId(),
                 comparisonSupport.datasetVersionId(candidate),
                 request.baselineBranch(),
-                PageRequest.of(0, 1));
+                PageRequest.of(0, 1),
+                scope);
         return candidates.isEmpty() ? null : candidates.get(0);
     }
 
@@ -188,12 +191,12 @@ public class GateService {
         return cases;
     }
 
-    private Experiment getExperiment(UUID experimentId) {
+    private Experiment getExperiment(UUID experimentId, TenantScope scope) {
         if (experimentId == null) {
             throw new IllegalArgumentException("Experiment ID cannot be null");
         }
         return experimentRepository
-                .findById(experimentId)
+                .findById(experimentId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Experiment not found: " + experimentId));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/JudgeJobTransactions.java
@@ -111,6 +111,7 @@ public class JudgeJobTransactions {
     public void persistPage(UUID jobId, List<ScoredResult> results, UUID lastItemId) {
         for (ScoredResult scored : results) {
             ItemResult item = itemResultRepository.getReferenceById(scored.itemId());
+            scored.evalResult().setTenantId(item.getTenantId());
             item.addEvalResult(scored.evalResult());
             evalResultRepository.save(scored.evalResult());
         }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/LlmConnectionService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/LlmConnectionService.java
@@ -6,6 +6,7 @@ import dev.dokimos.server.dto.v1.UpdateLlmConnectionRequest;
 import dev.dokimos.server.entity.LlmConnection;
 import dev.dokimos.server.repository.EvalJobRepository;
 import dev.dokimos.server.repository.LlmConnectionRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -40,12 +41,13 @@ public class LlmConnectionService {
      * @throws IllegalStateException if a connection with the same name already exists (mapped to 409)
      */
     @Transactional
-    public LlmConnectionView create(CreateLlmConnectionRequest request) {
+    public LlmConnectionView create(CreateLlmConnectionRequest request, TenantScope scope) {
         if (connectionRepository.existsByName(request.name())) {
             throw new IllegalStateException("Connection already exists: " + request.name());
         }
 
         LlmConnection connection = new LlmConnection(request.name(), request.baseUrl(), request.model());
+        connection.setTenantId(scope.stampTenantId());
         if (request.protocol() != null) {
             connection.setProtocol(request.protocol());
         }
@@ -59,20 +61,20 @@ public class LlmConnectionService {
     }
 
     @Transactional(readOnly = true)
-    public List<LlmConnectionView> list() {
-        return connectionRepository.findAll().stream()
+    public List<LlmConnectionView> list(TenantScope scope) {
+        return connectionRepository.findAllOrdered(scope).stream()
                 .map(LlmConnectionView::from)
                 .toList();
     }
 
     /**
-     * Returns a connection by id.
+     * Returns a connection by id, visible under the scope.
      *
-     * @throws IllegalArgumentException if no connection has the id (mapped to 404)
+     * @throws IllegalArgumentException if no connection has the id under the scope (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public LlmConnectionView get(UUID id) {
-        return LlmConnectionView.from(loadConnection(id));
+    public LlmConnectionView get(UUID id, TenantScope scope) {
+        return LlmConnectionView.from(loadConnection(id, scope));
     }
 
     /**
@@ -88,8 +90,8 @@ public class LlmConnectionService {
      *     409)
      */
     @Transactional
-    public LlmConnectionView update(UUID id, UpdateLlmConnectionRequest request) {
-        LlmConnection connection = loadConnection(id);
+    public LlmConnectionView update(UUID id, UpdateLlmConnectionRequest request, TenantScope scope) {
+        LlmConnection connection = loadConnection(id, scope);
         if (!connection.getName().equals(request.name()) && connectionRepository.existsByName(request.name())) {
             throw new IllegalStateException("Connection already exists: " + request.name());
         }
@@ -118,15 +120,15 @@ public class LlmConnectionService {
      * @throws IllegalArgumentException if no connection has the id (mapped to 404)
      */
     @Transactional
-    public void delete(UUID id) {
-        LlmConnection connection = loadConnection(id);
+    public void delete(UUID id, TenantScope scope) {
+        LlmConnection connection = loadConnection(id, scope);
         evalJobRepository.deleteByConnectionId(id);
         connectionRepository.delete(connection);
     }
 
-    private LlmConnection loadConnection(UUID id) {
+    private LlmConnection loadConnection(UUID id, TenantScope scope) {
         return connectionRepository
-                .findById(id)
+                .findById(id, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Connection not found: " + id));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/LlmConnectionService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/LlmConnectionService.java
@@ -42,7 +42,7 @@ public class LlmConnectionService {
      */
     @Transactional
     public LlmConnectionView create(CreateLlmConnectionRequest request, TenantScope scope) {
-        if (connectionRepository.existsByName(request.name())) {
+        if (connectionRepository.existsByName(request.name(), scope)) {
             throw new IllegalStateException("Connection already exists: " + request.name());
         }
 
@@ -92,7 +92,7 @@ public class LlmConnectionService {
     @Transactional
     public LlmConnectionView update(UUID id, UpdateLlmConnectionRequest request, TenantScope scope) {
         LlmConnection connection = loadConnection(id, scope);
-        if (!connection.getName().equals(request.name()) && connectionRepository.existsByName(request.name())) {
+        if (!connection.getName().equals(request.name()) && connectionRepository.existsByName(request.name(), scope)) {
             throw new IllegalStateException("Connection already exists: " + request.name());
         }
         connection.setName(request.name());

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/ProjectService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/ProjectService.java
@@ -3,6 +3,7 @@ package dev.dokimos.server.service;
 import dev.dokimos.server.dto.v1.ProjectSummary;
 import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.repository.ProjectRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.lang.NonNull;
@@ -18,16 +19,28 @@ public class ProjectService {
         this.projectRepository = projectRepository;
     }
 
+    /**
+     * Resolves the project by name within the scope, creating it stamped with the scope's tenant when it
+     * does not exist. The lookup is scoped so two tenants can each own a project of the same name; a new
+     * row is stamped from the scope so it lands in the caller's tenant.
+     *
+     * @param name the project name
+     * @param scope the tenant scope of the caller
+     * @return the existing or newly created project
+     */
     @Transactional
     @NonNull
-    public Project getOrCreateProject(String name) {
-        return Objects.requireNonNull(
-                projectRepository.findByName(name).orElseGet(() -> projectRepository.save(new Project(name))));
+    public Project getOrCreateProject(String name, TenantScope scope) {
+        return Objects.requireNonNull(projectRepository.findByName(name, scope).orElseGet(() -> {
+            Project project = new Project(name);
+            project.setTenantId(scope.stampTenantId());
+            return projectRepository.save(project);
+        }));
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectSummary> listProjects() {
-        return projectRepository.findAllWithExperimentCount().stream()
+    public List<ProjectSummary> listProjects(TenantScope scope) {
+        return projectRepository.findAllWithExperimentCount(scope).stream()
                 .map(row -> {
                     Project project = (Project) row[0];
                     long count = (Long) row[1];
@@ -38,16 +51,16 @@ public class ProjectService {
 
     @Transactional(readOnly = true)
     @NonNull
-    public Project getProject(String name) {
+    public Project getProject(String name, TenantScope scope) {
         return Objects.requireNonNull(projectRepository
-                .findByName(name)
+                .findByName(name, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Project not found: " + name)));
     }
 
-    /** Deletes a project; FKs cascade to its experiments, runs, items, and evals. */
+    /** Deletes a project visible under the scope; FKs cascade to its experiments, runs, items, and evals. */
     @Transactional
-    public void deleteProject(String name) {
-        Project project = getProject(name);
+    public void deleteProject(String name, TenantScope scope) {
+        Project project = getProject(name, scope);
         projectRepository.delete(project);
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RegressionAlertService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RegressionAlertService.java
@@ -76,7 +76,8 @@ public class RegressionAlertService {
                 candidate.getId(),
                 comparisonSupport.datasetVersionId(candidate),
                 candidate.getGitBranch(),
-                PageRequest.of(0, 1));
+                PageRequest.of(0, 1),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
         return candidates.isEmpty() ? null : candidates.get(0);
     }
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/ReviewQueueService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/ReviewQueueService.java
@@ -9,6 +9,7 @@ import dev.dokimos.server.entity.ExperimentRun;
 import dev.dokimos.server.entity.ItemResult;
 import dev.dokimos.server.repository.AnnotationRepository;
 import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,11 +44,14 @@ public class ReviewQueueService {
      * @param experimentId restrict to this experiment, or null for any
      * @param runId        restrict to this run, or null for any
      * @param pageable     the page to return
+     * @param scope        the tenant scope the caller reads under
      * @return the page of review items
      */
     @Transactional(readOnly = true)
-    public Page<ReviewQueueItem> list(String projectName, UUID experimentId, UUID runId, Pageable pageable) {
-        Page<ItemResult> page = itemResultRepository.findItemsNeedingReview(projectName, experimentId, runId, pageable);
+    public Page<ReviewQueueItem> list(
+            String projectName, UUID experimentId, UUID runId, Pageable pageable, TenantScope scope) {
+        Page<ItemResult> page = itemResultRepository.findItemsNeedingReview(
+                projectName, experimentId, runId, scope.restricted(), scope.tenantId(), pageable);
 
         Map<UUID, AnnotationVerdict> verdictByItem = new HashMap<>();
         List<ItemResult> items = page.getContent();

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
@@ -130,11 +130,9 @@ public class RunService {
             return;
         }
 
-        // Batch-load the referenced dataset items in one query rather than a PK select per item.
-        // A stale id (its dataset version was deleted between resolve and report) is simply absent
-        // from the map: the FK is SET NULL, so an unlinked result is a valid point-in-time record,
-        // not a reason to fail the whole batch. An id of another tenant is dropped the same way, so a
-        // caller cannot link its run items to a dataset item it cannot see.
+        // A stale id (version deleted between resolve and report) or a foreign-tenant id is simply absent
+        // from the map: the FK is SET NULL, so an unlinked result is a valid point-in-time record and the
+        // batch is not failed, and a caller cannot link to a dataset item it cannot see.
         Map<UUID, DatasetItem> datasetItemsById = loadDatasetItems(request.items(), scope);
 
         List<ItemResult> items = new ArrayList<>(request.items().size());
@@ -407,11 +405,7 @@ public class RunService {
         return byId;
     }
 
-    /**
-     * Returns whether a dataset item is visible under the scope, applying the same own-plus-shared rule
-     * the scoped repositories use. The {@code datasetItemId} comes straight from the request body, so an
-     * item of another tenant must be filtered out before it is linked.
-     */
+    /** Applies the own-plus-shared rule to a dataset item id from the request body, before it is linked. */
     private static boolean visibleUnder(DatasetItem datasetItem, TenantScope scope) {
         if (!scope.restricted()) {
             return true;

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
@@ -133,8 +133,9 @@ public class RunService {
         // Batch-load the referenced dataset items in one query rather than a PK select per item.
         // A stale id (its dataset version was deleted between resolve and report) is simply absent
         // from the map: the FK is SET NULL, so an unlinked result is a valid point-in-time record,
-        // not a reason to fail the whole batch.
-        Map<UUID, DatasetItem> datasetItemsById = loadDatasetItems(request.items());
+        // not a reason to fail the whole batch. An id of another tenant is dropped the same way, so a
+        // caller cannot link its run items to a dataset item it cannot see.
+        Map<UUID, DatasetItem> datasetItemsById = loadDatasetItems(request.items(), scope);
 
         List<ItemResult> items = new ArrayList<>(request.items().size());
         for (AddItemsRequest.ItemData itemData : request.items()) {
@@ -388,7 +389,7 @@ public class RunService {
                 run.getAvgLatencyMs());
     }
 
-    private Map<UUID, DatasetItem> loadDatasetItems(List<AddItemsRequest.ItemData> items) {
+    private Map<UUID, DatasetItem> loadDatasetItems(List<AddItemsRequest.ItemData> items, TenantScope scope) {
         List<UUID> ids = items.stream()
                 .map(AddItemsRequest.ItemData::datasetItemId)
                 .filter(java.util.Objects::nonNull)
@@ -399,9 +400,24 @@ public class RunService {
         }
         Map<UUID, DatasetItem> byId = new java.util.HashMap<>();
         for (DatasetItem datasetItem : datasetItemRepository.findAllById(ids)) {
-            byId.put(datasetItem.getId(), datasetItem);
+            if (visibleUnder(datasetItem, scope)) {
+                byId.put(datasetItem.getId(), datasetItem);
+            }
         }
         return byId;
+    }
+
+    /**
+     * Returns whether a dataset item is visible under the scope, applying the same own-plus-shared rule
+     * the scoped repositories use. The {@code datasetItemId} comes straight from the request body, so an
+     * item of another tenant must be filtered out before it is linked.
+     */
+    private static boolean visibleUnder(DatasetItem datasetItem, TenantScope scope) {
+        if (!scope.restricted()) {
+            return true;
+        }
+        String tenant = datasetItem.getTenantId();
+        return tenant == null || tenant.equals(scope.tenantId());
     }
 
     private RunDetails.ItemSummary toItemSummary(ItemResult item, AnnotationView annotation) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/RunService.java
@@ -20,6 +20,7 @@ import dev.dokimos.server.repository.DatasetItemRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
 import dev.dokimos.server.repository.IngestedBatchRepository;
 import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -66,6 +67,7 @@ public class RunService {
     @Transactional
     public ExperimentRun createRun(Experiment experiment, Map<String, Object> config) {
         ExperimentRun run = new ExperimentRun(experiment, config);
+        run.setTenantId(experiment.getTenantId());
         return runRepository.save(run);
     }
 
@@ -79,14 +81,15 @@ public class RunService {
      *     supplied, or if the referenced dataset version does not exist
      */
     @Transactional
-    public ExperimentRun createRun(Experiment experiment, CreateRunRequest request) {
+    public ExperimentRun createRun(Experiment experiment, CreateRunRequest request, TenantScope scope) {
         ExperimentRun run = new ExperimentRun(experiment, request.metadata());
         run.setName(request.name());
         run.setGitSha(request.gitSha());
         run.setGitBranch(request.gitBranch());
         run.setTriggeredBy(request.triggeredBy());
+        run.setTenantId(experiment.getTenantId());
 
-        DatasetVersion datasetVersion = resolveDatasetVersion(request);
+        DatasetVersion datasetVersion = resolveDatasetVersion(request, scope);
         if (datasetVersion != null) {
             run.setDatasetVersion(datasetVersion);
         }
@@ -94,7 +97,7 @@ public class RunService {
         return runRepository.save(run);
     }
 
-    private DatasetVersion resolveDatasetVersion(CreateRunRequest request) {
+    private DatasetVersion resolveDatasetVersion(CreateRunRequest request, TenantScope scope) {
         boolean hasName =
                 request.datasetName() != null && !request.datasetName().isBlank();
         boolean hasVersion = request.datasetVersion() != null;
@@ -104,7 +107,7 @@ public class RunService {
         if (!hasName) {
             return null;
         }
-        return datasetService.getVersion(request.datasetName(), request.datasetVersion());
+        return datasetService.getVersion(request.datasetName(), request.datasetVersion(), scope);
     }
 
     /**
@@ -117,8 +120,8 @@ public class RunService {
      * @throws IllegalStateException if the run is not RUNNING
      */
     @Transactional
-    public void addItems(UUID runId, AddItemsRequest request, String idempotencyKey) {
-        ExperimentRun run = getRunForUpdate(runId);
+    public void addItems(UUID runId, AddItemsRequest request, String idempotencyKey, TenantScope scope) {
+        ExperimentRun run = getRunForUpdate(runId, scope);
         if (run.getStatus() != RunStatus.RUNNING) {
             throw new IllegalStateException("Cannot add items to a run that is not RUNNING: " + runId);
         }
@@ -137,6 +140,7 @@ public class RunService {
         for (AddItemsRequest.ItemData itemData : request.items()) {
             ItemResult item = new ItemResult(
                     run, itemData.inputs(), itemData.expectedOutputs(), itemData.actualOutputs(), itemData.metadata());
+            item.setTenantId(run.getTenantId());
 
             item.setTokensIn(itemData.tokensIn());
             item.setTokensOut(itemData.tokensOut());
@@ -164,6 +168,7 @@ public class RunService {
                             evalData.success(),
                             evalData.reason());
                     eval.setMetadata(evalData.metadata());
+                    eval.setTenantId(run.getTenantId());
                     item.addEvalResult(eval);
                 }
             }
@@ -178,10 +183,10 @@ public class RunService {
         }
     }
 
-    /** Deletes a run; FKs cascade to its item and eval results. */
+    /** Deletes a run visible under the scope; FKs cascade to its item and eval results. */
     @Transactional
-    public void deleteRun(UUID runId) {
-        ExperimentRun run = getRun(runId);
+    public void deleteRun(UUID runId, TenantScope scope) {
+        ExperimentRun run = getRun(runId, scope);
         runRepository.delete(run);
     }
 
@@ -191,8 +196,8 @@ public class RunService {
      * {@link #addItems} batch commits.
      */
     @Transactional
-    public void updateRun(UUID runId, UpdateRunRequest request) {
-        ExperimentRun run = getRunForUpdate(runId);
+    public void updateRun(UUID runId, UpdateRunRequest request, TenantScope scope) {
+        ExperimentRun run = getRunForUpdate(runId, scope);
         if (run.getStatus() == RunStatus.EVALUATING) {
             throw new IllegalStateException(
                     "Run " + runId + " is evaluating; its status is managed by the judge worker");
@@ -218,7 +223,7 @@ public class RunService {
      */
     @Transactional
     public void finalizeEvaluatedRun(UUID runId) {
-        ExperimentRun run = getRunForUpdate(runId);
+        ExperimentRun run = getRunForUpdate(runId, TenantScope.unrestricted());
         if (run.getStatus() != RunStatus.EVALUATING) {
             return;
         }
@@ -238,7 +243,7 @@ public class RunService {
      */
     @Transactional
     public void failEvaluatedRun(UUID runId) {
-        ExperimentRun run = getRunForUpdate(runId);
+        ExperimentRun run = getRunForUpdate(runId, TenantScope.unrestricted());
         if (run.getStatus() != RunStatus.EVALUATING) {
             return;
         }
@@ -262,14 +267,14 @@ public class RunService {
     }
 
     @Transactional(readOnly = true)
-    public List<RunSummary> listRuns(Experiment experiment) {
-        List<ExperimentRun> runs = runRepository.findByExperimentOrderByStartedAtDesc(experiment);
+    public List<RunSummary> listRuns(Experiment experiment, TenantScope scope) {
+        List<ExperimentRun> runs = runRepository.findByExperiment(experiment, scope);
         return runs.stream().map(this::toRunSummary).toList();
     }
 
     @Transactional(readOnly = true)
-    public RunDetails getRunDetails(UUID runId, Pageable pageable) {
-        ExperimentRun run = getRun(runId);
+    public RunDetails getRunDetails(UUID runId, Pageable pageable, TenantScope scope) {
+        ExperimentRun run = getRun(runId, scope);
         Experiment experiment = run.getExperiment();
         RunMetrics metrics = computeMetrics(run);
 
@@ -303,19 +308,21 @@ public class RunService {
                 itemSummaries);
     }
 
-    private ExperimentRun getRun(UUID runId) {
-        if (runId == null) {
-            throw new IllegalArgumentException("Run ID cannot be null");
-        }
-        return runRepository.findById(runId).orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
-    }
-
-    private ExperimentRun getRunForUpdate(UUID runId) {
+    private ExperimentRun getRun(UUID runId, TenantScope scope) {
         if (runId == null) {
             throw new IllegalArgumentException("Run ID cannot be null");
         }
         return runRepository
-                .findByIdForUpdate(runId)
+                .findById(runId, scope)
+                .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
+    }
+
+    private ExperimentRun getRunForUpdate(UUID runId, TenantScope scope) {
+        if (runId == null) {
+            throw new IllegalArgumentException("Run ID cannot be null");
+        }
+        return runRepository
+                .findByIdForUpdate(runId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Run not found: " + runId));
     }
 

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/TraceEvalRuleService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/TraceEvalRuleService.java
@@ -3,11 +3,13 @@ package dev.dokimos.server.service;
 import dev.dokimos.server.dto.v1.CreateTraceEvalRuleRequest;
 import dev.dokimos.server.dto.v1.TraceEvalRuleView;
 import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.entity.TraceEvalRule;
 import dev.dokimos.server.entity.TraceMatchType;
 import dev.dokimos.server.repository.LlmConnectionRepository;
 import dev.dokimos.server.repository.ProjectRepository;
 import dev.dokimos.server.repository.TraceEvalRuleRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -16,7 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Manages per-project trace eval rules. A rule names what to match (span name or attribute key/value)
  * and the judge configuration plus connection used to score matching spans. Rule names are unique within
- * a project.
+ * a project. Every load is tenant-scoped so a cross-tenant id surfaces as a 404, and a new rule is
+ * stamped with its owning project's tenant.
  */
 @Service
 public class TraceEvalRuleService {
@@ -35,22 +38,24 @@ public class TraceEvalRuleService {
     }
 
     /**
-     * Creates a rule for a project.
+     * Creates a rule for a project, stamped with the project's tenant.
      *
      * @param projectId the owning project
-     * @param request   the rule definition
+     * @param request the rule definition
+     * @param scope the tenant scope of the caller
      * @return the public view of the created rule
-     * @throws IllegalArgumentException if the project or connection does not exist (mapped to 404)
+     * @throws IllegalArgumentException if the project or connection does not exist under the scope
+     *     (mapped to 404)
      * @throws IllegalStateException if a rule with the same name already exists in the project (mapped to
      *     409)
      */
     @Transactional
-    public TraceEvalRuleView create(UUID projectId, CreateTraceEvalRuleRequest request) {
-        requireProject(projectId);
-        if (ruleRepository.existsByProjectIdAndName(projectId, request.name())) {
+    public TraceEvalRuleView create(UUID projectId, CreateTraceEvalRuleRequest request, TenantScope scope) {
+        Project project = requireProject(projectId, scope);
+        if (ruleRepository.existsByProjectIdAndName(projectId, request.name(), scope)) {
             throw new IllegalStateException("A trace eval rule named '" + request.name() + "' already exists");
         }
-        LlmConnection connection = loadConnection(request.connectionId());
+        LlmConnection connection = loadConnection(request.connectionId(), scope);
 
         TraceEvalRule rule = new TraceEvalRule(
                 projectId,
@@ -60,19 +65,20 @@ public class TraceEvalRuleService {
                 connection,
                 request.evaluatorName(),
                 request.criteria());
+        rule.setTenantId(project.getTenantId());
         applyEditable(rule, request);
         return TraceEvalRuleView.from(ruleRepository.save(rule));
     }
 
     /**
-     * Lists the rules of a project, oldest first.
+     * Lists the rules of a project, oldest first, within the scope.
      *
-     * @throws IllegalArgumentException if the project does not exist (mapped to 404)
+     * @throws IllegalArgumentException if the project does not exist under the scope (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public List<TraceEvalRuleView> list(UUID projectId) {
-        requireProject(projectId);
-        return ruleRepository.findByProjectIdOrderByCreatedAtAsc(projectId).stream()
+    public List<TraceEvalRuleView> list(UUID projectId, TenantScope scope) {
+        requireProject(projectId, scope);
+        return ruleRepository.findByProjectId(projectId, scope).stream()
                 .map(TraceEvalRuleView::from)
                 .toList();
     }
@@ -80,22 +86,24 @@ public class TraceEvalRuleService {
     /**
      * Replaces a rule's definition.
      *
-     * @throws IllegalArgumentException if the rule, project, or connection does not exist (mapped to 404)
+     * @throws IllegalArgumentException if the rule, project, or connection does not exist under the scope
+     *     (mapped to 404)
      * @throws IllegalStateException if the new name collides with another rule in the project (mapped to
      *     409)
      */
     @Transactional
-    public TraceEvalRuleView update(UUID projectId, UUID ruleId, CreateTraceEvalRuleRequest request) {
-        requireProject(projectId);
-        TraceEvalRule rule = loadRule(projectId, ruleId);
+    public TraceEvalRuleView update(
+            UUID projectId, UUID ruleId, CreateTraceEvalRuleRequest request, TenantScope scope) {
+        requireProject(projectId, scope);
+        TraceEvalRule rule = loadRule(projectId, ruleId, scope);
         if (!rule.getName().equals(request.name())
-                && ruleRepository.existsByProjectIdAndName(projectId, request.name())) {
+                && ruleRepository.existsByProjectIdAndName(projectId, request.name(), scope)) {
             throw new IllegalStateException("A trace eval rule named '" + request.name() + "' already exists");
         }
         rule.setName(request.name());
         rule.setMatchType(request.matchType());
         rule.setMatchValue(request.matchValue());
-        rule.setConnection(loadConnection(request.connectionId()));
+        rule.setConnection(loadConnection(request.connectionId(), scope));
         rule.setEvaluatorName(request.evaluatorName());
         rule.setCriteria(request.criteria());
         applyEditable(rule, request);
@@ -106,12 +114,13 @@ public class TraceEvalRuleService {
     /**
      * Deletes a rule. Its enqueued jobs cascade away via the foreign key.
      *
-     * @throws IllegalArgumentException if the rule or project does not exist (mapped to 404)
+     * @throws IllegalArgumentException if the rule or project does not exist under the scope (mapped to
+     *     404)
      */
     @Transactional
-    public void delete(UUID projectId, UUID ruleId) {
-        requireProject(projectId);
-        TraceEvalRule rule = loadRule(projectId, ruleId);
+    public void delete(UUID projectId, UUID ruleId, TenantScope scope) {
+        requireProject(projectId, scope);
+        TraceEvalRule rule = loadRule(projectId, ruleId, scope);
         ruleRepository.delete(rule);
     }
 
@@ -123,15 +132,15 @@ public class TraceEvalRuleService {
         rule.setThreshold(request.threshold());
     }
 
-    private void requireProject(UUID projectId) {
-        if (!projectRepository.existsById(projectId)) {
-            throw new IllegalArgumentException("Project not found: " + projectId);
-        }
+    private Project requireProject(UUID projectId, TenantScope scope) {
+        return projectRepository
+                .findById(projectId, scope)
+                .orElseThrow(() -> new IllegalArgumentException("Project not found: " + projectId));
     }
 
-    private TraceEvalRule loadRule(UUID projectId, UUID ruleId) {
+    private TraceEvalRule loadRule(UUID projectId, UUID ruleId, TenantScope scope) {
         TraceEvalRule rule = ruleRepository
-                .findById(ruleId)
+                .findById(ruleId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Trace eval rule not found: " + ruleId));
         if (!rule.getProjectId().equals(projectId)) {
             throw new IllegalArgumentException("Trace eval rule not found: " + ruleId);
@@ -139,9 +148,9 @@ public class TraceEvalRuleService {
         return rule;
     }
 
-    private LlmConnection loadConnection(UUID connectionId) {
+    private LlmConnection loadConnection(UUID connectionId, TenantScope scope) {
         return connectionRepository
-                .findById(connectionId)
+                .findById(connectionId, scope)
                 .orElseThrow(() -> new IllegalArgumentException("Connection not found: " + connectionId));
     }
 }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/TraceIngestService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/TraceIngestService.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -93,9 +92,12 @@ public class TraceIngestService {
         Trace trace = traceRepository.findByTraceId(traceId).orElseGet(() -> new Trace(traceId, now, expiresAt));
         trace.setExpiresAt(expiresAt);
 
-        UUID projectId = resolveProjectId(spans);
-        if (projectId != null) {
-            trace.setProjectId(projectId);
+        Project project = resolveProject(spans);
+        if (project != null) {
+            trace.setProjectId(project.getId());
+            // Stamp the trace with its project's tenant so scoped trace reads land in the right tenant.
+            // Ingestion runs without a tenant-scoped principal, so the project is the only tenant signal.
+            trace.setTenantId(project.getTenantId());
         }
 
         ParsedSpan root = findRoot(spans);
@@ -107,6 +109,7 @@ public class TraceIngestService {
 
         for (ParsedSpan parsed : spans) {
             TraceSpan span = new TraceSpan(parsed.traceId(), parsed.spanId(), parsed.name(), now);
+            span.setTenantId(trace.getTenantId());
             span.setParentSpanId(parsed.parentSpanId());
             span.setKind(parsed.kind());
             span.setStatusCode(parsed.statusCode());
@@ -121,12 +124,15 @@ public class TraceIngestService {
         return traceRepository.save(trace);
     }
 
-    private UUID resolveProjectId(List<ParsedSpan> spans) {
+    private Project resolveProject(List<ParsedSpan> spans) {
         for (ParsedSpan span : spans) {
             if (span.projectName() != null && !span.projectName().isBlank()) {
-                Optional<Project> project = projectRepository.findByName(span.projectName());
+                // Ingestion derives the soft project link regardless of tenant, so the lookup is
+                // unrestricted; the resulting tenant is then carried onto the trace and its spans.
+                Optional<Project> project = projectRepository.findByName(
+                        span.projectName(), dev.dokimos.server.tenant.TenantScope.unrestricted());
                 if (project.isPresent()) {
-                    return project.get().getId();
+                    return project.get();
                 }
             }
         }

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/TraceIngestService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/TraceIngestService.java
@@ -95,8 +95,7 @@ public class TraceIngestService {
         Project project = resolveProject(spans);
         if (project != null) {
             trace.setProjectId(project.getId());
-            // Stamp the trace with its project's tenant so scoped trace reads land in the right tenant.
-            // Ingestion runs without a tenant-scoped principal, so the project is the only tenant signal.
+            // Ingestion has no tenant-scoped principal, so the project is the only tenant signal.
             trace.setTenantId(project.getTenantId());
         }
 
@@ -127,8 +126,7 @@ public class TraceIngestService {
     private Project resolveProject(List<ParsedSpan> spans) {
         for (ParsedSpan span : spans) {
             if (span.projectName() != null && !span.projectName().isBlank()) {
-                // Ingestion derives the soft project link regardless of tenant, so the lookup is
-                // unrestricted; the resulting tenant is then carried onto the trace and its spans.
+                // The soft project link is derived regardless of tenant, so the lookup is unrestricted.
                 Optional<Project> project = projectRepository.findByName(
                         span.projectName(), dev.dokimos.server.tenant.TenantScope.unrestricted());
                 if (project.isPresent()) {

--- a/dokimos-server/src/main/java/dev/dokimos/server/service/TraceQueryService.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/service/TraceQueryService.java
@@ -8,6 +8,7 @@ import dev.dokimos.server.entity.Trace;
 import dev.dokimos.server.repository.TraceEvalJobRepository;
 import dev.dokimos.server.repository.TraceRepository;
 import dev.dokimos.server.repository.TraceSpanRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -38,10 +39,10 @@ public class TraceQueryService {
      * @return a page of trace summaries
      */
     @Transactional(readOnly = true)
-    public Page<TraceSummary> listTraces(UUID projectId, Pageable pageable) {
+    public Page<TraceSummary> listTraces(UUID projectId, Pageable pageable, TenantScope scope) {
         Page<Trace> page = projectId == null
-                ? traceRepository.findAllByOrderByCreatedAtDesc(pageable)
-                : traceRepository.findByProjectIdOrderByCreatedAtDesc(projectId, pageable);
+                ? traceRepository.findAllOrdered(pageable, scope)
+                : traceRepository.findByProjectId(projectId, pageable, scope);
         return page.map(TraceSummary::from);
     }
 
@@ -54,9 +55,10 @@ public class TraceQueryService {
      * @throws IllegalArgumentException if no trace has the id (mapped to 404)
      */
     @Transactional(readOnly = true)
-    public TraceDetail getTrace(UUID id) {
-        Trace trace =
-                traceRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Trace not found: " + id));
+    public TraceDetail getTrace(UUID id, TenantScope scope) {
+        Trace trace = traceRepository
+                .findById(id, scope)
+                .orElseThrow(() -> new IllegalArgumentException("Trace not found: " + id));
 
         List<SpanView> spans = spanRepository.findByTrace_IdOrderByStartTimeUnixNanoAsc(id).stream()
                 .map(SpanView::from)

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/AbstractScopedRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/AbstractScopedRepository.java
@@ -8,15 +8,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Base implementation of {@link ScopedRepository} shared by every scoped repository's custom fragment
- * implementation. It owns the {@link EntityManager} and delegates scoped reads to a {@link
- * TenantScopedFinder}. Concrete fragment implementations extend this, pass their entity class up, and add
- * the entity-specific scoped finders.
- *
- * <p>Holding the {@code EntityManager} here, inside the repository layer, is what lets the ArchUnit
- * backstop forbid services from touching {@code EntityManager} directly: the only legitimate place to
- * build a query is a scoped repository, and the only finders a scoped repository exposes require a {@link
- * TenantScope}.
+ * Base implementation of {@link ScopedRepository}. It owns the {@link EntityManager} and delegates scoped
+ * reads to a {@link TenantScopedFinder}; fragment implementations extend this, pass their entity class
+ * up, and add the entity-specific finders. Confining the {@code EntityManager} to this layer is what lets
+ * the architecture backstop forbid services from holding one and bypassing the scope predicate.
  *
  * @param <T> the scoped entity type
  */
@@ -28,20 +23,11 @@ public abstract class AbstractScopedRepository<T> implements ScopedRepository<T>
     private final Class<T> entityType;
     private TenantScopedFinder<T> finder;
 
-    /**
-     * Creates the base for the given entity type.
-     *
-     * @param entityType the scoped entity class
-     */
     protected AbstractScopedRepository(Class<T> entityType) {
         this.entityType = entityType;
     }
 
-    /**
-     * Returns the lazily created tenant-scoped finder bound to this repository's entity manager.
-     *
-     * @return the finder
-     */
+    /** Returns the finder, created lazily so it binds to the injected entity manager. */
     protected TenantScopedFinder<T> finder() {
         if (finder == null) {
             finder = new TenantScopedFinder<>(entityManager, entityType);
@@ -90,14 +76,7 @@ public abstract class AbstractScopedRepository<T> implements ScopedRepository<T>
         entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));
     }
 
-    /**
-     * Returns whether the entity has not been persisted yet, used to choose persist over merge. Entities
-     * generate their id on persist, so a null id means new. Reflection reads the {@code id} field once per
-     * call, which is acceptable for the write volume here.
-     *
-     * @param entity the entity to test
-     * @return true when the entity has no id yet
-     */
+    /** Chooses persist over merge: a null {@code id} means the entity has not been persisted yet. */
     protected boolean isNew(Object entity) {
         try {
             var field = findIdField(entity.getClass());

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/AbstractScopedRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/AbstractScopedRepository.java
@@ -1,0 +1,122 @@
+package dev.dokimos.server.tenant;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Base implementation of {@link ScopedRepository} shared by every scoped repository's custom fragment
+ * implementation. It owns the {@link EntityManager} and delegates scoped reads to a {@link
+ * TenantScopedFinder}. Concrete fragment implementations extend this, pass their entity class up, and add
+ * the entity-specific scoped finders.
+ *
+ * <p>Holding the {@code EntityManager} here, inside the repository layer, is what lets the ArchUnit
+ * backstop forbid services from touching {@code EntityManager} directly: the only legitimate place to
+ * build a query is a scoped repository, and the only finders a scoped repository exposes require a {@link
+ * TenantScope}.
+ *
+ * @param <T> the scoped entity type
+ */
+public abstract class AbstractScopedRepository<T> implements ScopedRepository<T> {
+
+    @PersistenceContext
+    protected EntityManager entityManager;
+
+    private final Class<T> entityType;
+    private TenantScopedFinder<T> finder;
+
+    /**
+     * Creates the base for the given entity type.
+     *
+     * @param entityType the scoped entity class
+     */
+    protected AbstractScopedRepository(Class<T> entityType) {
+        this.entityType = entityType;
+    }
+
+    /**
+     * Returns the lazily created tenant-scoped finder bound to this repository's entity manager.
+     *
+     * @return the finder
+     */
+    protected TenantScopedFinder<T> finder() {
+        if (finder == null) {
+            finder = new TenantScopedFinder<>(entityManager, entityType);
+        }
+        return finder;
+    }
+
+    @Override
+    public Optional<T> findById(UUID id, TenantScope scope) {
+        return finder().findById(id, scope);
+    }
+
+    @Override
+    public List<T> findAll(TenantScope scope) {
+        return finder().findAll(scope, null);
+    }
+
+    @Override
+    public long count(TenantScope scope) {
+        return finder().count(scope);
+    }
+
+    @Override
+    public <S extends T> S save(S entity) {
+        if (entityManager.contains(entity)) {
+            return entity;
+        }
+        if (isNew(entity)) {
+            entityManager.persist(entity);
+            return entity;
+        }
+        return entityManager.merge(entity);
+    }
+
+    @Override
+    public <S extends T> List<S> saveAll(Iterable<S> entities) {
+        List<S> saved = new ArrayList<>();
+        for (S entity : entities) {
+            saved.add(save(entity));
+        }
+        return saved;
+    }
+
+    @Override
+    public void delete(T entity) {
+        entityManager.remove(entityManager.contains(entity) ? entity : entityManager.merge(entity));
+    }
+
+    /**
+     * Returns whether the entity has not been persisted yet, used to choose persist over merge. Entities
+     * generate their id on persist, so a null id means new. Reflection reads the {@code id} field once per
+     * call, which is acceptable for the write volume here.
+     *
+     * @param entity the entity to test
+     * @return true when the entity has no id yet
+     */
+    protected boolean isNew(Object entity) {
+        try {
+            var field = findIdField(entity.getClass());
+            field.setAccessible(true);
+            return field.get(entity) == null;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not read id of " + entity.getClass(), e);
+        }
+    }
+
+    private static java.lang.reflect.Field findIdField(Class<?> type) throws NoSuchFieldException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return current.getDeclaredField("id");
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException("id");
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/ScopedRepository.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/ScopedRepository.java
@@ -1,0 +1,73 @@
+package dev.dokimos.server.tenant;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Common tenant-scoped operations shared by every scoped repository. A scoped repository extends Spring
+ * Data's empty {@code Repository<T, UUID>} plus this fragment, so the dangerous inherited finders
+ * ({@code findById(id)}, {@code findAll()}, {@code getReferenceById}, {@code getById}) do not exist and an
+ * unscoped load does not compile.
+ *
+ * <p>Every read takes a {@link TenantScope}. Request paths pass the principal's scope; background workers
+ * pass {@link TenantScope#unrestricted()} explicitly. Writes are stamped by the service from the resolved
+ * scope before {@link #save(Object)} is called, so persistence itself stays scope-agnostic.
+ *
+ * @param <T> the scoped entity type
+ */
+public interface ScopedRepository<T> {
+
+    /**
+     * Loads an entity by id only if it is visible under the scope. A row of another tenant returns empty,
+     * which the service maps to a 404 so existence is not leaked.
+     *
+     * @param id the entity id
+     * @param scope the tenant scope
+     * @return the entity if visible, otherwise empty
+     */
+    Optional<T> findById(UUID id, TenantScope scope);
+
+    /**
+     * Lists every entity visible under the scope.
+     *
+     * @param scope the tenant scope
+     * @return the visible entities
+     */
+    List<T> findAll(TenantScope scope);
+
+    /**
+     * Counts the entities visible under the scope.
+     *
+     * @param scope the tenant scope
+     * @return the count of visible rows
+     */
+    long count(TenantScope scope);
+
+    /**
+     * Persists a new or updated entity. The caller stamps the tenant id from the resolved scope before
+     * calling this.
+     *
+     * @param entity the entity to persist
+     * @param <S> the concrete entity subtype
+     * @return the managed, persisted entity
+     */
+    <S extends T> S save(S entity);
+
+    /**
+     * Persists all the given entities. The caller stamps each from the resolved scope first.
+     *
+     * @param entities the entities to persist
+     * @param <S> the concrete entity subtype
+     * @return the managed, persisted entities
+     */
+    <S extends T> List<S> saveAll(Iterable<S> entities);
+
+    /**
+     * Removes an entity. Services load through {@link #findById(UUID, TenantScope)} first, so a delete
+     * cannot reach across tenants.
+     *
+     * @param entity the entity to remove
+     */
+    void delete(T entity);
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantPredicate.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantPredicate.java
@@ -1,0 +1,40 @@
+package dev.dokimos.server.tenant;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+
+/**
+ * Builds the SQL/JPQL tenant predicate for a {@link TenantScope} against a {@code tenant_id} path.
+ *
+ * <p>The rule is uniform across every scoped entity:
+ *
+ * <ul>
+ *   <li>unrestricted: no predicate (always true), so every row is visible.
+ *   <li>scoped(tenantId) with a non-null tenant: {@code tenant_id = :tenantId OR tenant_id IS NULL}
+ *       (own rows plus shared rows).
+ *   <li>scoped(null) (anonymous): {@code tenant_id IS NULL} (shared rows only).
+ * </ul>
+ */
+public final class TenantPredicate {
+
+    private TenantPredicate() {}
+
+    /**
+     * Builds the criteria predicate for the scope over the given {@code tenant_id} path.
+     *
+     * @param cb the criteria builder
+     * @param tenantIdPath the path to the entity's {@code tenant_id} attribute
+     * @param scope the tenant scope to enforce
+     * @return the predicate to AND into the query's restriction
+     */
+    public static Predicate forScope(CriteriaBuilder cb, Path<String> tenantIdPath, TenantScope scope) {
+        if (!scope.restricted()) {
+            return cb.conjunction();
+        }
+        if (scope.tenantId() == null) {
+            return cb.isNull(tenantIdPath);
+        }
+        return cb.or(cb.equal(tenantIdPath, scope.tenantId()), cb.isNull(tenantIdPath));
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScope.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScope.java
@@ -3,22 +3,17 @@ package dev.dokimos.server.tenant;
 /**
  * Immutable tenant visibility used by every scoped repository read and by service-side write stamping.
  *
- * <p>Two shapes exist:
- *
  * <ul>
- *   <li>{@link #unrestricted()} applies no tenant predicate. Reads see every row regardless of tenant,
- *       and writes stamp {@code null} (a shared row). This is the scope of the system principal (no-key
- *       and legacy single-key deployments) and of background workers, so existing single-tenant and
- *       no-key behavior is preserved exactly.
- *   <li>{@link #scoped(String)} applies the predicate {@code tenant_id = :tenantId OR tenant_id IS NULL},
- *       so a tenant sees its own rows plus shared (null-tenant) rows. Writes stamp {@code tenantId}. A
- *       {@code null} tenant id collapses to shared-only: the predicate becomes {@code tenant_id IS NULL}
- *       and writes stamp {@code null}. This is the scope of a scoped API key and of an anonymous keyless
- *       reader (which resolves to {@code scoped(null)}).
+ *   <li>{@link #unrestricted()} applies no predicate; reads see every row and writes stamp {@code null}.
+ *       This is the scope of the system principal (no-key and legacy single-key deployments) and of
+ *       background workers, so existing single-tenant and no-key behavior is preserved exactly.
+ *   <li>{@link #scoped(String)} applies {@code tenant_id = :tenantId OR tenant_id IS NULL}, so a tenant
+ *       sees its own rows plus shared (null-tenant) rows, and writes stamp {@code tenantId}. A {@code
+ *       null} tenant id collapses to shared-only. This is the scope of a scoped API key and of an
+ *       anonymous keyless reader.
  * </ul>
  *
- * <p>Because the scope is a required parameter on every scoped finder, there is no unscoped overload a
- * caller can reach by accident: an unscoped load does not compile.
+ * <p>The scope is required on every finder, so an unscoped load does not compile.
  *
  * @param restricted whether a tenant predicate applies; {@code false} for {@link #unrestricted()}
  * @param tenantId the tenant to filter and stamp by when {@code restricted} is true, possibly {@code null}
@@ -50,11 +45,10 @@ public record TenantScope(boolean restricted, String tenantId) {
     }
 
     /**
-     * Returns the tenant id to stamp on a newly written row. This is {@code null} for the unrestricted
-     * scope (shared) and the scope's tenant id otherwise (which may itself be {@code null} for the
-     * shared-only scope).
+     * Returns the tenant id to stamp on a newly written row, or {@code null} for a shared row (the
+     * unrestricted and shared-only scopes).
      *
-     * @return the tenant id to stamp, or {@code null} for a shared row
+     * @return the tenant id to stamp, or {@code null}
      */
     public String stampTenantId() {
         return restricted ? tenantId : null;

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScope.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScope.java
@@ -1,0 +1,62 @@
+package dev.dokimos.server.tenant;
+
+/**
+ * Immutable tenant visibility used by every scoped repository read and by service-side write stamping.
+ *
+ * <p>Two shapes exist:
+ *
+ * <ul>
+ *   <li>{@link #unrestricted()} applies no tenant predicate. Reads see every row regardless of tenant,
+ *       and writes stamp {@code null} (a shared row). This is the scope of the system principal (no-key
+ *       and legacy single-key deployments) and of background workers, so existing single-tenant and
+ *       no-key behavior is preserved exactly.
+ *   <li>{@link #scoped(String)} applies the predicate {@code tenant_id = :tenantId OR tenant_id IS NULL},
+ *       so a tenant sees its own rows plus shared (null-tenant) rows. Writes stamp {@code tenantId}. A
+ *       {@code null} tenant id collapses to shared-only: the predicate becomes {@code tenant_id IS NULL}
+ *       and writes stamp {@code null}. This is the scope of a scoped API key and of an anonymous keyless
+ *       reader (which resolves to {@code scoped(null)}).
+ * </ul>
+ *
+ * <p>Because the scope is a required parameter on every scoped finder, there is no unscoped overload a
+ * caller can reach by accident: an unscoped load does not compile.
+ *
+ * @param restricted whether a tenant predicate applies; {@code false} for {@link #unrestricted()}
+ * @param tenantId the tenant to filter and stamp by when {@code restricted} is true, possibly {@code null}
+ *     for shared-only
+ */
+public record TenantScope(boolean restricted, String tenantId) {
+
+    private static final TenantScope UNRESTRICTED = new TenantScope(false, null);
+
+    /**
+     * Returns the scope that applies no tenant predicate. Reads see every row; writes stamp {@code null}.
+     *
+     * @return the unrestricted scope
+     */
+    public static TenantScope unrestricted() {
+        return UNRESTRICTED;
+    }
+
+    /**
+     * Returns a scope restricted to the given tenant. Reads see {@code tenant_id = tenantId OR tenant_id
+     * IS NULL}; writes stamp {@code tenantId}. A {@code null} tenant id yields a shared-only scope (reads
+     * see only null-tenant rows, writes stamp {@code null}).
+     *
+     * @param tenantId the tenant to scope to, or {@code null} for shared-only
+     * @return a restricted scope for the tenant
+     */
+    public static TenantScope scoped(String tenantId) {
+        return new TenantScope(true, tenantId);
+    }
+
+    /**
+     * Returns the tenant id to stamp on a newly written row. This is {@code null} for the unrestricted
+     * scope (shared) and the scope's tenant id otherwise (which may itself be {@code null} for the
+     * shared-only scope).
+     *
+     * @return the tenant id to stamp, or {@code null} for a shared row
+     */
+    public String stampTenantId() {
+        return restricted ? tenantId : null;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopeResolver.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopeResolver.java
@@ -1,0 +1,53 @@
+package dev.dokimos.server.tenant;
+
+import dev.dokimos.server.filter.ApiKeyAuthFilter;
+import dev.dokimos.server.filter.Principal;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Derives the {@link TenantScope} and principal id for the current request from the {@link Principal}
+ * the auth filter placed on the request attribute.
+ *
+ * <p>This is the single seam controllers use so the principal-to-scope mapping lives in one place. When
+ * no principal is present (a code path that does not pass through the auth filter, which only runs for
+ * {@code /api/v1/**}), the request is treated as the system principal so behavior matches an open,
+ * unauthenticated deployment.
+ */
+public final class TenantScopeResolver {
+
+    private TenantScopeResolver() {}
+
+    /**
+     * Resolves the principal behind a request, falling back to the system principal when the auth filter
+     * did not set one.
+     *
+     * @param request the current request
+     * @return the resolved principal, never null
+     */
+    public static Principal principal(HttpServletRequest request) {
+        Object attr = request.getAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE);
+        return attr instanceof Principal principal ? principal : Principal.system();
+    }
+
+    /**
+     * Resolves the tenant scope the current request reads and writes under.
+     *
+     * @param request the current request
+     * @return the tenant scope for the request
+     */
+    public static TenantScope scope(HttpServletRequest request) {
+        return principal(request).tenantScope();
+    }
+
+    /**
+     * Resolves the principal id of the current request, or {@code null} when no principal is present.
+     * Used to stamp {@code created_by} fields.
+     *
+     * @param request the current request
+     * @return the principal id, or {@code null}
+     */
+    public static String principalId(HttpServletRequest request) {
+        Object attr = request.getAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE);
+        return attr instanceof Principal principal ? principal.id() : null;
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopeResolver.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopeResolver.java
@@ -8,13 +8,11 @@ import jakarta.servlet.http.HttpServletRequest;
  * Derives the {@link TenantScope} and principal id for the current request from the {@link Principal}
  * the auth filter placed on the request attribute.
  *
- * <p>This is the single seam controllers use so the principal-to-scope mapping lives in one place. The
- * auth filter sets the principal attribute on every {@code /api/v1/**} request that reaches a controller
- * (the system principal in no-key and legacy single-key mode, a scoped or anonymous principal in
- * authenticated mode), so a request that passed the filter always carries one. The fallbacks below only
- * apply to a code path that bypasses the filter, and {@link #scope(HttpServletRequest)} fails closed
- * there: it resolves to a restricted, shared-only scope rather than the unrestricted system scope, so an
- * unfiltered request can never read another tenant's rows.
+ * <p>This is the single seam controllers use, so the principal-to-scope mapping lives in one place. The
+ * auth filter sets the principal on every {@code /api/v1/**} request that reaches a controller, so a
+ * filtered request always carries one. The fallbacks here cover only a path that bypasses the filter, and
+ * {@link #scope(HttpServletRequest)} fails closed there to a restricted, shared-only scope rather than
+ * the unrestricted system scope, so an unfiltered request can never read another tenant's rows.
  */
 public final class TenantScopeResolver {
 
@@ -33,12 +31,8 @@ public final class TenantScopeResolver {
     }
 
     /**
-     * Resolves the tenant scope the current request reads and writes under. This fails closed: when the
-     * auth filter set no principal (only possible on a code path that bypasses the filter), the request
-     * resolves to a restricted, shared-only scope rather than the unrestricted system scope, so an
-     * unfiltered request can never read another tenant's rows. When a principal is present its own scope
-     * is used unchanged, so a request carrying the system principal (no-key and legacy single-key mode)
-     * still resolves to {@link TenantScope#unrestricted()} and existing deployments are unaffected.
+     * Resolves the tenant scope the current request reads and writes under, using the principal's own
+     * scope and failing closed to a shared-only scope when no principal is present.
      *
      * @param request the current request
      * @return the tenant scope for the request, shared-only when no principal was set

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopeResolver.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopeResolver.java
@@ -8,10 +8,13 @@ import jakarta.servlet.http.HttpServletRequest;
  * Derives the {@link TenantScope} and principal id for the current request from the {@link Principal}
  * the auth filter placed on the request attribute.
  *
- * <p>This is the single seam controllers use so the principal-to-scope mapping lives in one place. When
- * no principal is present (a code path that does not pass through the auth filter, which only runs for
- * {@code /api/v1/**}), the request is treated as the system principal so behavior matches an open,
- * unauthenticated deployment.
+ * <p>This is the single seam controllers use so the principal-to-scope mapping lives in one place. The
+ * auth filter sets the principal attribute on every {@code /api/v1/**} request that reaches a controller
+ * (the system principal in no-key and legacy single-key mode, a scoped or anonymous principal in
+ * authenticated mode), so a request that passed the filter always carries one. The fallbacks below only
+ * apply to a code path that bypasses the filter, and {@link #scope(HttpServletRequest)} fails closed
+ * there: it resolves to a restricted, shared-only scope rather than the unrestricted system scope, so an
+ * unfiltered request can never read another tenant's rows.
  */
 public final class TenantScopeResolver {
 
@@ -30,13 +33,19 @@ public final class TenantScopeResolver {
     }
 
     /**
-     * Resolves the tenant scope the current request reads and writes under.
+     * Resolves the tenant scope the current request reads and writes under. This fails closed: when the
+     * auth filter set no principal (only possible on a code path that bypasses the filter), the request
+     * resolves to a restricted, shared-only scope rather than the unrestricted system scope, so an
+     * unfiltered request can never read another tenant's rows. When a principal is present its own scope
+     * is used unchanged, so a request carrying the system principal (no-key and legacy single-key mode)
+     * still resolves to {@link TenantScope#unrestricted()} and existing deployments are unaffected.
      *
      * @param request the current request
-     * @return the tenant scope for the request
+     * @return the tenant scope for the request, shared-only when no principal was set
      */
     public static TenantScope scope(HttpServletRequest request) {
-        return principal(request).tenantScope();
+        Object attr = request.getAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE);
+        return attr instanceof Principal principal ? principal.tenantScope() : TenantScope.scoped(null);
     }
 
     /**

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopedFinder.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopedFinder.java
@@ -1,0 +1,245 @@
+package dev.dokimos.server.tenant;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+/**
+ * Reusable tenant-scoped query helper shared by every scoped repository implementation. It owns the
+ * {@link EntityManager} and applies the {@link TenantPredicate} so individual repositories never touch
+ * the entity manager themselves and never expose an unscoped finder.
+ *
+ * <p>This class is the only place outside a repository that holds an {@code EntityManager}; the ArchUnit
+ * backstop forbids services from depending on {@code EntityManager} directly, and forbids tenant
+ * repositories from extending {@code CrudRepository}/{@code JpaRepository}, so the scope predicate cannot
+ * be bypassed by an inherited finder.
+ *
+ * @param <T> the scoped entity type
+ */
+public class TenantScopedFinder<T> {
+
+    private final EntityManager entityManager;
+    private final Class<T> entityType;
+
+    /**
+     * Creates a finder for the given entity type.
+     *
+     * @param entityManager the JPA entity manager
+     * @param entityType the scoped entity class
+     */
+    public TenantScopedFinder(EntityManager entityManager, Class<T> entityType) {
+        this.entityManager = entityManager;
+        this.entityType = entityType;
+    }
+
+    /**
+     * Loads an entity by id, applying the scope predicate so a row of another tenant is invisible
+     * (returns empty rather than throwing or leaking existence).
+     *
+     * @param id the entity id
+     * @param scope the tenant scope
+     * @return the entity if visible under the scope, otherwise empty
+     */
+    public Optional<T> findById(UUID id, TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        Predicate idMatch = cb.equal(root.get("id"), id);
+        query.select(root).where(cb.and(idMatch, tenantPredicate(cb, root, scope)));
+        return entityManager.createQuery(query).setMaxResults(1).getResultList().stream()
+                .findFirst();
+    }
+
+    /**
+     * Loads an entity by id under a pessimistic write lock, applying the scope predicate. Used to
+     * serialize concurrent writers (for example run ingestion against run completion) while keeping the
+     * load tenant-scoped.
+     *
+     * @param id the entity id
+     * @param scope the tenant scope
+     * @return the locked entity if visible under the scope, otherwise empty
+     */
+    public Optional<T> findByIdForUpdate(UUID id, TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        Predicate idMatch = cb.equal(root.get("id"), id);
+        query.select(root).where(cb.and(idMatch, tenantPredicate(cb, root, scope)));
+        return entityManager
+                .createQuery(query)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .setMaxResults(1)
+                .getResultList()
+                .stream()
+                .findFirst();
+    }
+
+    /**
+     * Returns the first entity matching an extra predicate and visible under the scope, under a
+     * pessimistic write lock. Used by version creation to lock a dataset by name while staying scoped.
+     *
+     * @param scope the tenant scope
+     * @param extra builds the extra predicate (for example a name match)
+     * @return the locked entity, or empty
+     */
+    public Optional<T> findFirstForUpdate(TenantScope scope, BiFunction<CriteriaBuilder, Root<T>, Predicate> extra) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        query.select(root).where(cb.and(tenantPredicate(cb, root, scope), extra.apply(cb, root)));
+        return entityManager
+                .createQuery(query)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .setMaxResults(1)
+                .getResultList()
+                .stream()
+                .findFirst();
+    }
+
+    /**
+     * Lists every entity visible under the scope, with an optional ordering.
+     *
+     * @param scope the tenant scope
+     * @param order builds the order list, or null for no ordering
+     * @return the visible entities
+     */
+    public List<T> findAll(TenantScope scope, BiFunction<CriteriaBuilder, Root<T>, List<Order>> order) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        query.select(root).where(tenantPredicate(cb, root, scope));
+        if (order != null) {
+            query.orderBy(order.apply(cb, root));
+        }
+        return entityManager.createQuery(query).getResultList();
+    }
+
+    /**
+     * Lists entities matching an extra predicate and visible under the scope, with an optional ordering.
+     *
+     * @param scope the tenant scope
+     * @param extra builds an extra predicate (for example a parent-id match), or null for none
+     * @param order builds the order list, or null for no ordering
+     * @return the matching, visible entities
+     */
+    public List<T> findWhere(
+            TenantScope scope,
+            BiFunction<CriteriaBuilder, Root<T>, Predicate> extra,
+            BiFunction<CriteriaBuilder, Root<T>, List<Order>> order) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(tenantPredicate(cb, root, scope));
+        if (extra != null) {
+            predicates.add(extra.apply(cb, root));
+        }
+        query.select(root).where(cb.and(predicates.toArray(new Predicate[0])));
+        if (order != null) {
+            query.orderBy(order.apply(cb, root));
+        }
+        return entityManager.createQuery(query).getResultList();
+    }
+
+    /**
+     * Returns the first entity matching an extra predicate and visible under the scope, ordered as given.
+     *
+     * @param scope the tenant scope
+     * @param extra builds an extra predicate, or null for none
+     * @param order builds the order list, or null for no ordering
+     * @return the first matching entity, or empty
+     */
+    public Optional<T> findFirst(
+            TenantScope scope,
+            BiFunction<CriteriaBuilder, Root<T>, Predicate> extra,
+            BiFunction<CriteriaBuilder, Root<T>, List<Order>> order) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(tenantPredicate(cb, root, scope));
+        if (extra != null) {
+            predicates.add(extra.apply(cb, root));
+        }
+        query.select(root).where(cb.and(predicates.toArray(new Predicate[0])));
+        if (order != null) {
+            query.orderBy(order.apply(cb, root));
+        }
+        return entityManager.createQuery(query).setMaxResults(1).getResultList().stream()
+                .findFirst();
+    }
+
+    /**
+     * Returns a page of entities matching an extra predicate and visible under the scope, ordered as
+     * given. The total count honors the same predicates so paging metadata is correct.
+     *
+     * @param scope the tenant scope
+     * @param extra builds an extra predicate, or null for none
+     * @param order builds the order list, or null for no ordering
+     * @param pageable the page request
+     * @return the requested page of visible entities
+     */
+    public org.springframework.data.domain.Page<T> findPage(
+            TenantScope scope,
+            BiFunction<CriteriaBuilder, Root<T>, Predicate> extra,
+            BiFunction<CriteriaBuilder, Root<T>, List<Order>> order,
+            org.springframework.data.domain.Pageable pageable) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<T> query = cb.createQuery(entityType);
+        Root<T> root = query.from(entityType);
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(tenantPredicate(cb, root, scope));
+        if (extra != null) {
+            predicates.add(extra.apply(cb, root));
+        }
+        Predicate[] where = predicates.toArray(new Predicate[0]);
+        query.select(root).where(cb.and(where));
+        if (order != null) {
+            query.orderBy(order.apply(cb, root));
+        }
+        List<T> content = entityManager
+                .createQuery(query)
+                .setFirstResult((int) pageable.getOffset())
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<T> countRoot = countQuery.from(entityType);
+        List<Predicate> countPredicates = new ArrayList<>();
+        countPredicates.add(tenantPredicate(cb, countRoot, scope));
+        if (extra != null) {
+            countPredicates.add(extra.apply(cb, countRoot));
+        }
+        countQuery.select(cb.count(countRoot)).where(cb.and(countPredicates.toArray(new Predicate[0])));
+        long total = entityManager.createQuery(countQuery).getSingleResult();
+
+        return new org.springframework.data.domain.PageImpl<>(content, pageable, total);
+    }
+
+    /**
+     * Counts the entities visible under the scope.
+     *
+     * @param scope the tenant scope
+     * @return the count of visible rows
+     */
+    public long count(TenantScope scope) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<T> root = query.from(entityType);
+        query.select(cb.count(root)).where(tenantPredicate(cb, root, scope));
+        return entityManager.createQuery(query).getSingleResult();
+    }
+
+    private Predicate tenantPredicate(CriteriaBuilder cb, Root<T> root, TenantScope scope) {
+        return TenantPredicate.forScope(cb, root.get("tenantId"), scope);
+    }
+}

--- a/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopedFinder.java
+++ b/dokimos-server/src/main/java/dev/dokimos/server/tenant/TenantScopedFinder.java
@@ -18,11 +18,6 @@ import java.util.function.BiFunction;
  * {@link EntityManager} and applies the {@link TenantPredicate} so individual repositories never touch
  * the entity manager themselves and never expose an unscoped finder.
  *
- * <p>This class is the only place outside a repository that holds an {@code EntityManager}; the ArchUnit
- * backstop forbids services from depending on {@code EntityManager} directly, and forbids tenant
- * repositories from extending {@code CrudRepository}/{@code JpaRepository}, so the scope predicate cannot
- * be bypassed by an inherited finder.
- *
  * @param <T> the scoped entity type
  */
 public class TenantScopedFinder<T> {
@@ -30,25 +25,12 @@ public class TenantScopedFinder<T> {
     private final EntityManager entityManager;
     private final Class<T> entityType;
 
-    /**
-     * Creates a finder for the given entity type.
-     *
-     * @param entityManager the JPA entity manager
-     * @param entityType the scoped entity class
-     */
     public TenantScopedFinder(EntityManager entityManager, Class<T> entityType) {
         this.entityManager = entityManager;
         this.entityType = entityType;
     }
 
-    /**
-     * Loads an entity by id, applying the scope predicate so a row of another tenant is invisible
-     * (returns empty rather than throwing or leaking existence).
-     *
-     * @param id the entity id
-     * @param scope the tenant scope
-     * @return the entity if visible under the scope, otherwise empty
-     */
+    /** Loads an entity by id under the scope; a row of another tenant returns empty, never leaking existence. */
     public Optional<T> findById(UUID id, TenantScope scope) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<T> query = cb.createQuery(entityType);
@@ -59,15 +41,7 @@ public class TenantScopedFinder<T> {
                 .findFirst();
     }
 
-    /**
-     * Loads an entity by id under a pessimistic write lock, applying the scope predicate. Used to
-     * serialize concurrent writers (for example run ingestion against run completion) while keeping the
-     * load tenant-scoped.
-     *
-     * @param id the entity id
-     * @param scope the tenant scope
-     * @return the locked entity if visible under the scope, otherwise empty
-     */
+    /** Loads an entity by id under the scope and a pessimistic write lock, to serialize concurrent writers. */
     public Optional<T> findByIdForUpdate(UUID id, TenantScope scope) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<T> query = cb.createQuery(entityType);
@@ -83,14 +57,7 @@ public class TenantScopedFinder<T> {
                 .findFirst();
     }
 
-    /**
-     * Returns the first entity matching an extra predicate and visible under the scope, under a
-     * pessimistic write lock. Used by version creation to lock a dataset by name while staying scoped.
-     *
-     * @param scope the tenant scope
-     * @param extra builds the extra predicate (for example a name match)
-     * @return the locked entity, or empty
-     */
+    /** Returns the first entity matching {@code extra} under the scope and a pessimistic write lock. */
     public Optional<T> findFirstForUpdate(TenantScope scope, BiFunction<CriteriaBuilder, Root<T>, Predicate> extra) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<T> query = cb.createQuery(entityType);
@@ -105,13 +72,7 @@ public class TenantScopedFinder<T> {
                 .findFirst();
     }
 
-    /**
-     * Lists every entity visible under the scope, with an optional ordering.
-     *
-     * @param scope the tenant scope
-     * @param order builds the order list, or null for no ordering
-     * @return the visible entities
-     */
+    /** Lists every entity visible under the scope, with an optional {@code order}. */
     public List<T> findAll(TenantScope scope, BiFunction<CriteriaBuilder, Root<T>, List<Order>> order) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<T> query = cb.createQuery(entityType);
@@ -123,14 +84,7 @@ public class TenantScopedFinder<T> {
         return entityManager.createQuery(query).getResultList();
     }
 
-    /**
-     * Lists entities matching an extra predicate and visible under the scope, with an optional ordering.
-     *
-     * @param scope the tenant scope
-     * @param extra builds an extra predicate (for example a parent-id match), or null for none
-     * @param order builds the order list, or null for no ordering
-     * @return the matching, visible entities
-     */
+    /** Lists entities matching {@code extra} and visible under the scope, with an optional {@code order}. */
     public List<T> findWhere(
             TenantScope scope,
             BiFunction<CriteriaBuilder, Root<T>, Predicate> extra,
@@ -150,14 +104,7 @@ public class TenantScopedFinder<T> {
         return entityManager.createQuery(query).getResultList();
     }
 
-    /**
-     * Returns the first entity matching an extra predicate and visible under the scope, ordered as given.
-     *
-     * @param scope the tenant scope
-     * @param extra builds an extra predicate, or null for none
-     * @param order builds the order list, or null for no ordering
-     * @return the first matching entity, or empty
-     */
+    /** Returns the first entity matching {@code extra} and visible under the scope, with an optional {@code order}. */
     public Optional<T> findFirst(
             TenantScope scope,
             BiFunction<CriteriaBuilder, Root<T>, Predicate> extra,
@@ -179,14 +126,8 @@ public class TenantScopedFinder<T> {
     }
 
     /**
-     * Returns a page of entities matching an extra predicate and visible under the scope, ordered as
-     * given. The total count honors the same predicates so paging metadata is correct.
-     *
-     * @param scope the tenant scope
-     * @param extra builds an extra predicate, or null for none
-     * @param order builds the order list, or null for no ordering
-     * @param pageable the page request
-     * @return the requested page of visible entities
+     * Returns a page of entities matching {@code extra} and visible under the scope. The total count
+     * honors the same predicates so paging metadata is correct.
      */
     public org.springframework.data.domain.Page<T> findPage(
             TenantScope scope,
@@ -225,12 +166,7 @@ public class TenantScopedFinder<T> {
         return new org.springframework.data.domain.PageImpl<>(content, pageable, total);
     }
 
-    /**
-     * Counts the entities visible under the scope.
-     *
-     * @param scope the tenant scope
-     * @return the count of visible rows
-     */
+    /** Counts the entities visible under the scope. */
     public long count(TenantScope scope) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<Long> query = cb.createQuery(Long.class);

--- a/dokimos-server/src/main/resources/db/migration/V14__tenant_scoping.sql
+++ b/dokimos-server/src/main/resources/db/migration/V14__tenant_scoping.sql
@@ -23,6 +23,18 @@ ALTER TABLE projects DROP CONSTRAINT projects_name_key;
 ALTER TABLE projects ADD CONSTRAINT uq_project_name_tenant UNIQUE (name, tenant_id);
 CREATE UNIQUE INDEX uq_project_name_shared ON projects(name) WHERE tenant_id IS NULL;
 
+-- Per-tenant dataset names, mirroring projects so two tenants can each own a "regression" dataset and
+-- a scoped existence check is not a cross-tenant oracle. Same shape: (name, tenant_id) unique plus a
+-- partial unique on name for the shared (null-tenant) rows.
+ALTER TABLE datasets DROP CONSTRAINT datasets_name_key;
+ALTER TABLE datasets ADD CONSTRAINT uq_dataset_name_tenant UNIQUE (name, tenant_id);
+CREATE UNIQUE INDEX uq_dataset_name_shared ON datasets(name) WHERE tenant_id IS NULL;
+
+-- Per-tenant llm_connection names, same rule as projects and datasets.
+ALTER TABLE llm_connections DROP CONSTRAINT llm_connections_name_key;
+ALTER TABLE llm_connections ADD CONSTRAINT uq_llm_connection_name_tenant UNIQUE (name, tenant_id);
+CREATE UNIQUE INDEX uq_llm_connection_name_shared ON llm_connections(name) WHERE tenant_id IS NULL;
+
 -- Indexes on the filtered tables. The scoped read predicate is tenant_id = :t OR tenant_id IS NULL, so
 -- an index on tenant_id keeps the per-tenant scan selective on the high-volume tables.
 CREATE INDEX idx_projects_tenant_id ON projects(tenant_id);

--- a/dokimos-server/src/main/resources/db/migration/V14__tenant_scoping.sql
+++ b/dokimos-server/src/main/resources/db/migration/V14__tenant_scoping.sql
@@ -1,9 +1,8 @@
--- Tenant data isolation. Adds the tenant_id seam to the child and config tables that did not yet
--- carry it, and makes the project name unique per tenant instead of globally so two tenants can each
--- own a "default" project. Every new column is nullable with no backfill: with no tenants provisioned
--- yet, all existing rows are legitimately shared (null tenant), which the scoped reads treat as visible
--- to everyone. The system principal (no-key and legacy single-key deployments) reads unrestricted and
--- stamps null, so existing deployments behave exactly as before.
+-- Tenant data isolation. Adds the tenant_id seam to the child and config tables that lacked it, and
+-- makes names unique per tenant instead of globally so two tenants can each own a "default" project.
+-- Every new column is nullable with no backfill: existing rows become shared (null tenant), which the
+-- system principal (no-key and legacy single-key deployments) reads unrestricted, so those deployments
+-- behave exactly as before.
 
 -- Child tables loaded by id straight from user input, previously with no tenant column at all. Each is
 -- stamped from its parent on write so a scoped parent query and a scoped child query agree.

--- a/dokimos-server/src/main/resources/db/migration/V14__tenant_scoping.sql
+++ b/dokimos-server/src/main/resources/db/migration/V14__tenant_scoping.sql
@@ -1,0 +1,41 @@
+-- Tenant data isolation. Adds the tenant_id seam to the child and config tables that did not yet
+-- carry it, and makes the project name unique per tenant instead of globally so two tenants can each
+-- own a "default" project. Every new column is nullable with no backfill: with no tenants provisioned
+-- yet, all existing rows are legitimately shared (null tenant), which the scoped reads treat as visible
+-- to everyone. The system principal (no-key and legacy single-key deployments) reads unrestricted and
+-- stamps null, so existing deployments behave exactly as before.
+
+-- Child tables loaded by id straight from user input, previously with no tenant column at all. Each is
+-- stamped from its parent on write so a scoped parent query and a scoped child query agree.
+ALTER TABLE item_results ADD COLUMN tenant_id VARCHAR(255);
+ALTER TABLE eval_results ADD COLUMN tenant_id VARCHAR(255);
+ALTER TABLE dataset_versions ADD COLUMN tenant_id VARCHAR(255);
+ALTER TABLE dataset_items ADD COLUMN tenant_id VARCHAR(255);
+ALTER TABLE trace_spans ADD COLUMN tenant_id VARCHAR(255);
+
+-- Config entity scoped by its own tenant_id, one uniform rule (no "scope by owning project").
+ALTER TABLE llm_connections ADD COLUMN tenant_id VARCHAR(255);
+
+-- Per-tenant project names. Drop the global unique on projects.name and replace it with a unique on
+-- (name, tenant_id) plus a partial unique on name for the shared (null-tenant) rows, since a unique
+-- over (name, tenant_id) does not constrain rows whose tenant_id is null in Postgres.
+ALTER TABLE projects DROP CONSTRAINT projects_name_key;
+ALTER TABLE projects ADD CONSTRAINT uq_project_name_tenant UNIQUE (name, tenant_id);
+CREATE UNIQUE INDEX uq_project_name_shared ON projects(name) WHERE tenant_id IS NULL;
+
+-- Indexes on the filtered tables. The scoped read predicate is tenant_id = :t OR tenant_id IS NULL, so
+-- an index on tenant_id keeps the per-tenant scan selective on the high-volume tables.
+CREATE INDEX idx_projects_tenant_id ON projects(tenant_id);
+CREATE INDEX idx_experiments_tenant_id ON experiments(tenant_id);
+CREATE INDEX idx_experiment_runs_tenant_id ON experiment_runs(tenant_id);
+CREATE INDEX idx_item_results_tenant_id ON item_results(tenant_id);
+CREATE INDEX idx_eval_results_tenant_id ON eval_results(tenant_id);
+CREATE INDEX idx_datasets_tenant_id ON datasets(tenant_id);
+CREATE INDEX idx_dataset_versions_tenant_id ON dataset_versions(tenant_id);
+CREATE INDEX idx_dataset_items_tenant_id ON dataset_items(tenant_id);
+CREATE INDEX idx_traces_tenant_id ON traces(tenant_id);
+CREATE INDEX idx_trace_spans_tenant_id ON trace_spans(tenant_id);
+CREATE INDEX idx_annotations_tenant_id ON annotations(tenant_id);
+CREATE INDEX idx_alert_webhooks_tenant_id ON alert_webhooks(tenant_id);
+CREATE INDEX idx_trace_eval_rules_tenant_id ON trace_eval_rules(tenant_id);
+CREATE INDEX idx_llm_connections_tenant_id ON llm_connections(tenant_id);

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/AlignmentControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/AlignmentControllerTest.java
@@ -1,5 +1,6 @@
 package dev.dokimos.server.controller.v1;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import dev.dokimos.server.controller.GlobalExceptionHandler;
 import dev.dokimos.server.dto.v1.AlignmentView;
 import dev.dokimos.server.service.AlignmentService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +43,7 @@ class AlignmentControllerTest extends AbstractControllerTest {
                 List.of(
                         new AlignmentView.EvaluatorAlignment("accuracy", 2, 2, 1, 1.0),
                         new AlignmentView.EvaluatorAlignment("relevance", 0, 0, 1, null)));
-        when(alignmentService.getAlignment(eq(runId))).thenReturn(view);
+        when(alignmentService.getAlignment(eq(runId), any(TenantScope.class))).thenReturn(view);
 
         mockMvc.perform(get("/api/v1/runs/{runId}/alignment", runId))
                 .andExpect(status().isOk())
@@ -57,7 +59,7 @@ class AlignmentControllerTest extends AbstractControllerTest {
     @Test
     void alignment_returns404WhenRunMissing() throws Exception {
         UUID runId = UUID.randomUUID();
-        when(alignmentService.getAlignment(eq(runId)))
+        when(alignmentService.getAlignment(eq(runId), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Run not found: " + runId));
 
         mockMvc.perform(get("/api/v1/runs/{runId}/alignment", runId))

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/AnnotationControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/AnnotationControllerTest.java
@@ -20,6 +20,7 @@ import dev.dokimos.server.filter.ApiKeyAuthFilter;
 import dev.dokimos.server.filter.Principal;
 import dev.dokimos.server.filter.Role;
 import dev.dokimos.server.service.AnnotationService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
@@ -54,7 +55,8 @@ class AnnotationControllerTest extends AbstractControllerTest {
         UUID runId = UUID.randomUUID();
         UUID itemResultId = UUID.randomUUID();
         AnnotationView view = view(AnnotationVerdict.INCORRECT, "alice");
-        when(annotationService.upsert(eq(runId), eq(itemResultId), any(AnnotationRequest.class), eq("alice")))
+        when(annotationService.upsert(
+                        eq(runId), eq(itemResultId), any(AnnotationRequest.class), eq("alice"), any(TenantScope.class)))
                 .thenReturn(view);
 
         AnnotationRequest request = new AnnotationRequest(AnnotationVerdict.INCORRECT, Map.of("a", "fixed"), "note");
@@ -83,7 +85,8 @@ class AnnotationControllerTest extends AbstractControllerTest {
     void upsert_returns404WhenItemNotInRun() throws Exception {
         UUID runId = UUID.randomUUID();
         UUID itemResultId = UUID.randomUUID();
-        when(annotationService.upsert(eq(runId), eq(itemResultId), any(AnnotationRequest.class), any()))
+        when(annotationService.upsert(
+                        eq(runId), eq(itemResultId), any(AnnotationRequest.class), any(), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException(
                         "Item result " + itemResultId + " does not belong to run " + runId));
 
@@ -98,7 +101,8 @@ class AnnotationControllerTest extends AbstractControllerTest {
     void get_returns200() throws Exception {
         UUID runId = UUID.randomUUID();
         UUID itemResultId = UUID.randomUUID();
-        when(annotationService.get(runId, itemResultId)).thenReturn(view(AnnotationVerdict.UNSURE, null));
+        when(annotationService.get(eq(runId), eq(itemResultId), any(TenantScope.class)))
+                .thenReturn(view(AnnotationVerdict.UNSURE, null));
 
         mockMvc.perform(get("/api/v1/runs/{runId}/items/{itemResultId}/annotation", runId, itemResultId))
                 .andExpect(status().isOk())
@@ -109,7 +113,7 @@ class AnnotationControllerTest extends AbstractControllerTest {
     void get_returns404WhenMissing() throws Exception {
         UUID runId = UUID.randomUUID();
         UUID itemResultId = UUID.randomUUID();
-        when(annotationService.get(runId, itemResultId))
+        when(annotationService.get(eq(runId), eq(itemResultId), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Annotation not found for item result: " + itemResultId));
 
         mockMvc.perform(get("/api/v1/runs/{runId}/items/{itemResultId}/annotation", runId, itemResultId))
@@ -120,12 +124,12 @@ class AnnotationControllerTest extends AbstractControllerTest {
     void delete_returns204() throws Exception {
         UUID runId = UUID.randomUUID();
         UUID itemResultId = UUID.randomUUID();
-        doNothing().when(annotationService).delete(runId, itemResultId);
+        doNothing().when(annotationService).delete(eq(runId), eq(itemResultId), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/runs/{runId}/items/{itemResultId}/annotation", runId, itemResultId))
                 .andExpect(status().isNoContent());
 
-        verify(annotationService).delete(runId, itemResultId);
+        verify(annotationService).delete(eq(runId), eq(itemResultId), any(TenantScope.class));
     }
 
     @Test
@@ -134,7 +138,7 @@ class AnnotationControllerTest extends AbstractControllerTest {
         UUID itemResultId = UUID.randomUUID();
         doThrow(new IllegalArgumentException("Item result " + itemResultId + " does not belong to run " + runId))
                 .when(annotationService)
-                .delete(runId, itemResultId);
+                .delete(eq(runId), eq(itemResultId), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/runs/{runId}/items/{itemResultId}/annotation", runId, itemResultId))
                 .andExpect(status().isNotFound());

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/DatasetControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/DatasetControllerTest.java
@@ -26,6 +26,7 @@ import dev.dokimos.server.filter.ApiKeyAuthFilter;
 import dev.dokimos.server.filter.Principal;
 import dev.dokimos.server.filter.Role;
 import dev.dokimos.server.service.DatasetService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.List;
@@ -64,7 +65,7 @@ class DatasetControllerTest extends AbstractControllerTest {
     void listDatasets_returnsSummaries() throws Exception {
         DatasetSummary summary =
                 new DatasetSummary(UUID.randomUUID(), "qa", "qa set", 2, 100, Instant.now(), Instant.now());
-        when(datasetService.listDatasets()).thenReturn(List.of(summary));
+        when(datasetService.listDatasets(any(TenantScope.class))).thenReturn(List.of(summary));
 
         mockMvc.perform(get("/api/v1/datasets"))
                 .andExpect(status().isOk())
@@ -76,7 +77,8 @@ class DatasetControllerTest extends AbstractControllerTest {
     @Test
     void createDataset_returns201WithLocationHeader() throws Exception {
         Dataset dataset = dataset("qa", "qa set");
-        when(datasetService.createDataset("qa", "qa set")).thenReturn(dataset);
+        when(datasetService.createDataset(eq("qa"), eq("qa set"), any(TenantScope.class)))
+                .thenReturn(dataset);
 
         CreateDatasetRequest request = new CreateDatasetRequest("qa", "qa set");
         mockMvc.perform(post("/api/v1/datasets")
@@ -89,7 +91,7 @@ class DatasetControllerTest extends AbstractControllerTest {
 
     @Test
     void createDataset_returns409OnDuplicate() throws Exception {
-        when(datasetService.createDataset(eq("qa"), any()))
+        when(datasetService.createDataset(eq("qa"), any(), any(TenantScope.class)))
                 .thenThrow(new IllegalStateException("Dataset already exists: qa"));
 
         CreateDatasetRequest request = new CreateDatasetRequest("qa", null);
@@ -113,7 +115,7 @@ class DatasetControllerTest extends AbstractControllerTest {
     void getDataset_returnsDetails() throws Exception {
         var details = new dev.dokimos.server.dto.v1.DatasetDetails(
                 UUID.randomUUID(), "qa", "set", Instant.now(), Instant.now(), List.of());
-        when(datasetService.getDatasetDetails("qa")).thenReturn(details);
+        when(datasetService.getDatasetDetails(eq("qa"), any(TenantScope.class))).thenReturn(details);
 
         mockMvc.perform(get("/api/v1/datasets/{name}", "qa"))
                 .andExpect(status().isOk())
@@ -122,7 +124,7 @@ class DatasetControllerTest extends AbstractControllerTest {
 
     @Test
     void getDataset_returns404OnUnknown() throws Exception {
-        when(datasetService.getDatasetDetails("missing"))
+        when(datasetService.getDatasetDetails(eq("missing"), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Dataset not found: missing"));
 
         mockMvc.perform(get("/api/v1/datasets/{name}", "missing"))
@@ -132,18 +134,18 @@ class DatasetControllerTest extends AbstractControllerTest {
 
     @Test
     void deleteDataset_returns204() throws Exception {
-        doNothing().when(datasetService).deleteDataset("qa");
+        doNothing().when(datasetService).deleteDataset(eq("qa"), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/datasets/{name}", "qa")).andExpect(status().isNoContent());
 
-        verify(datasetService).deleteDataset("qa");
+        verify(datasetService).deleteDataset(eq("qa"), any(TenantScope.class));
     }
 
     @Test
     void deleteDataset_returns404OnUnknown() throws Exception {
         doThrow(new IllegalArgumentException("Dataset not found: missing"))
                 .when(datasetService)
-                .deleteDataset("missing");
+                .deleteDataset(eq("missing"), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/datasets/{name}", "missing")).andExpect(status().isNotFound());
     }
@@ -151,7 +153,8 @@ class DatasetControllerTest extends AbstractControllerTest {
     @Test
     void createVersion_passesPrincipalAsCreatedBy() throws Exception {
         DatasetVersion version = datasetVersion("qa", 1, 2, "alice");
-        when(datasetService.createVersion(eq("qa"), any(), any(), eq("alice"))).thenReturn(version);
+        when(datasetService.createVersion(eq("qa"), any(), any(), eq("alice"), any(TenantScope.class)))
+                .thenReturn(version);
 
         CreateVersionRequest request = new CreateVersionRequest(
                 "v1", List.of(new CreateVersionRequest.ItemPayload(Map.of("q", "a"), null, null)));
@@ -169,7 +172,8 @@ class DatasetControllerTest extends AbstractControllerTest {
     @Test
     void createVersion_passesNullCreatedByWhenNoPrincipal() throws Exception {
         DatasetVersion version = datasetVersion("qa", 1, 1, null);
-        when(datasetService.createVersion(eq("qa"), any(), any(), eq(null))).thenReturn(version);
+        when(datasetService.createVersion(eq("qa"), any(), any(), eq(null), any(TenantScope.class)))
+                .thenReturn(version);
 
         CreateVersionRequest request = new CreateVersionRequest(
                 null, List.of(new CreateVersionRequest.ItemPayload(Map.of("q", "a"), null, null)));
@@ -180,7 +184,7 @@ class DatasetControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated());
 
         ArgumentCaptor<String> createdBy = ArgumentCaptor.forClass(String.class);
-        verify(datasetService).createVersion(eq("qa"), any(), any(), createdBy.capture());
+        verify(datasetService).createVersion(eq("qa"), any(), any(), createdBy.capture(), any(TenantScope.class));
         assertThat(createdBy.getValue()).isNull();
     }
 
@@ -197,7 +201,7 @@ class DatasetControllerTest extends AbstractControllerTest {
     @Test
     void getVersion_byNumber_returnsDetails() throws Exception {
         DatasetVersion version = datasetVersion("qa", 3, 5, "bob");
-        when(datasetService.getVersion("qa", 3)).thenReturn(version);
+        when(datasetService.getVersion(eq("qa"), eq(3), any(TenantScope.class))).thenReturn(version);
 
         mockMvc.perform(get("/api/v1/datasets/{name}/versions/{version}", "qa", "3"))
                 .andExpect(status().isOk())
@@ -208,7 +212,7 @@ class DatasetControllerTest extends AbstractControllerTest {
     @Test
     void getVersion_latestAlias_returnsLatest() throws Exception {
         DatasetVersion version = datasetVersion("qa", 7, 2, "bob");
-        when(datasetService.getLatestVersion("qa")).thenReturn(version);
+        when(datasetService.getLatestVersion(eq("qa"), any(TenantScope.class))).thenReturn(version);
 
         mockMvc.perform(get("/api/v1/datasets/{name}/versions/{version}", "qa", "latest"))
                 .andExpect(status().isOk())
@@ -229,7 +233,7 @@ class DatasetControllerTest extends AbstractControllerTest {
         DatasetItem item = datasetItem(itemId, version, 0);
         Page<DatasetItem> page = new PageImpl<>(List.of(item));
 
-        when(datasetService.getVersion("qa", 1)).thenReturn(version);
+        when(datasetService.getVersion(eq("qa"), eq(1), any(TenantScope.class))).thenReturn(version);
         when(datasetService.listItems(eq(version), any())).thenReturn(page);
 
         mockMvc.perform(get("/api/v1/datasets/{name}/versions/{version}/items", "qa", "1"))
@@ -247,7 +251,7 @@ class DatasetControllerTest extends AbstractControllerTest {
 
     @Test
     void listItems_unknownVersion_returns404() throws Exception {
-        when(datasetService.getVersion(eq("qa"), anyInt()))
+        when(datasetService.getVersion(eq("qa"), anyInt(), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Dataset version not found: qa v9"));
 
         mockMvc.perform(get("/api/v1/datasets/{name}/versions/{version}/items", "qa", "9"))

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/DiffControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/DiffControllerTest.java
@@ -13,6 +13,7 @@ import dev.dokimos.server.dto.v1.DiffSummary;
 import dev.dokimos.server.dto.v1.DiffView;
 import dev.dokimos.server.dto.v1.PageResponse;
 import dev.dokimos.server.service.DiffService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,13 @@ class DiffControllerTest extends AbstractControllerTest {
         UUID experimentId = UUID.randomUUID();
         UUID candidateId = UUID.randomUUID();
         UUID baselineId = UUID.randomUUID();
-        when(diffService.listDiff(eq(experimentId), eq(candidateId), eq(baselineId), any(), any(Pageable.class)))
+        when(diffService.listDiff(
+                        eq(experimentId),
+                        eq(candidateId),
+                        eq(baselineId),
+                        any(),
+                        any(Pageable.class),
+                        any(TenantScope.class)))
                 .thenReturn(sampleView(baselineId, candidateId));
 
         mockMvc.perform(get("/api/v1/experiments/{e}/runs/{c}/diff", experimentId, candidateId)
@@ -99,7 +106,13 @@ class DiffControllerTest extends AbstractControllerTest {
         UUID experimentId = UUID.randomUUID();
         UUID candidateId = UUID.randomUUID();
         UUID baselineId = UUID.randomUUID();
-        when(diffService.listDiff(eq(experimentId), eq(candidateId), eq(baselineId), any(), any(Pageable.class)))
+        when(diffService.listDiff(
+                        eq(experimentId),
+                        eq(candidateId),
+                        eq(baselineId),
+                        any(),
+                        any(Pageable.class),
+                        any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Candidate run not found: " + candidateId));
 
         mockMvc.perform(get("/api/v1/experiments/{e}/runs/{c}/diff", experimentId, candidateId)
@@ -113,7 +126,13 @@ class DiffControllerTest extends AbstractControllerTest {
         UUID experimentId = UUID.randomUUID();
         UUID candidateId = UUID.randomUUID();
         UUID baselineId = UUID.randomUUID();
-        when(diffService.listDiff(eq(experimentId), eq(candidateId), eq(baselineId), any(), any(Pageable.class)))
+        when(diffService.listDiff(
+                        eq(experimentId),
+                        eq(candidateId),
+                        eq(baselineId),
+                        any(),
+                        any(Pageable.class),
+                        any(TenantScope.class)))
                 .thenThrow(new IllegalStateException("Candidate run is not in a terminal SUCCESS/FAILED status"));
 
         mockMvc.perform(get("/api/v1/experiments/{e}/runs/{c}/diff", experimentId, candidateId)

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/EvalJobControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/EvalJobControllerTest.java
@@ -14,6 +14,7 @@ import dev.dokimos.server.dto.v1.EnqueueJudgeRequest;
 import dev.dokimos.server.dto.v1.EvalJobView;
 import dev.dokimos.server.entity.EvalJobStatus;
 import dev.dokimos.server.service.EvalJobService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -57,7 +58,7 @@ class EvalJobControllerTest extends AbstractControllerTest {
     @Test
     void enqueue_shouldReturn201() throws Exception {
         UUID jobId = UUID.randomUUID();
-        when(jobService.enqueue(eq(runId), any())).thenReturn(view(jobId));
+        when(jobService.enqueue(eq(runId), any(), any(TenantScope.class))).thenReturn(view(jobId));
 
         mockMvc.perform(post("/api/v1/runs/" + runId + "/judge-jobs")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -71,7 +72,7 @@ class EvalJobControllerTest extends AbstractControllerTest {
     void enqueue_shouldReturn409OnDuplicateJob() throws Exception {
         doThrow(new IllegalStateException("A judge job already exists"))
                 .when(jobService)
-                .enqueue(eq(runId), any());
+                .enqueue(eq(runId), any(), any(TenantScope.class));
 
         mockMvc.perform(post("/api/v1/runs/" + runId + "/judge-jobs")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -92,7 +93,7 @@ class EvalJobControllerTest extends AbstractControllerTest {
 
     @Test
     void list_shouldReturnEmptyList() throws Exception {
-        when(jobService.getJobsForRun(runId)).thenReturn(List.of());
+        when(jobService.getJobsForRun(eq(runId), any(TenantScope.class))).thenReturn(List.of());
 
         mockMvc.perform(get("/api/v1/runs/" + runId + "/judge-jobs"))
                 .andExpect(status().isOk())

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/ExperimentControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/ExperimentControllerTest.java
@@ -1,5 +1,7 @@
 package dev.dokimos.server.controller.v1;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -17,6 +19,7 @@ import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.entity.RunStatus;
 import dev.dokimos.server.service.ExperimentService;
 import dev.dokimos.server.service.RunService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -71,8 +74,9 @@ class ExperimentControllerTest {
                 null,
                 null);
 
-        when(experimentService.getExperiment(experimentId)).thenReturn(experiment);
-        when(runService.listRuns(experiment)).thenReturn(List.of(summary));
+        when(experimentService.getExperiment(eq(experimentId), any(TenantScope.class)))
+                .thenReturn(experiment);
+        when(runService.listRuns(eq(experiment), any(TenantScope.class))).thenReturn(List.of(summary));
 
         mockMvc.perform(get("/api/v1/experiments/{experimentId}/runs", experimentId))
                 .andExpect(status().isOk())
@@ -83,7 +87,7 @@ class ExperimentControllerTest {
     @Test
     void listRuns_shouldReturn404WhenExperimentNotFound() throws Exception {
         UUID experimentId = UUID.randomUUID();
-        when(experimentService.getExperiment(experimentId))
+        when(experimentService.getExperiment(eq(experimentId), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Experiment not found: " + experimentId));
 
         mockMvc.perform(get("/api/v1/experiments/{experimentId}/runs", experimentId))
@@ -98,7 +102,8 @@ class ExperimentControllerTest {
         TrendData.RunPoint point = new TrendData.RunPoint(runId, Instant.now(), 0.85, 20, 17);
         TrendData trendData = new TrendData("my-experiment", "my-project", List.of(point));
 
-        when(experimentService.getTrends(experimentId, 20)).thenReturn(trendData);
+        when(experimentService.getTrends(eq(experimentId), eq(20), any(TenantScope.class)))
+                .thenReturn(trendData);
 
         mockMvc.perform(get("/api/v1/experiments/{experimentId}/trends", experimentId))
                 .andExpect(status().isOk())
@@ -111,7 +116,8 @@ class ExperimentControllerTest {
         UUID experimentId = UUID.randomUUID();
         TrendData trendData = new TrendData("my-experiment", "my-project", List.of());
 
-        when(experimentService.getTrends(experimentId, 50)).thenReturn(trendData);
+        when(experimentService.getTrends(eq(experimentId), eq(50), any(TenantScope.class)))
+                .thenReturn(trendData);
 
         mockMvc.perform(get("/api/v1/experiments/{experimentId}/trends", experimentId)
                         .param("limit", "50"))
@@ -122,7 +128,7 @@ class ExperimentControllerTest {
     @Test
     void getTrends_shouldReturn404WhenExperimentNotFound() throws Exception {
         UUID experimentId = UUID.randomUUID();
-        when(experimentService.getTrends(experimentId, 20))
+        when(experimentService.getTrends(eq(experimentId), eq(20), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Experiment not found: " + experimentId));
 
         mockMvc.perform(get("/api/v1/experiments/{experimentId}/trends", experimentId))
@@ -132,12 +138,12 @@ class ExperimentControllerTest {
     @Test
     void deleteExperiment_shouldReturn204OnSuccess() throws Exception {
         UUID experimentId = UUID.randomUUID();
-        doNothing().when(experimentService).deleteExperiment(experimentId);
+        doNothing().when(experimentService).deleteExperiment(eq(experimentId), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/experiments/{experimentId}", experimentId))
                 .andExpect(status().isNoContent());
 
-        verify(experimentService).deleteExperiment(experimentId);
+        verify(experimentService).deleteExperiment(eq(experimentId), any(TenantScope.class));
     }
 
     @Test
@@ -145,7 +151,7 @@ class ExperimentControllerTest {
         UUID experimentId = UUID.randomUUID();
         doThrow(new IllegalArgumentException("Experiment not found: " + experimentId))
                 .when(experimentService)
-                .deleteExperiment(experimentId);
+                .deleteExperiment(eq(experimentId), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/experiments/{experimentId}", experimentId))
                 .andExpect(status().isNotFound())

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/GateControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/GateControllerTest.java
@@ -11,6 +11,7 @@ import dev.dokimos.server.controller.GlobalExceptionHandler;
 import dev.dokimos.server.dto.v1.GateRequest;
 import dev.dokimos.server.dto.v1.GateResult;
 import dev.dokimos.server.service.GateService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,8 @@ class GateControllerTest extends AbstractControllerTest {
                 List.of(),
                 List.of(),
                 false);
-        when(gateService.evaluateGate(eq(experimentId), any(GateRequest.class))).thenReturn(verdict);
+        when(gateService.evaluateGate(eq(experimentId), any(GateRequest.class), any(TenantScope.class)))
+                .thenReturn(verdict);
 
         GateRequest request = new GateRequest(candidateId, null, null);
         mockMvc.perform(post("/api/v1/experiments/{experimentId}/gate", experimentId)
@@ -78,7 +80,7 @@ class GateControllerTest extends AbstractControllerTest {
     void evaluateGate_returns404WhenExperimentOrRunMissing() throws Exception {
         UUID experimentId = UUID.randomUUID();
         UUID candidateId = UUID.randomUUID();
-        when(gateService.evaluateGate(eq(experimentId), any(GateRequest.class)))
+        when(gateService.evaluateGate(eq(experimentId), any(GateRequest.class), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Candidate run not found: " + candidateId));
 
         GateRequest request = new GateRequest(candidateId, null, null);
@@ -93,7 +95,7 @@ class GateControllerTest extends AbstractControllerTest {
     void evaluateGate_returns409WhenCandidateNotTerminal() throws Exception {
         UUID experimentId = UUID.randomUUID();
         UUID candidateId = UUID.randomUUID();
-        when(gateService.evaluateGate(eq(experimentId), any(GateRequest.class)))
+        when(gateService.evaluateGate(eq(experimentId), any(GateRequest.class), any(TenantScope.class)))
                 .thenThrow(new IllegalStateException("Candidate run is still RUNNING: " + candidateId));
 
         GateRequest request = new GateRequest(candidateId, null, null);

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/LlmConnectionControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/LlmConnectionControllerTest.java
@@ -14,6 +14,7 @@ import dev.dokimos.server.dto.v1.CreateLlmConnectionRequest;
 import dev.dokimos.server.dto.v1.LlmConnectionView;
 import dev.dokimos.server.entity.LlmConnectionProtocol;
 import dev.dokimos.server.service.LlmConnectionService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +55,7 @@ class LlmConnectionControllerTest extends AbstractControllerTest {
     @Test
     void create_shouldReturn201AndNoKeyMaterial() throws Exception {
         UUID id = UUID.randomUUID();
-        when(connectionService.create(any())).thenReturn(view(id));
+        when(connectionService.create(any(), any(TenantScope.class))).thenReturn(view(id));
         CreateLlmConnectionRequest request =
                 new CreateLlmConnectionRequest("conn", "https://api.example.com", "gpt-4", null, null, "OPENAI_KEY");
 
@@ -83,7 +84,7 @@ class LlmConnectionControllerTest extends AbstractControllerTest {
     void create_shouldReturn409OnDuplicateName() throws Exception {
         doThrow(new IllegalStateException("Connection already exists: conn"))
                 .when(connectionService)
-                .create(any());
+                .create(any(), any(TenantScope.class));
         CreateLlmConnectionRequest request =
                 new CreateLlmConnectionRequest("conn", "https://api.example.com", "gpt-4", null, null, "OPENAI_KEY");
 
@@ -96,7 +97,8 @@ class LlmConnectionControllerTest extends AbstractControllerTest {
     @Test
     void get_shouldReturn404WhenMissing() throws Exception {
         UUID id = UUID.randomUUID();
-        when(connectionService.get(eq(id))).thenThrow(new IllegalArgumentException("Connection not found: " + id));
+        when(connectionService.get(eq(id), any(TenantScope.class)))
+                .thenThrow(new IllegalArgumentException("Connection not found: " + id));
 
         mockMvc.perform(get("/api/v1/llm-connections/" + id)).andExpect(status().isNotFound());
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/ProjectControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/ProjectControllerTest.java
@@ -22,6 +22,7 @@ import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.service.ExperimentService;
 import dev.dokimos.server.service.ProjectService;
 import dev.dokimos.server.service.RunService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ class ProjectControllerTest extends AbstractControllerTest {
     void listProjects_shouldReturnProjects() throws Exception {
         UUID projectId = UUID.randomUUID();
         ProjectSummary summary = new ProjectSummary(projectId, "my-project", 5, Instant.now());
-        when(projectService.listProjects()).thenReturn(List.of(summary));
+        when(projectService.listProjects(any(TenantScope.class))).thenReturn(List.of(summary));
 
         mockMvc.perform(get("/api/v1/projects"))
                 .andExpect(status().isOk())
@@ -69,7 +70,7 @@ class ProjectControllerTest extends AbstractControllerTest {
 
     @Test
     void listProjects_shouldReturnEmptyList() throws Exception {
-        when(projectService.listProjects()).thenReturn(List.of());
+        when(projectService.listProjects(any(TenantScope.class))).thenReturn(List.of());
 
         mockMvc.perform(get("/api/v1/projects"))
                 .andExpect(status().isOk())
@@ -82,8 +83,10 @@ class ProjectControllerTest extends AbstractControllerTest {
         UUID experimentId = UUID.randomUUID();
         ExperimentSummary summary = new ExperimentSummary(experimentId, "my-experiment", Instant.now(), null);
 
-        when(projectService.getProject("my-project")).thenReturn(project);
-        when(experimentService.listExperiments(project)).thenReturn(List.of(summary));
+        when(projectService.getProject(eq("my-project"), any(TenantScope.class)))
+                .thenReturn(project);
+        when(experimentService.listExperiments(eq(project), any(TenantScope.class)))
+                .thenReturn(List.of(summary));
 
         mockMvc.perform(get("/api/v1/projects/my-project/experiments"))
                 .andExpect(status().isOk())
@@ -92,7 +95,7 @@ class ProjectControllerTest extends AbstractControllerTest {
 
     @Test
     void listExperiments_shouldReturn404WhenProjectNotFound() throws Exception {
-        when(projectService.getProject("unknown"))
+        when(projectService.getProject(eq("unknown"), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Project not found: unknown"));
 
         mockMvc.perform(get("/api/v1/projects/unknown/experiments"))
@@ -108,9 +111,12 @@ class ProjectControllerTest extends AbstractControllerTest {
         ExperimentRun run = new ExperimentRun(experiment, Map.of());
         setField(run, "id", runId);
 
-        when(projectService.getOrCreateProject("my-project")).thenReturn(project);
-        when(experimentService.getOrCreateExperiment(project, "my-experiment")).thenReturn(experiment);
-        when(runService.createRun(eq(experiment), any(CreateRunRequest.class))).thenReturn(run);
+        when(projectService.getOrCreateProject(eq("my-project"), any(TenantScope.class)))
+                .thenReturn(project);
+        when(experimentService.getOrCreateExperiment(eq(project), eq("my-experiment"), any(TenantScope.class)))
+                .thenReturn(experiment);
+        when(runService.createRun(eq(experiment), any(CreateRunRequest.class), any(TenantScope.class)))
+                .thenReturn(run);
 
         CreateRunRequest request =
                 new CreateRunRequest("my-experiment", Map.of("key", "value"), "nightly", "abc123", "main", "ci");
@@ -156,18 +162,18 @@ class ProjectControllerTest extends AbstractControllerTest {
 
     @Test
     void deleteProject_shouldReturn204OnSuccess() throws Exception {
-        doNothing().when(projectService).deleteProject("my-project");
+        doNothing().when(projectService).deleteProject(eq("my-project"), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/projects/{projectName}", "my-project")).andExpect(status().isNoContent());
 
-        verify(projectService).deleteProject("my-project");
+        verify(projectService).deleteProject(eq("my-project"), any(TenantScope.class));
     }
 
     @Test
     void deleteProject_shouldReturn404WhenNotFound() throws Exception {
         doThrow(new IllegalArgumentException("Project not found: unknown"))
                 .when(projectService)
-                .deleteProject("unknown");
+                .deleteProject(eq("unknown"), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/projects/{projectName}", "unknown"))
                 .andExpect(status().isNotFound())

--- a/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/RunControllerTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/controller/v1/RunControllerTest.java
@@ -21,6 +21,7 @@ import dev.dokimos.server.dto.v1.RunDetails;
 import dev.dokimos.server.dto.v1.UpdateRunRequest;
 import dev.dokimos.server.entity.RunStatus;
 import dev.dokimos.server.service.RunService;
+import dev.dokimos.server.tenant.TenantScope;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -97,7 +98,8 @@ class RunControllerTest extends AbstractControllerTest {
                 412.5,
                 page);
 
-        when(runService.getRunDetails(eq(runId), any(Pageable.class))).thenReturn(details);
+        when(runService.getRunDetails(eq(runId), any(Pageable.class), any(TenantScope.class)))
+                .thenReturn(details);
 
         mockMvc.perform(get("/api/v1/runs/{runId}", runId))
                 .andDo(print())
@@ -120,7 +122,7 @@ class RunControllerTest extends AbstractControllerTest {
     @Test
     void getRunDetails_shouldReturn404WhenNotFound() throws Exception {
         UUID runId = UUID.randomUUID();
-        when(runService.getRunDetails(eq(runId), any(Pageable.class)))
+        when(runService.getRunDetails(eq(runId), any(Pageable.class), any(TenantScope.class)))
                 .thenThrow(new IllegalArgumentException("Run not found: " + runId));
 
         mockMvc.perform(get("/api/v1/runs/{runId}", runId))
@@ -138,7 +140,7 @@ class RunControllerTest extends AbstractControllerTest {
                 List.of(new AddItemsRequest.EvalData("eval", 1.0, 0.9, true, "pass", Map.of())),
                 true)));
 
-        doNothing().when(runService).addItems(eq(runId), any(AddItemsRequest.class), any());
+        doNothing().when(runService).addItems(eq(runId), any(AddItemsRequest.class), any(), any(TenantScope.class));
 
         mockMvc.perform(post("/api/v1/runs/{runId}/items", runId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -146,7 +148,7 @@ class RunControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("ok"));
 
-        verify(runService).addItems(eq(runId), any(AddItemsRequest.class), any());
+        verify(runService).addItems(eq(runId), any(AddItemsRequest.class), any(), any(TenantScope.class));
     }
 
     @Test
@@ -157,7 +159,7 @@ class RunControllerTest extends AbstractControllerTest {
                 "tokensIn":100,"tokensOut":50,"costUsd":0.002,"latencyMs":430}]}""";
 
         ArgumentCaptor<AddItemsRequest> captor = ArgumentCaptor.forClass(AddItemsRequest.class);
-        doNothing().when(runService).addItems(eq(runId), captor.capture(), any());
+        doNothing().when(runService).addItems(eq(runId), captor.capture(), any(), any(TenantScope.class));
 
         mockMvc.perform(post("/api/v1/runs/{runId}/items", runId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -182,7 +184,9 @@ class RunControllerTest extends AbstractControllerTest {
                 List.of(new AddItemsRequest.EvalData("eval", 1.0, 0.9, true, "pass", Map.of())),
                 true)));
 
-        doNothing().when(runService).addItems(eq(runId), any(AddItemsRequest.class), eq("batch-key-1"));
+        doNothing()
+                .when(runService)
+                .addItems(eq(runId), any(AddItemsRequest.class), eq("batch-key-1"), any(TenantScope.class));
 
         mockMvc.perform(post("/api/v1/runs/{runId}/items", runId)
                         .header("Idempotency-Key", "batch-key-1")
@@ -191,7 +195,7 @@ class RunControllerTest extends AbstractControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("ok"));
 
-        verify(runService).addItems(eq(runId), any(AddItemsRequest.class), eq("batch-key-1"));
+        verify(runService).addItems(eq(runId), any(AddItemsRequest.class), eq("batch-key-1"), any(TenantScope.class));
     }
 
     @Test
@@ -205,7 +209,7 @@ class RunControllerTest extends AbstractControllerTest {
                         .content(body))
                 .andExpect(status().isBadRequest());
 
-        verify(runService, never()).addItems(any(), any(), any());
+        verify(runService, never()).addItems(any(), any(), any(), any());
     }
 
     @Test
@@ -216,7 +220,7 @@ class RunControllerTest extends AbstractControllerTest {
 
         doThrow(new IllegalArgumentException("Run not found: " + runId))
                 .when(runService)
-                .addItems(eq(runId), any(AddItemsRequest.class), any());
+                .addItems(eq(runId), any(AddItemsRequest.class), any(), any(TenantScope.class));
 
         mockMvc.perform(post("/api/v1/runs/{runId}/items", runId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -232,7 +236,7 @@ class RunControllerTest extends AbstractControllerTest {
 
         doThrow(new IllegalStateException("Cannot add items to a run that is not RUNNING: " + runId))
                 .when(runService)
-                .addItems(eq(runId), any(AddItemsRequest.class), any());
+                .addItems(eq(runId), any(AddItemsRequest.class), any(), any(TenantScope.class));
 
         mockMvc.perform(post("/api/v1/runs/{runId}/items", runId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -246,7 +250,7 @@ class RunControllerTest extends AbstractControllerTest {
         UUID runId = UUID.randomUUID();
         UpdateRunRequest request = new UpdateRunRequest(RunStatus.SUCCESS);
 
-        doNothing().when(runService).updateRun(eq(runId), any(UpdateRunRequest.class));
+        doNothing().when(runService).updateRun(eq(runId), any(UpdateRunRequest.class), any(TenantScope.class));
 
         mockMvc.perform(patch("/api/v1/runs/{runId}", runId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -254,7 +258,7 @@ class RunControllerTest extends AbstractControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("updated"));
 
-        verify(runService).updateRun(eq(runId), any(UpdateRunRequest.class));
+        verify(runService).updateRun(eq(runId), any(UpdateRunRequest.class), any(TenantScope.class));
     }
 
     @Test
@@ -264,7 +268,7 @@ class RunControllerTest extends AbstractControllerTest {
 
         doThrow(new IllegalArgumentException("Run not found: " + runId))
                 .when(runService)
-                .updateRun(eq(runId), any(UpdateRunRequest.class));
+                .updateRun(eq(runId), any(UpdateRunRequest.class), any(TenantScope.class));
 
         mockMvc.perform(patch("/api/v1/runs/{runId}", runId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -275,11 +279,11 @@ class RunControllerTest extends AbstractControllerTest {
     @Test
     void deleteRun_shouldReturn204OnSuccess() throws Exception {
         UUID runId = UUID.randomUUID();
-        doNothing().when(runService).deleteRun(runId);
+        doNothing().when(runService).deleteRun(eq(runId), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/runs/{runId}", runId)).andExpect(status().isNoContent());
 
-        verify(runService).deleteRun(runId);
+        verify(runService).deleteRun(eq(runId), any(TenantScope.class));
     }
 
     @Test
@@ -287,7 +291,7 @@ class RunControllerTest extends AbstractControllerTest {
         UUID runId = UUID.randomUUID();
         doThrow(new IllegalArgumentException("Run not found: " + runId))
                 .when(runService)
-                .deleteRun(runId);
+                .deleteRun(eq(runId), any(TenantScope.class));
 
         mockMvc.perform(delete("/api/v1/runs/{runId}", runId))
                 .andExpect(status().isNotFound())

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/AlertWebhookServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/AlertWebhookServiceTest.java
@@ -3,6 +3,7 @@ package dev.dokimos.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,15 +45,17 @@ class AlertWebhookServiceTest {
     void create_shouldSaveEnabledWebhookAndNeverExposeSecret() {
         UUID projectId = UUID.randomUUID();
         Project project = project(projectId);
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project));
         when(webhookRepository.save(any(AlertWebhook.class))).thenAnswer(inv -> {
             AlertWebhook w = inv.getArgument(0);
             setField(w, "id", UUID.randomUUID());
             return w;
         });
 
-        AlertWebhookView view =
-                service.create(projectId, new CreateAlertWebhookRequest("https://hooks.test/x", "shh", null));
+        AlertWebhookView view = service.create(
+                projectId,
+                new CreateAlertWebhookRequest("https://hooks.test/x", "shh", null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.enabled()).isTrue();
         assertThat(view.hasSecret()).isTrue();
@@ -66,11 +69,13 @@ class AlertWebhookServiceTest {
     @Test
     void create_shouldTreatBlankSecretAsNoSecret() {
         UUID projectId = UUID.randomUUID();
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project(projectId)));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project(projectId)));
         when(webhookRepository.save(any(AlertWebhook.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        AlertWebhookView view =
-                service.create(projectId, new CreateAlertWebhookRequest("https://hooks.test/x", "  ", false));
+        AlertWebhookView view = service.create(
+                projectId,
+                new CreateAlertWebhookRequest("https://hooks.test/x", "  ", false),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.hasSecret()).isFalse();
         assertThat(view.enabled()).isFalse();
@@ -79,10 +84,12 @@ class AlertWebhookServiceTest {
     @Test
     void create_shouldThrowWhenProjectMissing() {
         UUID projectId = UUID.randomUUID();
-        when(projectRepository.findById(projectId)).thenReturn(Optional.empty());
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() ->
-                        service.create(projectId, new CreateAlertWebhookRequest("https://hooks.test/x", null, null)))
+        assertThatThrownBy(() -> service.create(
+                        projectId,
+                        new CreateAlertWebhookRequest("https://hooks.test/x", null, null),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Project not found");
     }
@@ -95,11 +102,15 @@ class AlertWebhookServiceTest {
         AlertWebhook webhook = new AlertWebhook(project, "https://old.test", "original", true);
         setField(webhook, "id", webhookId);
 
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
-        when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project));
+        when(webhookRepository.findById(eq(webhookId), any())).thenReturn(Optional.of(webhook));
         when(webhookRepository.save(any(AlertWebhook.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.update(projectId, webhookId, new UpdateAlertWebhookRequest("https://new.test", " ", false));
+        service.update(
+                projectId,
+                webhookId,
+                new UpdateAlertWebhookRequest("https://new.test", " ", false),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(webhook.getUrl()).isEqualTo("https://new.test");
         assertThat(webhook.isEnabled()).isFalse();
@@ -114,11 +125,15 @@ class AlertWebhookServiceTest {
         AlertWebhook webhook = new AlertWebhook(project, "https://old.test", "original", true);
         setField(webhook, "id", webhookId);
 
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
-        when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project));
+        when(webhookRepository.findById(eq(webhookId), any())).thenReturn(Optional.of(webhook));
         when(webhookRepository.save(any(AlertWebhook.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.update(projectId, webhookId, new UpdateAlertWebhookRequest("https://new.test", "rotated", true));
+        service.update(
+                projectId,
+                webhookId,
+                new UpdateAlertWebhookRequest("https://new.test", "rotated", true),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(webhook.getSecret()).isEqualTo("rotated");
     }
@@ -131,10 +146,11 @@ class AlertWebhookServiceTest {
         AlertWebhook webhook = new AlertWebhook(project(otherProjectId), "https://x.test", null, true);
         setField(webhook, "id", webhookId);
 
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project(projectId)));
-        when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project(projectId)));
+        when(webhookRepository.findById(eq(webhookId), any())).thenReturn(Optional.of(webhook));
 
-        assertThatThrownBy(() -> service.get(projectId, webhookId))
+        assertThatThrownBy(
+                        () -> service.get(projectId, webhookId, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not belong to project");
     }
@@ -146,10 +162,10 @@ class AlertWebhookServiceTest {
         AlertWebhook webhook = new AlertWebhook(project(projectId), "https://x.test", null, true);
         setField(webhook, "id", webhookId);
 
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project(projectId)));
-        when(webhookRepository.findById(webhookId)).thenReturn(Optional.of(webhook));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project(projectId)));
+        when(webhookRepository.findById(eq(webhookId), any())).thenReturn(Optional.of(webhook));
 
-        service.delete(projectId, webhookId);
+        service.delete(projectId, webhookId, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(webhookRepository).delete(webhook);
     }
@@ -158,10 +174,11 @@ class AlertWebhookServiceTest {
     void delete_shouldNotDeleteWhenWebhookMissing() {
         UUID projectId = UUID.randomUUID();
         UUID webhookId = UUID.randomUUID();
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project(projectId)));
-        when(webhookRepository.findById(webhookId)).thenReturn(Optional.empty());
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project(projectId)));
+        when(webhookRepository.findById(eq(webhookId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.delete(projectId, webhookId))
+        assertThatThrownBy(() ->
+                        service.delete(projectId, webhookId, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Webhook not found");
         verify(webhookRepository, never()).delete(any());
@@ -174,10 +191,10 @@ class AlertWebhookServiceTest {
         AlertWebhook w = new AlertWebhook(project, "https://x.test", "sec", true);
         setField(w, "id", UUID.randomUUID());
 
-        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
-        when(webhookRepository.findByProjectOrderByCreatedAtAsc(project)).thenReturn(List.of(w));
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.of(project));
+        when(webhookRepository.findByProject(eq(project), any())).thenReturn(List.of(w));
 
-        List<AlertWebhookView> views = service.list(projectId);
+        List<AlertWebhookView> views = service.list(projectId, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(views).hasSize(1);
         assertThat(views.get(0).hasSecret()).isTrue();

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/AlignmentServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/AlignmentServiceTest.java
@@ -71,7 +71,8 @@ class AlignmentServiceTest {
         annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
         annotate(itemWithEval(run, "accuracy", false), AnnotationVerdict.INCORRECT);
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.annotatedItems()).isEqualTo(2);
         AlignmentView.EvaluatorAlignment accuracy = only(view);
@@ -88,7 +89,8 @@ class AlignmentServiceTest {
         annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.INCORRECT);
         annotate(itemWithEval(run, "accuracy", false), AnnotationVerdict.CORRECT);
 
-        AlignmentView.EvaluatorAlignment accuracy = only(alignmentService.getAlignment(run.getId()));
+        AlignmentView.EvaluatorAlignment accuracy =
+                only(alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted()));
 
         assertThat(accuracy.comparableCount()).isEqualTo(2);
         assertThat(accuracy.agreedCount()).isZero();
@@ -101,7 +103,8 @@ class AlignmentServiceTest {
         annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
         annotate(itemWithEval(run, "accuracy", false), AnnotationVerdict.UNSURE);
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
         AlignmentView.EvaluatorAlignment accuracy = only(view);
 
         assertThat(view.annotatedItems()).isEqualTo(2);
@@ -117,7 +120,8 @@ class AlignmentServiceTest {
         annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.CORRECT);
         itemWithEval(run, "accuracy", false);
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
         AlignmentView.EvaluatorAlignment accuracy = only(view);
 
         assertThat(view.annotatedItems()).isEqualTo(1);
@@ -141,7 +145,8 @@ class AlignmentServiceTest {
         itemResultRepository.save(second);
         annotate(second, AnnotationVerdict.CORRECT);
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         AlignmentView.EvaluatorAlignment accuracy = byName(view, "accuracy");
         AlignmentView.EvaluatorAlignment relevance = byName(view, "relevance");
@@ -163,7 +168,8 @@ class AlignmentServiceTest {
         itemResultRepository.save(second);
         annotate(second, AnnotationVerdict.CORRECT);
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(byName(view, "accuracy").comparableCount()).isEqualTo(2);
         AlignmentView.EvaluatorAlignment toxicity = byName(view, "toxicity");
@@ -176,7 +182,8 @@ class AlignmentServiceTest {
         ExperimentRun run = newRun();
         annotate(itemWithEval(run, "accuracy", true), AnnotationVerdict.UNSURE);
 
-        AlignmentView.EvaluatorAlignment accuracy = only(alignmentService.getAlignment(run.getId()));
+        AlignmentView.EvaluatorAlignment accuracy =
+                only(alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted()));
 
         assertThat(accuracy.comparableCount()).isZero();
         assertThat(accuracy.excludedUnsure()).isEqualTo(1);
@@ -189,7 +196,8 @@ class AlignmentServiceTest {
         itemWithEval(run, "accuracy", true);
         itemWithEval(run, "accuracy", false);
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.annotatedItems()).isZero();
         assertThat(view.evaluators()).isEmpty();
@@ -199,7 +207,8 @@ class AlignmentServiceTest {
     void emptyRun_hasNoEvaluators() {
         ExperimentRun run = newRun();
 
-        AlignmentView view = alignmentService.getAlignment(run.getId());
+        AlignmentView view =
+                alignmentService.getAlignment(run.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.annotatedItems()).isZero();
         assertThat(view.evaluators()).isEmpty();
@@ -207,7 +216,8 @@ class AlignmentServiceTest {
 
     @Test
     void missingRunRaisesNotFound() {
-        assertThatThrownBy(() -> alignmentService.getAlignment(UUID.randomUUID()))
+        assertThatThrownBy(() -> alignmentService.getAlignment(
+                        UUID.randomUUID(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Run not found");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/AnnotationServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/AnnotationServiceTest.java
@@ -38,8 +38,10 @@ class AnnotationServiceTest {
     static class TestConfig {
         @org.springframework.context.annotation.Bean
         AnnotationService annotationService(
-                AnnotationRepository annotationRepository, ItemResultRepository itemResultRepository) {
-            return new AnnotationService(annotationRepository, itemResultRepository);
+                AnnotationRepository annotationRepository,
+                ItemResultRepository itemResultRepository,
+                ExperimentRunRepository runRepository) {
+            return new AnnotationService(annotationRepository, itemResultRepository, runRepository);
         }
     }
 
@@ -72,7 +74,8 @@ class AnnotationServiceTest {
                 fixture.runId,
                 fixture.itemResultId,
                 new AnnotationRequest(AnnotationVerdict.INCORRECT, Map.of("a", "fixed"), "first note"),
-                "alice");
+                "alice",
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(created.verdict()).isEqualTo(AnnotationVerdict.INCORRECT);
         assertThat(created.overriddenExpectedOutput()).containsEntry("a", "fixed");
@@ -84,7 +87,8 @@ class AnnotationServiceTest {
                 fixture.runId,
                 fixture.itemResultId,
                 new AnnotationRequest(AnnotationVerdict.CORRECT, null, "second note"),
-                "bob");
+                "bob",
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(updated.id()).isEqualTo(created.id());
         assertThat(updated.verdict()).isEqualTo(AnnotationVerdict.CORRECT);
@@ -99,9 +103,14 @@ class AnnotationServiceTest {
     void get_returnsExistingAnnotation() {
         Fixture fixture = newRunWithItem();
         annotationService.upsert(
-                fixture.runId, fixture.itemResultId, new AnnotationRequest(AnnotationVerdict.UNSURE, null, null), null);
+                fixture.runId,
+                fixture.itemResultId,
+                new AnnotationRequest(AnnotationVerdict.UNSURE, null, null),
+                null,
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        AnnotationView view = annotationService.get(fixture.runId, fixture.itemResultId);
+        AnnotationView view = annotationService.get(
+                fixture.runId, fixture.itemResultId, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.verdict()).isEqualTo(AnnotationVerdict.UNSURE);
     }
@@ -110,7 +119,8 @@ class AnnotationServiceTest {
     void get_onUnannotatedItemRaisesNotFound() {
         Fixture fixture = newRunWithItem();
 
-        assertThatThrownBy(() -> annotationService.get(fixture.runId, fixture.itemResultId))
+        assertThatThrownBy(() -> annotationService.get(
+                        fixture.runId, fixture.itemResultId, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Annotation not found");
     }
@@ -122,9 +132,11 @@ class AnnotationServiceTest {
                 fixture.runId,
                 fixture.itemResultId,
                 new AnnotationRequest(AnnotationVerdict.CORRECT, null, null),
-                null);
+                null,
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        annotationService.delete(fixture.runId, fixture.itemResultId);
+        annotationService.delete(
+                fixture.runId, fixture.itemResultId, dev.dokimos.server.tenant.TenantScope.unrestricted());
         entityManager.flush();
 
         assertThat(annotationRepository.findByItemResultId(fixture.itemResultId))
@@ -140,7 +152,8 @@ class AnnotationServiceTest {
                         otherRunId,
                         fixture.itemResultId,
                         new AnnotationRequest(AnnotationVerdict.CORRECT, null, null),
-                        null))
+                        null,
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not belong to run");
     }
@@ -153,7 +166,8 @@ class AnnotationServiceTest {
                         run.getId(),
                         UUID.randomUUID(),
                         new AnnotationRequest(AnnotationVerdict.CORRECT, null, null),
-                        null))
+                        null,
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Item result not found");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/DatasetServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/DatasetServiceTest.java
@@ -132,7 +132,8 @@ class DatasetServiceTest {
         assertThat(created.getId()).isNotNull();
         assertThat(created.getName()).isEqualTo("qa");
         assertThat(created.getDescription()).isEqualTo("small QA set");
-        assertThat(datasetRepository.existsByName("qa")).isTrue();
+        assertThat(datasetRepository.existsByName("qa", dev.dokimos.server.tenant.TenantScope.unrestricted()))
+                .isTrue();
     }
 
     @Test
@@ -271,7 +272,8 @@ class DatasetServiceTest {
         datasetService.deleteDataset("qa", dev.dokimos.server.tenant.TenantScope.unrestricted());
         entityManager.flush();
 
-        assertThat(datasetRepository.existsByName("qa")).isFalse();
+        assertThat(datasetRepository.existsByName("qa", dev.dokimos.server.tenant.TenantScope.unrestricted()))
+                .isFalse();
     }
 
     @Test

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/DatasetServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/DatasetServiceTest.java
@@ -126,7 +126,8 @@ class DatasetServiceTest {
 
     @Test
     void createDataset_persistsAndReturns() {
-        Dataset created = datasetService.createDataset("qa", "small QA set");
+        Dataset created = datasetService.createDataset(
+                "qa", "small QA set", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(created.getId()).isNotNull();
         assertThat(created.getName()).isEqualTo("qa");
@@ -136,19 +137,22 @@ class DatasetServiceTest {
 
     @Test
     void createDataset_duplicateNameRaisesConflict() {
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        assertThatThrownBy(() -> datasetService.createDataset("qa", "another"))
+        assertThatThrownBy(() -> datasetService.createDataset(
+                        "qa", "another", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Dataset already exists");
     }
 
     @Test
     void createVersion_incrementsAndPersistsItems() {
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        DatasetVersion v1 = datasetService.createVersion("qa", "first", twoItems(), "alice");
-        DatasetVersion v2 = datasetService.createVersion("qa", "second", twoItems(), "bob");
+        DatasetVersion v1 = datasetService.createVersion(
+                "qa", "first", twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        DatasetVersion v2 = datasetService.createVersion(
+                "qa", "second", twoItems(), "bob", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(v1.getVersion()).isEqualTo(1);
         assertThat(v1.getItemCount()).isEqualTo(2);
@@ -167,28 +171,32 @@ class DatasetServiceTest {
 
     @Test
     void createVersion_emptyItemsRejected() {
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        assertThatThrownBy(() -> datasetService.createVersion("qa", null, List.of(), "alice"))
+        assertThatThrownBy(() -> datasetService.createVersion(
+                        "qa", null, List.of(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("at least one item");
     }
 
     @Test
     void createVersion_unknownDatasetRaisesNotFound() {
-        assertThatThrownBy(() -> datasetService.createVersion("missing", null, twoItems(), "alice"))
+        assertThatThrownBy(() -> datasetService.createVersion(
+                        "missing", null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Dataset not found");
     }
 
     @Test
     void listDatasets_surfacesLatestVersionAndItemCount() {
-        datasetService.createDataset("qa", "qa set");
-        datasetService.createVersion("qa", null, twoItems(), "alice");
-        datasetService.createVersion("qa", null, twoItems(), "alice");
-        datasetService.createDataset("empty", null);
+        datasetService.createDataset("qa", "qa set", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        datasetService.createVersion(
+                "qa", null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        datasetService.createVersion(
+                "qa", null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        datasetService.createDataset("empty", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        List<DatasetSummary> all = datasetService.listDatasets();
+        List<DatasetSummary> all = datasetService.listDatasets(dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         DatasetSummary qa =
                 all.stream().filter(d -> d.name().equals("qa")).findFirst().orElseThrow();
@@ -207,10 +215,13 @@ class DatasetServiceTest {
         // the collapsed path issues 2 (one for datasets, one for latest-version-per-dataset).
         for (int i = 0; i < 5; i++) {
             String name = "ds-" + i;
-            datasetService.createDataset(name, null);
-            datasetService.createVersion(name, null, twoItems(), "alice");
-            datasetService.createVersion(name, null, twoItems(), "alice");
-            datasetService.createVersion(name, null, twoItems(), "alice");
+            datasetService.createDataset(name, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
+            datasetService.createVersion(
+                    name, null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
+            datasetService.createVersion(
+                    name, null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
+            datasetService.createVersion(
+                    name, null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
         }
 
         // Flush pending writes from the create loop before resetting stats so the auto-flush
@@ -219,7 +230,7 @@ class DatasetServiceTest {
         Statistics stats = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
         stats.clear();
 
-        List<DatasetSummary> all = datasetService.listDatasets();
+        List<DatasetSummary> all = datasetService.listDatasets(dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(all).hasSize(5);
         // Every dataset reports its latest (third) version with two items each.
@@ -235,11 +246,14 @@ class DatasetServiceTest {
 
     @Test
     void getDatasetDetails_listsVersionsNewestFirst() {
-        datasetService.createDataset("qa", null);
-        datasetService.createVersion("qa", "v1", twoItems(), "alice");
-        datasetService.createVersion("qa", "v2", twoItems(), "bob");
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
+        datasetService.createVersion(
+                "qa", "v1", twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        datasetService.createVersion(
+                "qa", "v2", twoItems(), "bob", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        DatasetDetails details = datasetService.getDatasetDetails("qa");
+        DatasetDetails details =
+                datasetService.getDatasetDetails("qa", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(details.versions()).hasSize(2);
         assertThat(details.versions().get(0).version()).isEqualTo(2);
@@ -252,9 +266,9 @@ class DatasetServiceTest {
         // Hibernate-generated schema omits the cascade clause (no @OnDelete on the entity). The
         // real cascade and the SET NULL on experiment_runs.dataset_version_id are verified end
         // to end against PostgreSQL in FlywayMigrationTest.v5BuildsDatasetTables.
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        datasetService.deleteDataset("qa");
+        datasetService.deleteDataset("qa", dev.dokimos.server.tenant.TenantScope.unrestricted());
         entityManager.flush();
 
         assertThat(datasetRepository.existsByName("qa")).isFalse();
@@ -262,32 +276,38 @@ class DatasetServiceTest {
 
     @Test
     void deleteDataset_unknownRaisesNotFound() {
-        assertThatThrownBy(() -> datasetService.deleteDataset("missing"))
+        assertThatThrownBy(() ->
+                        datasetService.deleteDataset("missing", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Dataset not found");
     }
 
     @Test
     void getLatestVersion_noVersionsRaisesNotFound() {
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        assertThatThrownBy(() -> datasetService.getLatestVersion("qa"))
+        assertThatThrownBy(() ->
+                        datasetService.getLatestVersion("qa", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("no versions");
     }
 
     @Test
     void createRun_withDatasetLink_setsDatasetVersionOnRun() {
-        datasetService.createDataset("qa", null);
-        DatasetVersion version = datasetService.createVersion("qa", null, twoItems(), "alice");
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
+        DatasetVersion version = datasetService.createVersion(
+                "qa", null, twoItems(), "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         Project project = projectRepository.save(new Project("p"));
         Experiment experiment = experimentRepository.save(new Experiment(project, "e"));
 
         CreateRunRequest request = new CreateRunRequest("e", null, null, null, null, null, "qa", 1);
 
-        ExperimentRun created = runService.createRun(experiment, request);
-        ExperimentRun reloaded = runRepository.findById(created.getId()).orElseThrow();
+        ExperimentRun created =
+                runService.createRun(experiment, request, dev.dokimos.server.tenant.TenantScope.unrestricted());
+        ExperimentRun reloaded = runRepository
+                .findById(created.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted())
+                .orElseThrow();
 
         assertThat(reloaded.getDatasetVersion()).isNotNull();
         assertThat(reloaded.getDatasetVersion().getId()).isEqualTo(version.getId());
@@ -301,7 +321,8 @@ class DatasetServiceTest {
 
         CreateRunRequest request = new CreateRunRequest("e", null, null, null, null, null, "qa", null);
 
-        assertThatThrownBy(() -> runService.createRun(experiment, request))
+        assertThatThrownBy(() ->
+                        runService.createRun(experiment, request, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("must be set together");
     }
@@ -313,7 +334,8 @@ class DatasetServiceTest {
 
         CreateRunRequest request = new CreateRunRequest("e", null, null, null, null, null, null, 1);
 
-        assertThatThrownBy(() -> runService.createRun(experiment, request))
+        assertThatThrownBy(() ->
+                        runService.createRun(experiment, request, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("must be set together");
     }
@@ -324,15 +346,18 @@ class DatasetServiceTest {
         Experiment experiment = experimentRepository.save(new Experiment(project, "e"));
 
         CreateRunRequest request = new CreateRunRequest("e", null, null, null, null, null);
-        ExperimentRun created = runService.createRun(experiment, request);
+        ExperimentRun created =
+                runService.createRun(experiment, request, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
-        ExperimentRun reloaded = runRepository.findById(created.getId()).orElseThrow();
+        ExperimentRun reloaded = runRepository
+                .findById(created.getId(), dev.dokimos.server.tenant.TenantScope.unrestricted())
+                .orElseThrow();
         assertThat(reloaded.getDatasetVersion()).isNull();
     }
 
     @Test
     void promote_createsNewVersionWithOverrideAndFallback() {
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ItemResult overridden = newItemResult(Map.of("q", "one"), Map.of("a", "orig one"), Map.of("tag", "t1"));
         ItemResult fallback = newItemResult(Map.of("q", "two"), Map.of("a", "orig two"), null);
@@ -344,14 +369,16 @@ class DatasetServiceTest {
                         new PromoteRequest.PromoteItem(overridden.getId(), Map.of("a", "corrected one")),
                         new PromoteRequest.PromoteItem(fallback.getId(), null)));
 
-        DatasetVersionDetails details = datasetService.promote(request, "alice");
+        DatasetVersionDetails details =
+                datasetService.promote(request, "alice", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(details.datasetName()).isEqualTo("qa");
         assertThat(details.version()).isEqualTo(1);
         assertThat(details.itemCount()).isEqualTo(2);
         assertThat(details.createdBy()).isEqualTo("alice");
 
-        DatasetVersion version = datasetService.getVersion("qa", 1);
+        DatasetVersion version =
+                datasetService.getVersion("qa", 1, dev.dokimos.server.tenant.TenantScope.unrestricted());
         List<DatasetItem> items = itemRepository
                 .findByDatasetVersionOrderByOrdinalAsc(version, PageRequest.of(0, 10))
                 .getContent();
@@ -367,12 +394,13 @@ class DatasetServiceTest {
 
     @Test
     void promote_missingItemResultRaisesNotFound() {
-        datasetService.createDataset("qa", null);
+        datasetService.createDataset("qa", null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         PromoteRequest request = new PromoteRequest(
                 "qa", null, List.of(new PromoteRequest.PromoteItem(java.util.UUID.randomUUID(), null)));
 
-        assertThatThrownBy(() -> datasetService.promote(request, "alice"))
+        assertThatThrownBy(() ->
+                        datasetService.promote(request, "alice", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Item result not found");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/DiffServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/DiffServiceTest.java
@@ -81,7 +81,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.summary().pairing()).isEqualTo("dataset_item_id");
         assertThat(view.summary().regressedCount()).isPositive();
@@ -118,7 +123,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.summary().regressedCount()).isZero();
         assertThat(view.summary().improvedCount()).isZero();
@@ -142,7 +152,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "REGRESSED", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "REGRESSED",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.cases().content()).isNotEmpty();
         assertThat(view.cases().content())
@@ -166,7 +181,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView page0 = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 2));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 2),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(page0.cases().totalElements()).isEqualTo(5);
         assertThat(page0.cases().totalPages()).isEqualTo(3);
@@ -174,7 +194,12 @@ class DiffServiceTest {
         assertThat(page0.cases().first()).isTrue();
 
         DiffView page2 = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(2, 2));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(2, 2),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
         assertThat(page2.cases().content()).hasSize(1);
         assertThat(page2.cases().last()).isTrue();
     }
@@ -198,7 +223,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.summary().pairing()).isEqualTo("positional");
         assertThat(view.summary().addedCount()).isEqualTo(2);
@@ -220,7 +250,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.summary().removedCount()).isEqualTo(2);
         DiffCase removed = view.cases().content().stream()
@@ -244,7 +279,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.summary().pairing()).isEqualTo("positional");
         assertThat(view.cases().content()).allSatisfy(c -> assertThat(c.index()).startsWith("item-"));
@@ -266,7 +306,12 @@ class DiffServiceTest {
         entityManager.clear();
 
         DiffView view = diffService.listDiff(
-                fixture.experimentId(), candidate.getId(), baseline.getId(), "ALL", PageRequest.of(0, 50));
+                fixture.experimentId(),
+                candidate.getId(),
+                baseline.getId(),
+                "ALL",
+                PageRequest.of(0, 50),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.cases().content()).allSatisfy(c -> assertThat(c.input()).startsWith("cand question "));
     }
@@ -282,7 +327,13 @@ class DiffServiceTest {
         UUID experimentId = fixture.experimentId();
         UUID candidateId = candidate.getId();
         UUID missing = UUID.randomUUID();
-        assertThatThrownBy(() -> diffService.listDiff(experimentId, candidateId, missing, "ALL", PageRequest.of(0, 50)))
+        assertThatThrownBy(() -> diffService.listDiff(
+                        experimentId,
+                        candidateId,
+                        missing,
+                        "ALL",
+                        PageRequest.of(0, 50),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Baseline run not found");
     }
@@ -299,8 +350,13 @@ class DiffServiceTest {
         UUID experimentId = fixture.experimentId();
         UUID candidateId = candidate.getId();
         UUID baselineId = baseline.getId();
-        assertThatThrownBy(
-                        () -> diffService.listDiff(experimentId, candidateId, baselineId, "ALL", PageRequest.of(0, 50)))
+        assertThatThrownBy(() -> diffService.listDiff(
+                        experimentId,
+                        candidateId,
+                        baselineId,
+                        "ALL",
+                        PageRequest.of(0, 50),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("terminal SUCCESS/FAILED");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/EvalJobServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/EvalJobServiceTest.java
@@ -3,6 +3,7 @@ package dev.dokimos.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -61,12 +62,12 @@ class EvalJobServiceTest {
 
     @Test
     void enqueueCreatesPendingJobAndMovesRunToEvaluating() {
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
-        when(connectionRepository.findById(connectionId)).thenReturn(Optional.of(connection));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
+        when(connectionRepository.findById(eq(connectionId), any())).thenReturn(Optional.of(connection));
         when(jobRepository.existsByRunAndEvaluatorName(run, "judge")).thenReturn(false);
         when(jobRepository.save(any(EvalJob.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        EvalJobView view = service.enqueue(runId, request());
+        EvalJobView view = service.enqueue(runId, request(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.evaluatorName()).isEqualTo("judge");
         verify(run).setStatus(RunStatus.EVALUATING);
@@ -79,27 +80,33 @@ class EvalJobServiceTest {
 
     @Test
     void enqueueRejectsDuplicateEvaluator() {
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
-        when(connectionRepository.findById(connectionId)).thenReturn(Optional.of(connection));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
+        when(connectionRepository.findById(eq(connectionId), any())).thenReturn(Optional.of(connection));
         when(jobRepository.existsByRunAndEvaluatorName(run, "judge")).thenReturn(true);
 
-        assertThatThrownBy(() -> service.enqueue(runId, request())).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(
+                        () -> service.enqueue(runId, request(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
+                .isInstanceOf(IllegalStateException.class);
 
         verify(jobRepository, never()).save(any());
     }
 
     @Test
     void enqueueRejectsMissingRun() {
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.empty());
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.enqueue(runId, request())).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () -> service.enqueue(runId, request(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void enqueueRejectsMissingConnection() {
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
-        when(connectionRepository.findById(connectionId)).thenReturn(Optional.empty());
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
+        when(connectionRepository.findById(eq(connectionId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.enqueue(runId, request())).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(
+                        () -> service.enqueue(runId, request(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/ExperimentServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/ExperimentServiceTest.java
@@ -16,7 +16,6 @@ import dev.dokimos.server.entity.Project;
 import dev.dokimos.server.entity.RunStatus;
 import dev.dokimos.server.repository.ExperimentRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
-import dev.dokimos.server.repository.ItemResultRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -39,24 +38,22 @@ class ExperimentServiceTest {
     @Mock
     private ExperimentRunRepository runRepository;
 
-    @Mock
-    private ItemResultRepository itemResultRepository;
-
     private ExperimentService experimentService;
 
     @BeforeEach
     void setUp() {
-        experimentService = new ExperimentService(experimentRepository, runRepository, itemResultRepository);
+        experimentService = new ExperimentService(experimentRepository, runRepository);
     }
 
     @Test
     void getOrCreateExperiment_shouldReturnExisting() {
         Project project = createProject("my-project");
         Experiment existing = createExperiment(project, "my-experiment");
-        when(experimentRepository.findByProjectAndName(project, "my-experiment"))
+        when(experimentRepository.findByProjectAndName(eq(project), eq("my-experiment"), any()))
                 .thenReturn(Optional.of(existing));
 
-        Experiment result = experimentService.getOrCreateExperiment(project, "my-experiment");
+        Experiment result = experimentService.getOrCreateExperiment(
+                project, "my-experiment", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).isEqualTo(existing);
         verify(experimentRepository, never()).save(any());
@@ -65,11 +62,12 @@ class ExperimentServiceTest {
     @Test
     void getOrCreateExperiment_shouldCreateNew() {
         Project project = createProject("my-project");
-        when(experimentRepository.findByProjectAndName(project, "new-experiment"))
+        when(experimentRepository.findByProjectAndName(eq(project), eq("new-experiment"), any()))
                 .thenReturn(Optional.empty());
         when(experimentRepository.save(any(Experiment.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Experiment result = experimentService.getOrCreateExperiment(project, "new-experiment");
+        Experiment result = experimentService.getOrCreateExperiment(
+                project, "new-experiment", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.getName()).isEqualTo("new-experiment");
         verify(experimentRepository).save(any(Experiment.class));
@@ -81,9 +79,10 @@ class ExperimentServiceTest {
         Project project = createProject("my-project");
         Experiment experiment = createExperiment(project, "my-experiment");
         setField(experiment, "id", experimentId);
-        when(experimentRepository.findById(experimentId)).thenReturn(Optional.of(experiment));
+        when(experimentRepository.findById(eq(experimentId), any())).thenReturn(Optional.of(experiment));
 
-        Experiment result = experimentService.getExperiment(experimentId);
+        Experiment result =
+                experimentService.getExperiment(experimentId, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).isEqualTo(experiment);
     }
@@ -91,16 +90,18 @@ class ExperimentServiceTest {
     @Test
     void getExperiment_shouldThrowWhenNotFound() {
         UUID experimentId = UUID.randomUUID();
-        when(experimentRepository.findById(experimentId)).thenReturn(Optional.empty());
+        when(experimentRepository.findById(eq(experimentId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> experimentService.getExperiment(experimentId))
+        assertThatThrownBy(() -> experimentService.getExperiment(
+                        experimentId, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Experiment not found");
     }
 
     @Test
     void getExperiment_shouldThrowWhenIdIsNull() {
-        assertThatThrownBy(() -> experimentService.getExperiment(null))
+        assertThatThrownBy(() ->
+                        experimentService.getExperiment(null, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Experiment ID cannot be null");
     }
@@ -111,9 +112,9 @@ class ExperimentServiceTest {
         Project project = createProject("my-project");
         Experiment experiment = createExperiment(project, "my-experiment");
         setField(experiment, "id", experimentId);
-        when(experimentRepository.findById(experimentId)).thenReturn(Optional.of(experiment));
+        when(experimentRepository.findById(eq(experimentId), any())).thenReturn(Optional.of(experiment));
 
-        experimentService.deleteExperiment(experimentId);
+        experimentService.deleteExperiment(experimentId, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(experimentRepository).delete(experiment);
     }
@@ -121,9 +122,10 @@ class ExperimentServiceTest {
     @Test
     void deleteExperiment_shouldThrowWhenNotFound() {
         UUID experimentId = UUID.randomUUID();
-        when(experimentRepository.findById(experimentId)).thenReturn(Optional.empty());
+        when(experimentRepository.findById(eq(experimentId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> experimentService.deleteExperiment(experimentId))
+        assertThatThrownBy(() -> experimentService.deleteExperiment(
+                        experimentId, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Experiment not found");
     }
@@ -135,11 +137,11 @@ class ExperimentServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.SUCCESS);
         setMaterializedCounts(run, 10, 8);
 
-        when(experimentRepository.findByProjectOrderByCreatedAtDesc(project)).thenReturn(List.of(experiment));
-        when(runRepository.findFirstByExperimentOrderByStartedAtDesc(experiment))
-                .thenReturn(Optional.of(run));
+        when(experimentRepository.findByProject(eq(project), any())).thenReturn(List.of(experiment));
+        when(runRepository.findFirstByExperiment(eq(experiment), any())).thenReturn(Optional.of(run));
 
-        List<ExperimentSummary> result = experimentService.listExperiments(project);
+        List<ExperimentSummary> result =
+                experimentService.listExperiments(project, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).name()).isEqualTo("my-experiment");
@@ -153,11 +155,11 @@ class ExperimentServiceTest {
         Project project = createProject("my-project");
         Experiment experiment = createExperiment(project, "my-experiment");
 
-        when(experimentRepository.findByProjectOrderByCreatedAtDesc(project)).thenReturn(List.of(experiment));
-        when(runRepository.findFirstByExperimentOrderByStartedAtDesc(experiment))
-                .thenReturn(Optional.empty());
+        when(experimentRepository.findByProject(eq(project), any())).thenReturn(List.of(experiment));
+        when(runRepository.findFirstByExperiment(eq(experiment), any())).thenReturn(Optional.empty());
 
-        List<ExperimentSummary> result = experimentService.listExperiments(project);
+        List<ExperimentSummary> result =
+                experimentService.listExperiments(project, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).latestRun()).isNull();
@@ -169,11 +171,11 @@ class ExperimentServiceTest {
         Experiment experiment = createExperiment(project, "my-experiment");
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
 
-        when(experimentRepository.findByProjectOrderByCreatedAtDesc(project)).thenReturn(List.of(experiment));
-        when(runRepository.findFirstByExperimentOrderByStartedAtDesc(experiment))
-                .thenReturn(Optional.of(run));
+        when(experimentRepository.findByProject(eq(project), any())).thenReturn(List.of(experiment));
+        when(runRepository.findFirstByExperiment(eq(experiment), any())).thenReturn(Optional.of(run));
 
-        List<ExperimentSummary> result = experimentService.listExperiments(project);
+        List<ExperimentSummary> result =
+                experimentService.listExperiments(project, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.get(0).latestRun().passRate()).isNull();
     }
@@ -189,11 +191,12 @@ class ExperimentServiceTest {
         setMaterializedCounts(run1, 10, 8);
         setMaterializedCounts(run2, 5, 5);
 
-        when(experimentRepository.findById(experimentId)).thenReturn(Optional.of(experiment));
-        when(runRepository.findCompletedRunsByExperiment(eq(experiment), any(PageRequest.class)))
+        when(experimentRepository.findById(eq(experimentId), any())).thenReturn(Optional.of(experiment));
+        when(runRepository.findCompletedRunsByExperiment(eq(experiment), any(PageRequest.class), any()))
                 .thenReturn(List.of(run1, run2));
 
-        TrendData result = experimentService.getTrends(experimentId, 20);
+        TrendData result =
+                experimentService.getTrends(experimentId, 20, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.experimentName()).isEqualTo("my-experiment");
         assertThat(result.runs()).hasSize(2);
@@ -208,11 +211,12 @@ class ExperimentServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.SUCCESS);
         setMaterializedCounts(run, 0, 0);
 
-        when(experimentRepository.findById(experimentId)).thenReturn(Optional.of(experiment));
-        when(runRepository.findCompletedRunsByExperiment(eq(experiment), any(PageRequest.class)))
+        when(experimentRepository.findById(eq(experimentId), any())).thenReturn(Optional.of(experiment));
+        when(runRepository.findCompletedRunsByExperiment(eq(experiment), any(PageRequest.class), any()))
                 .thenReturn(List.of(run));
 
-        TrendData result = experimentService.getTrends(experimentId, 20);
+        TrendData result =
+                experimentService.getTrends(experimentId, 20, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.runs().get(0).passRate()).isEqualTo(0.0);
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/GateServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/GateServiceTest.java
@@ -79,8 +79,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.status()).isEqualTo("FAIL");
         assertThat(result.passed()).isFalse();
@@ -107,8 +109,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.status()).isEqualTo("PASS");
         assertThat(result.passed()).isTrue();
@@ -136,8 +140,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.status()).isEqualTo("PASS");
         assertThat(result.passed()).isTrue();
@@ -164,8 +170,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.pairing()).isEqualTo("positional");
         assertThat(result.status()).isIn("PASS", "FAIL");
@@ -182,7 +190,10 @@ class GateServiceTest {
 
         UUID experimentId = fixture.experimentId();
         UUID candidateId = candidate.getId();
-        assertThatThrownBy(() -> gateService.evaluateGate(experimentId, new GateRequest(candidateId, null, null)))
+        assertThatThrownBy(() -> gateService.evaluateGate(
+                        experimentId,
+                        new GateRequest(candidateId, null, null),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("terminal SUCCESS/FAILED")
                 .hasMessageContaining("CANCELLED");
@@ -205,13 +216,17 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult auto =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult auto = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
         assertThat(auto.status()).isEqualTo("NO_BASELINE");
         assertThat(auto.baselineRunId()).isNull();
 
         GateResult explicit = gateService.evaluateGate(
-                fixture.experimentId(), new GateRequest(candidate.getId(), failedPrior.getId(), null));
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), failedPrior.getId(), null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
         assertThat(explicit.baselineRunId()).isEqualTo(failedPrior.getId());
         assertThat(explicit.status()).isIn("PASS", "FAIL");
     }
@@ -233,8 +248,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.status()).isEqualTo("FAIL");
         assertThat(result.cases()).hasSize(50);
@@ -254,8 +271,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.status()).isEqualTo("NO_BASELINE");
         assertThat(result.passed()).isTrue();
@@ -283,7 +302,9 @@ class GateServiceTest {
         entityManager.clear();
 
         GateResult result = gateService.evaluateGate(
-                fixture.experimentId(), new GateRequest(candidate.getId(), olderBaseline.getId(), null));
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), olderBaseline.getId(), null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.baselineRunId()).isEqualTo(olderBaseline.getId());
         assertThat(result.status()).isEqualTo("PASS");
@@ -307,8 +328,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, "main"));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, "main"),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.baselineRunId()).isEqualTo(mainBaseline.getId());
     }
@@ -323,7 +346,10 @@ class GateServiceTest {
 
         UUID experimentId = fixture.experimentId();
         UUID candidateId = candidate.getId();
-        assertThatThrownBy(() -> gateService.evaluateGate(experimentId, new GateRequest(candidateId, null, null)))
+        assertThatThrownBy(() -> gateService.evaluateGate(
+                        experimentId,
+                        new GateRequest(candidateId, null, null),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("terminal SUCCESS/FAILED")
                 .hasMessageContaining("RUNNING");
@@ -343,8 +369,10 @@ class GateServiceTest {
         entityManager.flush();
         entityManager.clear();
 
-        GateResult result =
-                gateService.evaluateGate(fixture.experimentId(), new GateRequest(candidate.getId(), null, null));
+        GateResult result = gateService.evaluateGate(
+                fixture.experimentId(),
+                new GateRequest(candidate.getId(), null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.pairing()).isEqualTo("positional");
         assertThat(result.status()).isEqualTo("PASS");
@@ -363,7 +391,10 @@ class GateServiceTest {
 
         UUID otherId = otherExperiment.getId();
         UUID candidateId = candidate.getId();
-        assertThatThrownBy(() -> gateService.evaluateGate(otherId, new GateRequest(candidateId, null, null)))
+        assertThatThrownBy(() -> gateService.evaluateGate(
+                        otherId,
+                        new GateRequest(candidateId, null, null),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not belong to experiment");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/JudgeJobTransactionsPostgresTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/JudgeJobTransactionsPostgresTest.java
@@ -1,0 +1,182 @@
+package dev.dokimos.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+import dev.dokimos.server.entity.EvalJob;
+import dev.dokimos.server.entity.EvalResult;
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.ItemResult;
+import dev.dokimos.server.entity.LlmConnection;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.repository.EvalJobRepository;
+import dev.dokimos.server.repository.EvalResultRepository;
+import dev.dokimos.server.repository.ExperimentRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.repository.ItemResultRepository;
+import dev.dokimos.server.repository.LlmConnectionRepository;
+import dev.dokimos.server.repository.ProjectRepository;
+import dev.dokimos.server.service.JudgeJobTransactions.ScoredResult;
+import dev.dokimos.server.tenant.TenantScope;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Proves that the judge worker stamps each eval result it persists with its parent item's tenant, so a
+ * worker-produced result stays visible only under the same tenant scope as the item it belongs to.
+ * Runs against a real PostgreSQL instance (Testcontainers) with the production Flyway schema because
+ * {@code persistPage} loads the parent item through {@code getReferenceById}, which only resolves a
+ * tenant id against a live session. {@code RunService} is mocked since {@code persistPage} never touches
+ * it. Self-skips when Docker is unavailable so it stays safe in the normal build.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JudgeJobTransactionsPostgresTest.TestConfig.class)
+class JudgeJobTransactionsPostgresTest {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    static class TestConfig {
+        @org.springframework.context.annotation.Bean
+        JudgeJobTransactions judgeJobTransactions(
+                EvalJobRepository jobRepository,
+                EvalResultRepository evalResultRepository,
+                ItemResultRepository itemResultRepository) {
+            return new JudgeJobTransactions(
+                    jobRepository, evalResultRepository, itemResultRepository, mock(RunService.class));
+        }
+    }
+
+    private static final boolean DOCKER_AVAILABLE =
+            DockerClientFactory.instance().isDockerAvailable();
+
+    private static final PostgreSQLContainer<?> postgres;
+
+    static {
+        if (DOCKER_AVAILABLE) {
+            postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+            postgres.start();
+            awaitConnectable(postgres);
+        } else {
+            postgres = null;
+        }
+    }
+
+    private static void awaitConnectable(PostgreSQLContainer<?> container) {
+        org.postgresql.ds.PGSimpleDataSource ds = new org.postgresql.ds.PGSimpleDataSource();
+        ds.setUrl(container.getJdbcUrl());
+        ds.setUser(container.getUsername());
+        ds.setPassword(container.getPassword());
+        RuntimeException last = null;
+        for (int attempt = 0; attempt < 30; attempt++) {
+            try (java.sql.Connection ignored = ds.getConnection()) {
+                return;
+            } catch (Exception e) {
+                last = new IllegalStateException("Postgres not yet connectable", e);
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for Postgres", ie);
+                }
+            }
+        }
+        throw new IllegalStateException("Postgres did not become connectable in time", last);
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        if (!DOCKER_AVAILABLE) {
+            return;
+        }
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+        registry.add("spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
+        registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    @Autowired
+    private JudgeJobTransactions transactions;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ExperimentRepository experimentRepository;
+
+    @Autowired
+    private ExperimentRunRepository runRepository;
+
+    @Autowired
+    private ItemResultRepository itemResultRepository;
+
+    @Autowired
+    private LlmConnectionRepository connectionRepository;
+
+    @Autowired
+    private EvalJobRepository jobRepository;
+
+    @Autowired
+    private EvalResultRepository evalResultRepository;
+
+    @Autowired
+    private org.springframework.transaction.PlatformTransactionManager transactionManager;
+
+    // NOT_SUPPORTED suspends the transaction @DataJpaTest wraps around the test method so the setup
+    // commits before persistPage runs. persistPage uses REQUIRES_NEW, which opens its own transaction
+    // that cannot see rows merely flushed into a never-committed context, so the parent item must be
+    // committed first. The assertion read is wrapped in its own committed transaction for the same
+    // reason.
+    @Test
+    @org.springframework.transaction.annotation.Transactional(
+            propagation = org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED)
+    void persistPage_shouldStampEvalResultWithParentItemTenant() {
+        assumeTrue(DOCKER_AVAILABLE, "Docker not available");
+
+        org.springframework.transaction.support.TransactionTemplate tx =
+                new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+
+        UUID jobId = tx.execute(status -> {
+            Project project = projectRepository.save(new Project("judge-project-" + UUID.randomUUID()));
+            Experiment experiment = experimentRepository.save(new Experiment(project, "judge-experiment"));
+            ExperimentRun run = runRepository.save(new ExperimentRun(experiment, Map.of()));
+            LlmConnection connectionEntity =
+                    new LlmConnection("judge-conn-" + UUID.randomUUID(), "https://example.invalid", "gpt");
+            connectionEntity.setCredentialRef("OPENAI_KEY");
+            LlmConnection connection = connectionRepository.save(connectionEntity);
+            EvalJob jobEntity = new EvalJob(run, connection, "correctness", "criteria");
+            jobEntity.setEvaluationParams("{}");
+            return jobRepository.save(jobEntity).getId();
+        });
+
+        UUID itemId = tx.execute(status -> {
+            ExperimentRun run = runRepository.findAll(TenantScope.unrestricted()).stream()
+                    .findFirst()
+                    .orElseThrow();
+            ItemResult item = new ItemResult(run, Map.of("q", "x"), Map.of("a", "y"), Map.of("a", "y"), Map.of());
+            item.setTenantId("tenant-a");
+            return itemResultRepository.save(item).getId();
+        });
+
+        EvalResult eval = new EvalResult("correctness", 1.0, 0.9, true, "ok");
+        transactions.persistPage(jobId, List.of(new ScoredResult(itemId, eval)), itemId);
+
+        EvalResult persisted =
+                tx.execute(status -> evalResultRepository.findById(eval.getId()).orElseThrow());
+        assertThat(persisted.getTenantId()).isEqualTo("tenant-a");
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/JudgeJobTransactionsPostgresTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/JudgeJobTransactionsPostgresTest.java
@@ -34,12 +34,10 @@ import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
- * Proves that the judge worker stamps each eval result it persists with its parent item's tenant, so a
- * worker-produced result stays visible only under the same tenant scope as the item it belongs to.
- * Runs against a real PostgreSQL instance (Testcontainers) with the production Flyway schema because
- * {@code persistPage} loads the parent item through {@code getReferenceById}, which only resolves a
- * tenant id against a live session. {@code RunService} is mocked since {@code persistPage} never touches
- * it. Self-skips when Docker is unavailable so it stays safe in the normal build.
+ * Proves the judge worker stamps each eval result with its parent item's tenant, so a worker-produced
+ * result stays visible only under the same scope as the item it belongs to. Runs on PostgreSQL
+ * (Testcontainers) with the Flyway schema because {@code persistPage} resolves the parent tenant through
+ * {@code getReferenceById}, which needs a live session. Self-skips when Docker is unavailable.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -136,11 +134,9 @@ class JudgeJobTransactionsPostgresTest {
     @Autowired
     private org.springframework.transaction.PlatformTransactionManager transactionManager;
 
-    // NOT_SUPPORTED suspends the transaction @DataJpaTest wraps around the test method so the setup
-    // commits before persistPage runs. persistPage uses REQUIRES_NEW, which opens its own transaction
-    // that cannot see rows merely flushed into a never-committed context, so the parent item must be
-    // committed first. The assertion read is wrapped in its own committed transaction for the same
-    // reason.
+    // NOT_SUPPORTED suspends the @DataJpaTest transaction so the setup commits before persistPage runs:
+    // persistPage uses REQUIRES_NEW and cannot see rows only flushed into a never-committed context. The
+    // assertion read is wrapped in its own committed transaction for the same reason.
     @Test
     @org.springframework.transaction.annotation.Transactional(
             propagation = org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED)

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/LlmConnectionServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/LlmConnectionServiceTest.java
@@ -41,7 +41,7 @@ class LlmConnectionServiceTest {
 
     @Test
     void create_defaultsProtocolToResponsesWhenOmitted() {
-        when(connectionRepository.existsByName("conn")).thenReturn(false);
+        when(connectionRepository.existsByName(eq("conn"), any())).thenReturn(false);
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
         service.create(
@@ -55,7 +55,7 @@ class LlmConnectionServiceTest {
 
     @Test
     void create_honorsAnExplicitProtocol() {
-        when(connectionRepository.existsByName("conn")).thenReturn(false);
+        when(connectionRepository.existsByName(eq("conn"), any())).thenReturn(false);
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
         service.create(
@@ -142,7 +142,7 @@ class LlmConnectionServiceTest {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("conn", "https://x", "gpt-4o-mini");
         when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
-        when(connectionRepository.existsByName("taken")).thenReturn(true);
+        when(connectionRepository.existsByName(eq("taken"), any())).thenReturn(true);
 
         assertThatThrownBy(() -> service.update(
                         id,

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/LlmConnectionServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/LlmConnectionServiceTest.java
@@ -3,6 +3,7 @@ package dev.dokimos.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,7 +44,9 @@ class LlmConnectionServiceTest {
         when(connectionRepository.existsByName("conn")).thenReturn(false);
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.create(new CreateLlmConnectionRequest("conn", "https://x", "gpt-4o-mini", null, null, "OPENAI_KEY"));
+        service.create(
+                new CreateLlmConnectionRequest("conn", "https://x", "gpt-4o-mini", null, null, "OPENAI_KEY"),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<LlmConnection> saved = ArgumentCaptor.forClass(LlmConnection.class);
         verify(connectionRepository).save(saved.capture());
@@ -55,8 +58,10 @@ class LlmConnectionServiceTest {
         when(connectionRepository.existsByName("conn")).thenReturn(false);
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.create(new CreateLlmConnectionRequest(
-                "conn", "https://x", "gpt-4o-mini", LlmConnectionProtocol.CHAT_COMPLETIONS, null, "OPENAI_KEY"));
+        service.create(
+                new CreateLlmConnectionRequest(
+                        "conn", "https://x", "gpt-4o-mini", LlmConnectionProtocol.CHAT_COMPLETIONS, null, "OPENAI_KEY"),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<LlmConnection> saved = ArgumentCaptor.forClass(LlmConnection.class);
         verify(connectionRepository).save(saved.capture());
@@ -67,13 +72,14 @@ class LlmConnectionServiceTest {
     void update_replacesProtocolWhenSupplied() {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("conn", "https://x", "gpt-4o-mini");
-        when(connectionRepository.findById(id)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
         service.update(
                 id,
                 new UpdateLlmConnectionRequest(
-                        "conn", "https://x", "gpt-4o-mini", LlmConnectionProtocol.CHAT_COMPLETIONS, null, null));
+                        "conn", "https://x", "gpt-4o-mini", LlmConnectionProtocol.CHAT_COMPLETIONS, null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(connection.getProtocol()).isEqualTo(LlmConnectionProtocol.CHAT_COMPLETIONS);
     }
@@ -83,10 +89,13 @@ class LlmConnectionServiceTest {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("conn", "https://x", "gpt-4o-mini");
         connection.setProtocol(LlmConnectionProtocol.CHAT_COMPLETIONS);
-        when(connectionRepository.findById(id)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.update(id, new UpdateLlmConnectionRequest("conn", "https://x", "gpt-4o-mini", null, null, null));
+        service.update(
+                id,
+                new UpdateLlmConnectionRequest("conn", "https://x", "gpt-4o-mini", null, null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(connection.getProtocol()).isEqualTo(LlmConnectionProtocol.CHAT_COMPLETIONS);
     }
@@ -96,11 +105,13 @@ class LlmConnectionServiceTest {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("old", "https://old", "gpt-3.5");
         connection.setEncryptedApiKey("cipher");
-        when(connectionRepository.findById(id)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
         LlmConnectionView view = service.update(
-                id, new UpdateLlmConnectionRequest("new", "https://new", "gpt-4o-mini", null, null, null));
+                id,
+                new UpdateLlmConnectionRequest("new", "https://new", "gpt-4o-mini", null, null, null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.name()).isEqualTo("new");
         assertThat(view.baseUrl()).isEqualTo("https://new");
@@ -114,10 +125,13 @@ class LlmConnectionServiceTest {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("conn", "https://x", "gpt-4o-mini");
         connection.setCredentialRef("OPENAI_KEY");
-        when(connectionRepository.findById(id)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
         when(connectionRepository.save(any(LlmConnection.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.update(id, new UpdateLlmConnectionRequest("conn", "https://x", "gpt-4o-mini", null, "sk-new", null));
+        service.update(
+                id,
+                new UpdateLlmConnectionRequest("conn", "https://x", "gpt-4o-mini", null, "sk-new", null),
+                dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(credentialService).encryptInlineKey(connection, "sk-new");
         assertThat(connection.getCredentialRef()).isNull();
@@ -127,11 +141,13 @@ class LlmConnectionServiceTest {
     void update_throwsWhenNewNameTaken() {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("conn", "https://x", "gpt-4o-mini");
-        when(connectionRepository.findById(id)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
         when(connectionRepository.existsByName("taken")).thenReturn(true);
 
         assertThatThrownBy(() -> service.update(
-                        id, new UpdateLlmConnectionRequest("taken", "https://x", "gpt-4o-mini", null, null, null)))
+                        id,
+                        new UpdateLlmConnectionRequest("taken", "https://x", "gpt-4o-mini", null, null, null),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("already exists");
     }
@@ -140,9 +156,9 @@ class LlmConnectionServiceTest {
     void delete_removesConnectionAndItsQueueRecords() {
         UUID id = UUID.randomUUID();
         LlmConnection connection = new LlmConnection("conn", "https://x", "gpt-4o-mini");
-        when(connectionRepository.findById(id)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.of(connection));
 
-        service.delete(id);
+        service.delete(id, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(evalJobRepository).deleteByConnectionId(id);
         verify(connectionRepository).delete(connection);
@@ -151,9 +167,9 @@ class LlmConnectionServiceTest {
     @Test
     void delete_throwsWhenConnectionMissing() {
         UUID id = UUID.randomUUID();
-        when(connectionRepository.findById(id)).thenReturn(Optional.empty());
+        when(connectionRepository.findById(eq(id), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.delete(id))
+        assertThatThrownBy(() -> service.delete(id, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("not found");
         verify(connectionRepository, never()).delete(any());

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/ProjectServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/ProjectServiceTest.java
@@ -3,6 +3,7 @@ package dev.dokimos.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,9 +38,10 @@ class ProjectServiceTest {
     @Test
     void getOrCreateProject_shouldReturnExistingProject() {
         Project existing = createProject("my-project");
-        when(projectRepository.findByName("my-project")).thenReturn(Optional.of(existing));
+        when(projectRepository.findByName(eq("my-project"), any())).thenReturn(Optional.of(existing));
 
-        Project result = projectService.getOrCreateProject("my-project");
+        Project result =
+                projectService.getOrCreateProject("my-project", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).isEqualTo(existing);
         verify(projectRepository, never()).save(any());
@@ -47,10 +49,11 @@ class ProjectServiceTest {
 
     @Test
     void getOrCreateProject_shouldCreateNewProject() {
-        when(projectRepository.findByName("new-project")).thenReturn(Optional.empty());
+        when(projectRepository.findByName(eq("new-project"), any())).thenReturn(Optional.empty());
         when(projectRepository.save(any(Project.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Project result = projectService.getOrCreateProject("new-project");
+        Project result =
+                projectService.getOrCreateProject("new-project", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.getName()).isEqualTo("new-project");
         verify(projectRepository).save(any(Project.class));
@@ -59,18 +62,19 @@ class ProjectServiceTest {
     @Test
     void getProject_shouldReturnProject() {
         Project project = createProject("my-project");
-        when(projectRepository.findByName("my-project")).thenReturn(Optional.of(project));
+        when(projectRepository.findByName(eq("my-project"), any())).thenReturn(Optional.of(project));
 
-        Project result = projectService.getProject("my-project");
+        Project result = projectService.getProject("my-project", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).isEqualTo(project);
     }
 
     @Test
     void getProject_shouldThrowWhenNotFound() {
-        when(projectRepository.findByName("unknown")).thenReturn(Optional.empty());
+        when(projectRepository.findByName(eq("unknown"), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> projectService.getProject("unknown"))
+        assertThatThrownBy(() ->
+                        projectService.getProject("unknown", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Project not found: unknown");
     }
@@ -81,9 +85,9 @@ class ProjectServiceTest {
         Project project2 = createProject("project-2");
 
         List<Object[]> rows = List.of(new Object[] {project1, 5L}, new Object[] {project2, 3L});
-        when(projectRepository.findAllWithExperimentCount()).thenReturn(rows);
+        when(projectRepository.findAllWithExperimentCount(any())).thenReturn(rows);
 
-        List<ProjectSummary> result = projectService.listProjects();
+        List<ProjectSummary> result = projectService.listProjects(dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).name()).isEqualTo("project-1");
@@ -94,9 +98,9 @@ class ProjectServiceTest {
 
     @Test
     void listProjects_shouldReturnEmptyList() {
-        when(projectRepository.findAllWithExperimentCount()).thenReturn(List.of());
+        when(projectRepository.findAllWithExperimentCount(any())).thenReturn(List.of());
 
-        List<ProjectSummary> result = projectService.listProjects();
+        List<ProjectSummary> result = projectService.listProjects(dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).isEmpty();
     }
@@ -104,18 +108,19 @@ class ProjectServiceTest {
     @Test
     void deleteProject_shouldDeleteWhenFound() {
         Project project = createProject("my-project");
-        when(projectRepository.findByName("my-project")).thenReturn(Optional.of(project));
+        when(projectRepository.findByName(eq("my-project"), any())).thenReturn(Optional.of(project));
 
-        projectService.deleteProject("my-project");
+        projectService.deleteProject("my-project", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(projectRepository).delete(project);
     }
 
     @Test
     void deleteProject_shouldThrowWhenNotFound() {
-        when(projectRepository.findByName("unknown")).thenReturn(Optional.empty());
+        when(projectRepository.findByName(eq("unknown"), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> projectService.deleteProject("unknown"))
+        assertThatThrownBy(() ->
+                        projectService.deleteProject("unknown", dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Project not found: unknown");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/RegressionAlertServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/RegressionAlertServiceTest.java
@@ -53,7 +53,7 @@ class RegressionAlertServiceTest {
         ExperimentRun baseline = run(experiment, RunStatus.SUCCESS);
 
         when(runRepository.findBaselineCandidates(
-                        eq(experiment), eq(candidate.getId()), any(), any(), any(Pageable.class)))
+                        eq(experiment), eq(candidate.getId()), any(), any(), any(Pageable.class), any()))
                 .thenReturn(List.of(baseline));
         RunComparisonResult comparison = comparison(0.9, 0.6, true);
         when(comparisonSupport.compare(baseline, candidate))
@@ -84,7 +84,7 @@ class RegressionAlertServiceTest {
         ExperimentRun baseline = run(experiment, RunStatus.SUCCESS);
 
         when(runRepository.findBaselineCandidates(
-                        eq(experiment), eq(candidate.getId()), any(), any(), any(Pageable.class)))
+                        eq(experiment), eq(candidate.getId()), any(), any(), any(Pageable.class), any()))
                 .thenReturn(List.of(baseline));
         when(comparisonSupport.compare(baseline, candidate))
                 .thenReturn(new ComparisonSupport.ComparisonOutcome(
@@ -102,7 +102,7 @@ class RegressionAlertServiceTest {
         ExperimentRun candidate = run(experiment, RunStatus.SUCCESS);
 
         when(runRepository.findBaselineCandidates(
-                        eq(experiment), eq(candidate.getId()), any(), any(), any(Pageable.class)))
+                        eq(experiment), eq(candidate.getId()), any(), any(), any(Pageable.class), any()))
                 .thenReturn(List.of());
 
         service.evaluateOnCompletion(candidate);
@@ -116,7 +116,7 @@ class RegressionAlertServiceTest {
         Experiment experiment = experiment(project, "qa-suite");
         ExperimentRun candidate = run(experiment, RunStatus.SUCCESS);
 
-        when(runRepository.findBaselineCandidates(any(), any(), any(), any(), any(Pageable.class)))
+        when(runRepository.findBaselineCandidates(any(), any(), any(), any(), any(Pageable.class), any()))
                 .thenThrow(new RuntimeException("db down"));
 
         // Must not propagate: run completion has already committed materialized counts.

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/ReviewQueuePostgresTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/ReviewQueuePostgresTest.java
@@ -15,6 +15,7 @@ import dev.dokimos.server.repository.ExperimentRepository;
 import dev.dokimos.server.repository.ExperimentRunRepository;
 import dev.dokimos.server.repository.ItemResultRepository;
 import dev.dokimos.server.repository.ProjectRepository;
+import dev.dokimos.server.tenant.TenantScope;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -131,7 +132,8 @@ class ReviewQueuePostgresTest {
         annotate(correct, AnnotationVerdict.CORRECT);
         annotate(incorrect, AnnotationVerdict.INCORRECT);
 
-        Page<ReviewQueueItem> page = reviewQueueService.list(null, null, null, PageRequest.of(0, 50));
+        Page<ReviewQueueItem> page =
+                reviewQueueService.list(null, null, null, PageRequest.of(0, 50), TenantScope.unrestricted());
 
         assertThat(page.getContent())
                 .extracting(ReviewQueueItem::itemId)
@@ -146,7 +148,8 @@ class ReviewQueuePostgresTest {
         ItemResult unsure = persistItem(run);
         annotate(unsure, AnnotationVerdict.UNSURE);
 
-        Page<ReviewQueueItem> page = reviewQueueService.list(null, null, null, PageRequest.of(0, 50));
+        Page<ReviewQueueItem> page =
+                reviewQueueService.list(null, null, null, PageRequest.of(0, 50), TenantScope.unrestricted());
 
         assertThat(itemFor(page.getContent(), unsure).currentVerdict()).isEqualTo(AnnotationVerdict.UNSURE);
         assertThat(itemFor(page.getContent(), unannotated).currentVerdict()).isNull();
@@ -161,21 +164,43 @@ class ReviewQueuePostgresTest {
         ItemResult itemTwo = persistItem(runTwo);
 
         assertThat(reviewQueueService
-                        .list(null, null, runOne.getId(), PageRequest.of(0, 50))
+                        .list(null, null, runOne.getId(), PageRequest.of(0, 50), TenantScope.unrestricted())
                         .getContent())
                 .extracting(ReviewQueueItem::itemId)
                 .containsExactly(itemOne.getId());
 
         assertThat(reviewQueueService
-                        .list("delta", null, null, PageRequest.of(0, 50))
+                        .list("delta", null, null, PageRequest.of(0, 50), TenantScope.unrestricted())
                         .getContent())
                 .extracting(ReviewQueueItem::itemId)
                 .containsExactly(itemTwo.getId());
 
         assertThat(reviewQueueService
-                        .list("no-such-project", null, null, PageRequest.of(0, 50))
+                        .list("no-such-project", null, null, PageRequest.of(0, 50), TenantScope.unrestricted())
                         .getContent())
                 .isEmpty();
+    }
+
+    @Test
+    void list_shouldScopeByTenant() {
+        assumeTrue(DOCKER_AVAILABLE, "Docker not available");
+        ExperimentRun run = persistRun("epsilon", "exp-e");
+        ItemResult tenantA = persistItem(run, "tenant-a");
+        ItemResult tenantB = persistItem(run, "tenant-b");
+        ItemResult shared = persistItem(run, null);
+
+        assertThat(reviewQueueService
+                        .list(null, null, null, PageRequest.of(0, 50), TenantScope.scoped("tenant-a"))
+                        .getContent())
+                .extracting(ReviewQueueItem::itemId)
+                .containsExactlyInAnyOrder(tenantA.getId(), shared.getId())
+                .doesNotContain(tenantB.getId());
+
+        assertThat(reviewQueueService
+                        .list(null, null, null, PageRequest.of(0, 50), TenantScope.scoped(null))
+                        .getContent())
+                .extracting(ReviewQueueItem::itemId)
+                .containsExactly(shared.getId());
     }
 
     private static ReviewQueueItem itemFor(List<ReviewQueueItem> items, ItemResult target) {
@@ -194,6 +219,12 @@ class ReviewQueuePostgresTest {
     private ItemResult persistItem(ExperimentRun run) {
         return itemResultRepository.save(
                 new ItemResult(run, Map.of("q", "x"), Map.of("a", "y"), Map.of("a", "y"), Map.of()));
+    }
+
+    private ItemResult persistItem(ExperimentRun run, String tenantId) {
+        ItemResult item = new ItemResult(run, Map.of("q", "x"), Map.of("a", "y"), Map.of("a", "y"), Map.of());
+        item.setTenantId(tenantId);
+        return itemResultRepository.save(item);
     }
 
     private void annotate(ItemResult item, AnnotationVerdict verdict) {

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceDedupPostgresTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceDedupPostgresTest.java
@@ -185,8 +185,8 @@ class RunServiceDedupPostgresTest {
         AddItemsRequest request = singleItemRequest();
 
         // Two calls with the SAME key: the items and dedup row are written once, the retry no-ops.
-        runService.addItems(runId, request, "key-1");
-        runService.addItems(runId, request, "key-1");
+        runService.addItems(runId, request, "key-1", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        runService.addItems(runId, request, "key-1", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(itemResultRepository.count()).isEqualTo(1);
         assertThat(ingestedBatchRepository.existsByRunIdAndIdempotencyKey(runId, "key-1"))
@@ -194,7 +194,7 @@ class RunServiceDedupPostgresTest {
         assertThat(countIngestedBatchesForRun(runId)).isEqualTo(1);
 
         // A different key for the same run inserts a second item and a second dedup row.
-        runService.addItems(runId, request, "key-2");
+        runService.addItems(runId, request, "key-2", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(itemResultRepository.count()).isEqualTo(2);
         assertThat(ingestedBatchRepository.existsByRunIdAndIdempotencyKey(runId, "key-2"))

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/RunServiceTest.java
@@ -107,10 +107,11 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+        runService.updateRun(
+                runId, new UpdateRunRequest(RunStatus.SUCCESS), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
         verify(runRepository).save(captor.capture());
@@ -126,12 +127,13 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
         when(itemResultRepository.countByRun(run)).thenReturn(10L);
         when(itemResultRepository.countItemsWithAllEvalsPassed(run)).thenReturn(7L);
 
-        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+        runService.updateRun(
+                runId, new UpdateRunRequest(RunStatus.SUCCESS), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
         verify(runRepository).save(captor.capture());
@@ -151,11 +153,12 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
         when(itemResultRepository.countByRun(run)).thenReturn(0L);
 
-        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+        runService.updateRun(
+                runId, new UpdateRunRequest(RunStatus.SUCCESS), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
         verify(runRepository).save(captor.capture());
@@ -171,7 +174,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
         Map<String, Object> evalMetadata = Map.of("model", "gpt-4", "tokens", 42);
         AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
@@ -181,7 +184,7 @@ class RunServiceTest {
                 List.of(new AddItemsRequest.EvalData("exact-match", 1.0, 0.9, true, "Correct", evalMetadata)),
                 true)));
 
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved.get(0).getEvalResults().get(0).getMetadata()).isEqualTo(evalMetadata);
@@ -196,7 +199,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         DatasetItem datasetItem = new DatasetItem(null, 0, Map.of("input", "q"), Map.of("output", "a"), null);
         setField(datasetItem, "id", datasetItemId);
         when(datasetItemRepository.findAllById(List.of(datasetItemId))).thenReturn(List.of(datasetItem));
@@ -210,7 +213,7 @@ class RunServiceTest {
                 true,
                 datasetItemId)));
 
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved.get(0).getDatasetItem()).isSameAs(datasetItem);
@@ -225,14 +228,14 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(datasetItemRepository.findAllById(List.of(staleId))).thenReturn(List.of());
 
         AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
                 Map.of("input", "q"), Map.of("output", "a"), Map.of("output", "a"), null, null, true, staleId)));
 
         // A stale id must not fail the batch; the item is stored unlinked.
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved).hasSize(1);
@@ -247,7 +250,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
         AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
                 Map.of("input", "q"),
@@ -262,7 +265,7 @@ class RunServiceTest {
                 0.002,
                 430L)));
 
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved).hasSize(1);
@@ -280,7 +283,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
         when(itemResultRepository.countByRun(run)).thenReturn(3L);
         when(itemResultRepository.countItemsWithAllEvalsPassed(run)).thenReturn(2L);
@@ -289,7 +292,8 @@ class RunServiceTest {
         when(itemResultRepository.sumCostByRun(run)).thenReturn(0.006);
         when(itemResultRepository.avgLatencyByRun(run)).thenReturn(412.5);
 
-        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+        runService.updateRun(
+                runId, new UpdateRunRequest(RunStatus.SUCCESS), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
         verify(runRepository).save(captor.capture());
@@ -308,7 +312,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
         when(itemResultRepository.countByRun(run)).thenReturn(2L);
         when(itemResultRepository.countItemsWithAllEvalsPassed(run)).thenReturn(1L);
@@ -317,7 +321,8 @@ class RunServiceTest {
         when(itemResultRepository.sumCostByRun(run)).thenReturn(null);
         when(itemResultRepository.avgLatencyByRun(run)).thenReturn(null);
 
-        runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS));
+        runService.updateRun(
+                runId, new UpdateRunRequest(RunStatus.SUCCESS), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
         verify(runRepository).save(captor.capture());
@@ -335,10 +340,11 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(runRepository.save(any(ExperimentRun.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        runService.updateRun(runId, new UpdateRunRequest(RunStatus.RUNNING));
+        runService.updateRun(
+                runId, new UpdateRunRequest(RunStatus.RUNNING), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<ExperimentRun> captor = ArgumentCaptor.forClass(ExperimentRun.class);
         verify(runRepository).save(captor.capture());
@@ -348,9 +354,12 @@ class RunServiceTest {
     @Test
     void updateRun_shouldThrowWhenRunNotFound() {
         UUID runId = UUID.randomUUID();
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.empty());
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS)))
+        assertThatThrownBy(() -> runService.updateRun(
+                        runId,
+                        new UpdateRunRequest(RunStatus.SUCCESS),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Run not found");
     }
@@ -362,9 +371,12 @@ class RunServiceTest {
         Experiment experiment = createExperiment(project, "my-experiment");
         ExperimentRun run = createRun(experiment, RunStatus.EVALUATING);
         setField(run, "id", runId);
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
-        assertThatThrownBy(() -> runService.updateRun(runId, new UpdateRunRequest(RunStatus.SUCCESS)))
+        assertThatThrownBy(() -> runService.updateRun(
+                        runId,
+                        new UpdateRunRequest(RunStatus.SUCCESS),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("evaluating");
 
@@ -373,7 +385,10 @@ class RunServiceTest {
 
     @Test
     void updateRun_shouldThrowWhenIdIsNull() {
-        assertThatThrownBy(() -> runService.updateRun(null, new UpdateRunRequest(RunStatus.SUCCESS)))
+        assertThatThrownBy(() -> runService.updateRun(
+                        null,
+                        new UpdateRunRequest(RunStatus.SUCCESS),
+                        dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Run ID cannot be null");
     }
@@ -386,7 +401,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
         AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
                 Map.of("input", "What is 2+2?"),
@@ -395,7 +410,7 @@ class RunServiceTest {
                 List.of(new AddItemsRequest.EvalData("exact-match", 1.0, 0.9, true, "Correct", Map.of())),
                 true)));
 
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved).hasSize(1);
@@ -414,7 +429,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
         AddItemsRequest request = new AddItemsRequest(List.of(
                 new AddItemsRequest.ItemData(
@@ -432,7 +447,7 @@ class RunServiceTest {
                                 new AddItemsRequest.EvalData("relevance", 0.5, 0.9, false, "weak", Map.of())),
                         false)));
 
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved).hasSize(2);
@@ -450,12 +465,12 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
         AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
                 Map.of("input", "test"), Map.of("output", "expected"), Map.of("output", "actual"), null, false)));
 
-        runService.addItems(runId, request, null);
+        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         List<ItemResult> saved = captureSavedItems();
         assertThat(saved.get(0).getEvalResults()).isEmpty();
@@ -469,12 +484,13 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.SUCCESS);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
         AddItemsRequest request = new AddItemsRequest(List.of(new AddItemsRequest.ItemData(
                 Map.of("input", "q"), Map.of("output", "a"), Map.of("output", "a"), null, true)));
 
-        assertThatThrownBy(() -> runService.addItems(runId, request, null))
+        assertThatThrownBy(() ->
+                        runService.addItems(runId, request, null, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Cannot add items to a run that is not RUNNING");
     }
@@ -487,7 +503,7 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         // First call sees no recorded key, second call sees the key recorded by the first.
         when(ingestedBatchRepository.existsByRunIdAndIdempotencyKey(runId, "key-1"))
                 .thenReturn(false)
@@ -495,8 +511,8 @@ class RunServiceTest {
 
         AddItemsRequest request = singleItemRequest();
 
-        runService.addItems(runId, request, "key-1");
-        runService.addItems(runId, request, "key-1");
+        runService.addItems(runId, request, "key-1", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        runService.addItems(runId, request, "key-1", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         // Items are inserted only on the first call; the retry is a no-op.
         verify(itemResultRepository, times(1)).saveAll(any());
@@ -512,14 +528,14 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
         when(ingestedBatchRepository.existsByRunIdAndIdempotencyKey(eq(runId), any()))
                 .thenReturn(false);
 
         AddItemsRequest request = singleItemRequest();
 
-        runService.addItems(runId, request, "key-1");
-        runService.addItems(runId, request, "key-2");
+        runService.addItems(runId, request, "key-1", dev.dokimos.server.tenant.TenantScope.unrestricted());
+        runService.addItems(runId, request, "key-2", dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(itemResultRepository, times(2)).saveAll(any());
         verify(ingestedBatchRepository, times(2)).save(any(IngestedBatch.class));
@@ -533,9 +549,9 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.RUNNING);
         setField(run, "id", runId);
 
-        when(runRepository.findByIdForUpdate(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findByIdForUpdate(eq(runId), any())).thenReturn(Optional.of(run));
 
-        runService.addItems(runId, singleItemRequest(), null);
+        runService.addItems(runId, singleItemRequest(), null, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         // Backward compatible path: items are inserted, no dedup lookup or record happens.
         verify(itemResultRepository, times(1)).saveAll(any());
@@ -561,9 +577,9 @@ class RunServiceTest {
         setMaterializedCounts(run1, 10, 8);
         setMaterializedCounts(run2, 5, 2);
 
-        when(runRepository.findByExperimentOrderByStartedAtDesc(experiment)).thenReturn(List.of(run1, run2));
+        when(runRepository.findByExperiment(eq(experiment), any())).thenReturn(List.of(run1, run2));
 
-        List<RunSummary> result = runService.listRuns(experiment);
+        List<RunSummary> result = runService.listRuns(experiment, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).status()).isEqualTo(RunStatus.SUCCESS);
@@ -579,9 +595,9 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.SUCCESS);
         setMaterializedCounts(run, 0, 0);
 
-        when(runRepository.findByExperimentOrderByStartedAtDesc(experiment)).thenReturn(List.of(run));
+        when(runRepository.findByExperiment(eq(experiment), any())).thenReturn(List.of(run));
 
-        List<RunSummary> result = runService.listRuns(experiment);
+        List<RunSummary> result = runService.listRuns(experiment, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.get(0).passRate()).isNull();
     }
@@ -598,10 +614,11 @@ class RunServiceTest {
         Pageable pageable = PageRequest.of(0, 50);
         Page<ItemResult> emptyPage = new PageImpl<>(List.of());
 
-        when(runRepository.findById(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findById(eq(runId), any())).thenReturn(Optional.of(run));
         when(itemResultRepository.findByRunOrderByCreatedAtAsc(run, pageable)).thenReturn(emptyPage);
 
-        RunDetails result = runService.getRunDetails(runId, pageable);
+        RunDetails result =
+                runService.getRunDetails(runId, pageable, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.id()).isEqualTo(runId);
         assertThat(result.experimentName()).isEqualTo("my-experiment");
@@ -620,7 +637,7 @@ class RunServiceTest {
         setField(run, "id", runId);
 
         Pageable pageable = PageRequest.of(0, 50);
-        when(runRepository.findById(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findById(eq(runId), any())).thenReturn(Optional.of(run));
         when(itemResultRepository.findByRunOrderByCreatedAtAsc(run, pageable)).thenReturn(new PageImpl<>(List.of()));
         when(itemResultRepository.countByRun(run)).thenReturn(3L);
         when(itemResultRepository.countItemsWithAllEvalsPassed(run)).thenReturn(2L);
@@ -629,7 +646,8 @@ class RunServiceTest {
         when(itemResultRepository.sumCostByRun(run)).thenReturn(0.006);
         when(itemResultRepository.avgLatencyByRun(run)).thenReturn(412.5);
 
-        RunDetails result = runService.getRunDetails(runId, pageable);
+        RunDetails result =
+                runService.getRunDetails(runId, pageable, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(result.totalItems()).isEqualTo(3);
         assertThat(result.passedItems()).isEqualTo(2);
@@ -642,9 +660,10 @@ class RunServiceTest {
     @Test
     void getRunDetails_shouldThrowWhenRunNotFound() {
         UUID runId = UUID.randomUUID();
-        when(runRepository.findById(runId)).thenReturn(Optional.empty());
+        when(runRepository.findById(eq(runId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> runService.getRunDetails(runId, PageRequest.of(0, 50)))
+        assertThatThrownBy(() -> runService.getRunDetails(
+                        runId, PageRequest.of(0, 50), dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Run not found");
     }
@@ -657,9 +676,9 @@ class RunServiceTest {
         ExperimentRun run = createRun(experiment, RunStatus.SUCCESS);
         setField(run, "id", runId);
 
-        when(runRepository.findById(runId)).thenReturn(Optional.of(run));
+        when(runRepository.findById(eq(runId), any())).thenReturn(Optional.of(run));
 
-        runService.deleteRun(runId);
+        runService.deleteRun(runId, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         verify(runRepository).delete(run);
     }
@@ -667,9 +686,9 @@ class RunServiceTest {
     @Test
     void deleteRun_shouldThrowWhenNotFound() {
         UUID runId = UUID.randomUUID();
-        when(runRepository.findById(runId)).thenReturn(Optional.empty());
+        when(runRepository.findById(eq(runId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> runService.deleteRun(runId))
+        assertThatThrownBy(() -> runService.deleteRun(runId, dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Run not found");
     }

--- a/dokimos-server/src/test/java/dev/dokimos/server/service/TraceEvalRuleServiceTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/service/TraceEvalRuleServiceTest.java
@@ -3,6 +3,7 @@ package dev.dokimos.server.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,13 +67,15 @@ class TraceEvalRuleServiceTest {
 
     @Test
     void createPersistsRuleWithDefaults() {
-        when(projectRepository.existsById(projectId)).thenReturn(true);
-        when(ruleRepository.existsByProjectIdAndName(projectId, "answer-quality"))
+        when(projectRepository.findById(eq(projectId), any()))
+                .thenReturn(Optional.of(new dev.dokimos.server.entity.Project("p")));
+        when(ruleRepository.existsByProjectIdAndName(eq(projectId), eq("answer-quality"), any()))
                 .thenReturn(false);
-        when(connectionRepository.findById(connectionId)).thenReturn(Optional.of(connection));
+        when(connectionRepository.findById(eq(connectionId), any())).thenReturn(Optional.of(connection));
         when(ruleRepository.save(any(TraceEvalRule.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        TraceEvalRuleView view = service.create(projectId, spanNameRequest());
+        TraceEvalRuleView view =
+                service.create(projectId, spanNameRequest(), dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         assertThat(view.name()).isEqualTo("answer-quality");
         assertThat(view.enabled()).isTrue();
@@ -88,12 +91,14 @@ class TraceEvalRuleServiceTest {
     void createClearsMatchKeyForSpanNameMatch() {
         CreateTraceEvalRuleRequest request = new CreateTraceEvalRuleRequest(
                 "r", null, TraceMatchType.SPAN_NAME, "ignored", "llm.generate", connectionId, "j", "c", 0.0, 1.0, null);
-        when(projectRepository.existsById(projectId)).thenReturn(true);
-        when(ruleRepository.existsByProjectIdAndName(projectId, "r")).thenReturn(false);
-        when(connectionRepository.findById(connectionId)).thenReturn(Optional.of(connection));
+        when(projectRepository.findById(eq(projectId), any()))
+                .thenReturn(Optional.of(new dev.dokimos.server.entity.Project("p")));
+        when(ruleRepository.existsByProjectIdAndName(eq(projectId), eq("r"), any()))
+                .thenReturn(false);
+        when(connectionRepository.findById(eq(connectionId), any())).thenReturn(Optional.of(connection));
         when(ruleRepository.save(any(TraceEvalRule.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        service.create(projectId, request);
+        service.create(projectId, request, dev.dokimos.server.tenant.TenantScope.unrestricted());
 
         ArgumentCaptor<TraceEvalRule> captor = ArgumentCaptor.forClass(TraceEvalRule.class);
         verify(ruleRepository).save(captor.capture());
@@ -102,31 +107,36 @@ class TraceEvalRuleServiceTest {
 
     @Test
     void createRejectsDuplicateName() {
-        when(projectRepository.existsById(projectId)).thenReturn(true);
-        when(ruleRepository.existsByProjectIdAndName(projectId, "answer-quality"))
+        when(projectRepository.findById(eq(projectId), any()))
+                .thenReturn(Optional.of(new dev.dokimos.server.entity.Project("p")));
+        when(ruleRepository.existsByProjectIdAndName(eq(projectId), eq("answer-quality"), any()))
                 .thenReturn(true);
 
-        assertThatThrownBy(() -> service.create(projectId, spanNameRequest()))
+        assertThatThrownBy(() -> service.create(
+                        projectId, spanNameRequest(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalStateException.class);
         verify(ruleRepository, never()).save(any());
     }
 
     @Test
     void createRejectsMissingProject() {
-        when(projectRepository.existsById(projectId)).thenReturn(false);
+        when(projectRepository.findById(eq(projectId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.create(projectId, spanNameRequest()))
+        assertThatThrownBy(() -> service.create(
+                        projectId, spanNameRequest(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void createRejectsMissingConnection() {
-        when(projectRepository.existsById(projectId)).thenReturn(true);
-        when(ruleRepository.existsByProjectIdAndName(projectId, "answer-quality"))
+        when(projectRepository.findById(eq(projectId), any()))
+                .thenReturn(Optional.of(new dev.dokimos.server.entity.Project("p")));
+        when(ruleRepository.existsByProjectIdAndName(eq(projectId), eq("answer-quality"), any()))
                 .thenReturn(false);
-        when(connectionRepository.findById(connectionId)).thenReturn(Optional.empty());
+        when(connectionRepository.findById(eq(connectionId), any())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.create(projectId, spanNameRequest()))
+        assertThatThrownBy(() -> service.create(
+                        projectId, spanNameRequest(), dev.dokimos.server.tenant.TenantScope.unrestricted()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantArchitectureTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantArchitectureTest.java
@@ -1,0 +1,126 @@
+package dev.dokimos.server.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.Repository;
+
+/**
+ * Structural backstop for the tenant isolation boundary, in the spirit of an ArchUnit test but with no
+ * extra dependency. It enforces two rules that keep the compile-time scoped-repository design intact:
+ *
+ * <ol>
+ *   <li>A tenant entity repository never extends {@link CrudRepository}, {@link JpaRepository}, or {@link
+ *       PagingAndSortingRepository}. Those carry the dangerous inherited finders ({@code findById(id)},
+ *       {@code findAll()}, {@code getReferenceById}) that would let an unscoped load slip through. Tenant
+ *       repositories extend only the empty {@link Repository} plus the scoped fragments.
+ *   <li>A service never depends on {@link EntityManager} directly. The only legitimate place to build a
+ *       query is a scoped repository (whose finders all require a {@link TenantScope}); a service holding
+ *       an {@code EntityManager} could bypass the scope predicate entirely.
+ * </ol>
+ *
+ * <p>Infrastructure repositories that carry no tenant column (queues, batches, the API key store) are
+ * allowed to remain {@code JpaRepository}; they are listed explicitly so the rule stays a deliberate
+ * allow-list rather than a blanket exemption.
+ */
+class TenantArchitectureTest {
+
+    private static final String BASE_PACKAGE = "dev.dokimos.server";
+
+    /**
+     * Repositories allowed to remain {@code JpaRepository}. Two groups:
+     *
+     * <ul>
+     *   <li>Infrastructure with no tenant column (queues, batches, the key store): {@code ApiKeyRepository},
+     *       {@code EvalJobRepository}, {@code TraceEvalJobRepository}, {@code IngestedBatchRepository}.
+     *   <li>Tenant child rows that are never loaded by id straight from user input. They carry a {@code
+     *       tenant_id} (stamped from their parent) but are reached only through a tenant-scoped parent (a
+     *       scoped run, dataset, or trace), so the parent load is the trust boundary. {@code
+     *       AnnotationRepository} is reached only through {@code AnnotationService}, which loads the run
+     *       through the scoped run finder before touching the item or its annotation.
+     * </ul>
+     */
+    private static final List<String> NON_TENANT_REPOSITORIES = List.of(
+            "ApiKeyRepository",
+            "EvalJobRepository",
+            "TraceEvalJobRepository",
+            "IngestedBatchRepository",
+            "ItemResultRepository",
+            "EvalResultRepository",
+            "DatasetItemRepository",
+            "DatasetVersionRepository",
+            "TraceSpanRepository",
+            "AnnotationRepository");
+
+    @Test
+    void tenantRepositoriesDoNotExtendCrudOrJpaRepository() throws Exception {
+        List<Class<?>> offenders = new ArrayList<>();
+        for (Class<?> type : classesIn("repository")) {
+            if (!type.isInterface() || !Repository.class.isAssignableFrom(type)) {
+                continue;
+            }
+            if (NON_TENANT_REPOSITORIES.contains(type.getSimpleName())) {
+                continue;
+            }
+            boolean dangerous = CrudRepository.class.isAssignableFrom(type)
+                    || JpaRepository.class.isAssignableFrom(type)
+                    || PagingAndSortingRepository.class.isAssignableFrom(type);
+            if (dangerous) {
+                offenders.add(type);
+            }
+        }
+        assertThat(offenders)
+                .as("tenant repositories must extend only Repository<T,ID> plus scoped fragments, never "
+                        + "Crud/Jpa/PagingAndSorting which carry unscoped finders")
+                .isEmpty();
+    }
+
+    @Test
+    void servicesDoNotDependOnEntityManagerDirectly() throws Exception {
+        List<String> offenders = new ArrayList<>();
+        for (Class<?> type : classesIn("service")) {
+            for (Field field : type.getDeclaredFields()) {
+                if (EntityManager.class.isAssignableFrom(field.getType())) {
+                    offenders.add(type.getSimpleName() + "." + field.getName());
+                }
+            }
+        }
+        assertThat(offenders)
+                .as("services must reach the database through scoped repositories, never an EntityManager "
+                        + "field that could bypass the tenant predicate")
+                .isEmpty();
+    }
+
+    private static List<Class<?>> classesIn(String subPackage) throws IOException, ClassNotFoundException {
+        String pkg = BASE_PACKAGE + "." + subPackage;
+        String path = pkg.replace('.', '/');
+        URL root = Thread.currentThread().getContextClassLoader().getResource(path);
+        if (root == null) {
+            return List.of();
+        }
+        Path dir = Path.of(root.getPath());
+        List<Class<?>> classes = new ArrayList<>();
+        try (Stream<Path> files = Files.list(dir)) {
+            for (Path file : files.filter(p -> p.toString().endsWith(".class")).toList()) {
+                String className = file.getFileName().toString().replace(".class", "");
+                if (className.contains("$")) {
+                    continue;
+                }
+                classes.add(Class.forName(pkg + "." + className));
+            }
+        }
+        return classes;
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantArchitectureTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantArchitectureTest.java
@@ -182,23 +182,14 @@ class TenantArchitectureTest {
         return loadClasses(subPackage, false);
     }
 
-    /**
-     * Loads every production class under the sub-package and its nested sub-packages, so a rule covering
-     * {@code controller} also covers {@code controller.v1}.
-     */
+    /** Recurses into nested sub-packages, so a rule covering {@code controller} also covers {@code controller.v1}. */
     private static List<Class<?>> classesInRecursive(String subPackage) throws IOException, ClassNotFoundException {
         return loadClasses(subPackage, true);
     }
 
     /**
-     * Loads production classes in the sub-package, scanning the main build output only. The root is
-     * derived from the {@code DokimosServerApplication} class location so the scan never picks up test
-     * classes that happen to share a package name with production code (a service test that injects a
-     * repository to set up a fixture must not count as a production accessor).
-     *
-     * @param subPackage the package under {@link #BASE_PACKAGE} to scan
-     * @param recursive  whether to descend into nested sub-packages
-     * @return the production classes found, never null
+     * Loads production classes in the sub-package, scanning the main build output only so a service test
+     * that injects a repository for a fixture is not counted as a production accessor.
      */
     private static List<Class<?>> loadClasses(String subPackage, boolean recursive)
             throws IOException, ClassNotFoundException {
@@ -222,10 +213,7 @@ class TenantArchitectureTest {
         return classes;
     }
 
-    /**
-     * Resolves the {@code target/classes} directory of the production build from the location of a known
-     * main class, so scans read production output rather than test output.
-     */
+    /** Resolves the production {@code target/classes} root from a known main class, not test output. */
     private static Path mainClassesRoot() {
         String mainClassPath = (BASE_PACKAGE + ".DokimosServerApplication").replace('.', '/') + ".class";
         URL marker = Thread.currentThread().getContextClassLoader().getResource(mainClassPath);

--- a/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantArchitectureTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantArchitectureTest.java
@@ -19,7 +19,7 @@ import org.springframework.data.repository.Repository;
 
 /**
  * Structural backstop for the tenant isolation boundary, in the spirit of an ArchUnit test but with no
- * extra dependency. It enforces two rules that keep the compile-time scoped-repository design intact:
+ * extra dependency. It enforces three rules that keep the compile-time scoped-repository design intact:
  *
  * <ol>
  *   <li>A tenant entity repository never extends {@link CrudRepository}, {@link JpaRepository}, or {@link
@@ -29,6 +29,11 @@ import org.springframework.data.repository.Repository;
  *   <li>A service never depends on {@link EntityManager} directly. The only legitimate place to build a
  *       query is a scoped repository (whose finders all require a {@link TenantScope}); a service holding
  *       an {@code EntityManager} could bypass the scope predicate entirely.
+ *   <li>The child-row repositories that still extend {@link JpaRepository} (so they expose the unscoped
+ *       {@code findById}/{@code getReferenceById}/{@code findAllById}) may be injected only by an explicit
+ *       allow-list of classes that already reach them behind a documented tenant gate. Any other class
+ *       that injects one fails the build, forcing a reviewer to add it to the allow-list and justify the
+ *       gate rather than silently loading a child row by id from user input.
  * </ol>
  *
  * <p>Infrastructure repositories that carry no tenant column (queues, batches, the API key store) are
@@ -63,6 +68,51 @@ class TenantArchitectureTest {
             "DatasetVersionRepository",
             "TraceSpanRepository",
             "AnnotationRepository");
+
+    /**
+     * The child-row repositories that still extend {@code JpaRepository} and so expose the unscoped
+     * inherited finders. Access to any of these is restricted to {@link #CHILD_REPOSITORY_ACCESSORS}.
+     */
+    private static final List<String> CHILD_REPOSITORIES = List.of(
+            "ItemResultRepository",
+            "EvalResultRepository",
+            "DatasetVersionRepository",
+            "DatasetItemRepository",
+            "TraceSpanRepository",
+            "AnnotationRepository");
+
+    /**
+     * The only classes allowed to inject a {@link #CHILD_REPOSITORIES child repository}. Each reaches its
+     * child rows behind a tenant gate, named alongside it. A new class that injects a child repository is
+     * not on this list, so it fails the build until a reviewer adds it and documents how it gates the
+     * load.
+     */
+    private static final List<String> CHILD_REPOSITORY_ACCESSORS = List.of(
+            // Loads items only by an ExperimentRun the caller already resolved through the scoped run
+            // finder (findByRunWithEvals), never by raw id.
+            "ComparisonSupport",
+            // Loads the run through the scoped run finder (runRepository.findById(runId, scope)) before
+            // reading its items and annotations.
+            "AlignmentService",
+            // Reads items through the tenant-predicated query (findItemsNeedingReview takes the scope),
+            // then batch-loads evals and annotations only for ids that query already returned.
+            "ReviewQueueService",
+            // Worker-side persistence behind a JudgeJob whose run was scoped when the job was enqueued;
+            // stamps each eval result with its parent item's tenant (getReferenceById is used only to
+            // attach a result to an item the job already owns).
+            "JudgeJobTransactions",
+            // Creates versions and items under a Dataset loaded through the scoped findByNameForUpdate,
+            // stamping the dataset's tenant; loads dataset items only behind a visibleUnder(scope) filter.
+            "DatasetService",
+            // Loads the run through the scoped run finder (requireItemResultInRun) before touching the
+            // item result or its annotation.
+            "AnnotationService",
+            // Saves items under a run the service already scoped, and loads dataset items only behind a
+            // visibleUnder(scope) filter (loadDatasetItems).
+            "RunService",
+            // Loads spans only for a Trace resolved through the scoped trace finder
+            // (traceRepository.findById(id, scope)).
+            "TraceQueryService");
 
     @Test
     void tenantRepositoriesDoNotExtendCrudOrJpaRepository() throws Exception {
@@ -103,24 +153,90 @@ class TenantArchitectureTest {
                 .isEmpty();
     }
 
+    @Test
+    void onlyAllowListedClassesInjectChildRepositories() throws Exception {
+        List<String> offenders = new ArrayList<>();
+        List<Class<?>> candidates = new ArrayList<>();
+        candidates.addAll(classesIn("service"));
+        candidates.addAll(classesInRecursive("controller"));
+        candidates.addAll(classesIn("judge"));
+        for (Class<?> type : candidates) {
+            if (CHILD_REPOSITORY_ACCESSORS.contains(type.getSimpleName())) {
+                continue;
+            }
+            for (Field field : type.getDeclaredFields()) {
+                if (CHILD_REPOSITORIES.contains(field.getType().getSimpleName())) {
+                    offenders.add(type.getSimpleName() + "." + field.getName() + " -> "
+                            + field.getType().getSimpleName());
+                }
+            }
+        }
+        assertThat(offenders)
+                .as("a child repository (which still exposes unscoped findById/getReferenceById/findAllById) "
+                        + "may be injected only by an allow-listed accessor that gates the load behind a "
+                        + "tenant scope; add the new class to CHILD_REPOSITORY_ACCESSORS and document its gate")
+                .isEmpty();
+    }
+
     private static List<Class<?>> classesIn(String subPackage) throws IOException, ClassNotFoundException {
+        return loadClasses(subPackage, false);
+    }
+
+    /**
+     * Loads every production class under the sub-package and its nested sub-packages, so a rule covering
+     * {@code controller} also covers {@code controller.v1}.
+     */
+    private static List<Class<?>> classesInRecursive(String subPackage) throws IOException, ClassNotFoundException {
+        return loadClasses(subPackage, true);
+    }
+
+    /**
+     * Loads production classes in the sub-package, scanning the main build output only. The root is
+     * derived from the {@code DokimosServerApplication} class location so the scan never picks up test
+     * classes that happen to share a package name with production code (a service test that injects a
+     * repository to set up a fixture must not count as a production accessor).
+     *
+     * @param subPackage the package under {@link #BASE_PACKAGE} to scan
+     * @param recursive  whether to descend into nested sub-packages
+     * @return the production classes found, never null
+     */
+    private static List<Class<?>> loadClasses(String subPackage, boolean recursive)
+            throws IOException, ClassNotFoundException {
+        Path mainRoot = mainClassesRoot();
         String pkg = BASE_PACKAGE + "." + subPackage;
-        String path = pkg.replace('.', '/');
-        URL root = Thread.currentThread().getContextClassLoader().getResource(path);
-        if (root == null) {
+        Path dir = mainRoot.resolve(pkg.replace('.', '/'));
+        if (!Files.isDirectory(dir)) {
             return List.of();
         }
-        Path dir = Path.of(root.getPath());
         List<Class<?>> classes = new ArrayList<>();
-        try (Stream<Path> files = Files.list(dir)) {
+        try (Stream<Path> files = recursive ? Files.walk(dir) : Files.list(dir)) {
             for (Path file : files.filter(p -> p.toString().endsWith(".class")).toList()) {
-                String className = file.getFileName().toString().replace(".class", "");
+                String relative = mainRoot.relativize(file).toString().replace('/', '.');
+                String className = relative.substring(0, relative.length() - ".class".length());
                 if (className.contains("$")) {
                     continue;
                 }
-                classes.add(Class.forName(pkg + "." + className));
+                classes.add(Class.forName(className));
             }
         }
         return classes;
+    }
+
+    /**
+     * Resolves the {@code target/classes} directory of the production build from the location of a known
+     * main class, so scans read production output rather than test output.
+     */
+    private static Path mainClassesRoot() {
+        String mainClassPath = (BASE_PACKAGE + ".DokimosServerApplication").replace('.', '/') + ".class";
+        URL marker = Thread.currentThread().getContextClassLoader().getResource(mainClassPath);
+        if (marker == null) {
+            throw new IllegalStateException("Could not locate production classes root via " + mainClassPath);
+        }
+        Path markerFile = Path.of(marker.getPath());
+        Path root = markerFile;
+        for (int i = 0; i < mainClassPath.split("/").length; i++) {
+            root = root.getParent();
+        }
+        return root;
     }
 }

--- a/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantScopeResolverTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantScopeResolverTest.java
@@ -1,0 +1,76 @@
+package dev.dokimos.server.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.dokimos.server.filter.ApiKeyAuthFilter;
+import dev.dokimos.server.filter.Principal;
+import dev.dokimos.server.filter.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Verifies the principal-to-scope mapping the resolver applies, with emphasis on the fail-closed
+ * behavior when the auth filter set no principal and the regression guard that a request carrying the
+ * system principal still resolves to the unrestricted scope (no-key and legacy single-key mode).
+ */
+class TenantScopeResolverTest {
+
+    @Test
+    void scopeFailsClosedToSharedOnlyWhenNoPrincipalAttribute() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        TenantScope scope = TenantScopeResolver.scope(request);
+
+        assertThat(scope.restricted()).isTrue();
+        assertThat(scope.tenantId()).isNull();
+    }
+
+    @Test
+    void scopeStaysUnrestrictedForSystemPrincipal() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE, Principal.system());
+
+        TenantScope scope = TenantScopeResolver.scope(request);
+
+        assertThat(scope.restricted()).isFalse();
+        assertThat(scope).isEqualTo(TenantScope.unrestricted());
+    }
+
+    @Test
+    void scopeResolvesToTenantForScopedKeyPrincipal() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE, new Principal("key-7", Role.EDITOR, "tenant-acme"));
+
+        TenantScope scope = TenantScopeResolver.scope(request);
+
+        assertThat(scope.restricted()).isTrue();
+        assertThat(scope.tenantId()).isEqualTo("tenant-acme");
+    }
+
+    @Test
+    void scopeForAnonymousReaderCollapsesToSharedOnly() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(ApiKeyAuthFilter.PRINCIPAL_ATTRIBUTE, Principal.anonymous());
+
+        TenantScope scope = TenantScopeResolver.scope(request);
+
+        assertThat(scope.restricted()).isTrue();
+        assertThat(scope.tenantId()).isNull();
+    }
+
+    @Test
+    void principalFallsBackToSystemWhenNoAttribute() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        Principal principal = TenantScopeResolver.principal(request);
+
+        assertThat(principal.isSystem()).isTrue();
+    }
+
+    @Test
+    void principalIdIsNullWhenNoAttribute() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        assertThat(TenantScopeResolver.principalId(request)).isNull();
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantScopingTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantScopingTest.java
@@ -1,0 +1,180 @@
+package dev.dokimos.server.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.dokimos.server.entity.Experiment;
+import dev.dokimos.server.entity.ExperimentRun;
+import dev.dokimos.server.entity.Project;
+import dev.dokimos.server.repository.ExperimentRepository;
+import dev.dokimos.server.repository.ExperimentRunRepository;
+import dev.dokimos.server.repository.ProjectRepository;
+import dev.dokimos.server.service.ExperimentService;
+import dev.dokimos.server.service.ProjectService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Proves the tenant isolation boundary at the repository and service layers. Each scoped read takes a
+ * {@link TenantScope}; this verifies that own-plus-shared visibility, foreign-tenant invisibility,
+ * shared-only ({@code scoped(null)}) visibility, unrestricted visibility, the project-count aggregate,
+ * per-tenant naming, the worker (unrestricted) path, and the cross-tenant by-id 404 all behave per the
+ * plan. Backed by the in-memory H2 DataJpaTest stack the rest of the suite uses; the scope predicate is
+ * plain JPQL/Criteria, so the behavior matches Postgres (which the migration and Postgres-backed tests
+ * cover separately).
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import(TenantScopingTest.TestConfig.class)
+class TenantScopingTest {
+
+    private static final TenantScope TENANT_A = TenantScope.scoped("tenant-a");
+    private static final TenantScope TENANT_B = TenantScope.scoped("tenant-b");
+    private static final TenantScope ANONYMOUS = TenantScope.scoped(null);
+    private static final TenantScope WORKER = TenantScope.unrestricted();
+
+    @org.springframework.boot.test.context.TestConfiguration
+    static class TestConfig {
+        @org.springframework.context.annotation.Bean
+        ProjectService projectService(ProjectRepository projectRepository) {
+            return new ProjectService(projectRepository);
+        }
+
+        @org.springframework.context.annotation.Bean
+        ExperimentService experimentService(
+                ExperimentRepository experimentRepository, ExperimentRunRepository runRepository) {
+            return new ExperimentService(experimentRepository, runRepository);
+        }
+    }
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ExperimentRepository experimentRepository;
+
+    @Autowired
+    private ExperimentRunRepository runRepository;
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Autowired
+    private ExperimentService experimentService;
+
+    @Test
+    void scopedRead_seesOwnAndSharedButNotForeign() {
+        UUID own = stampProject("p-own", "tenant-a").getId();
+        UUID shared = stampProject("p-shared", null).getId();
+        UUID foreign = stampProject("p-foreign", "tenant-b").getId();
+
+        assertThat(projectRepository.findById(own, TENANT_A)).isPresent();
+        assertThat(projectRepository.findById(shared, TENANT_A)).isPresent();
+        assertThat(projectRepository.findById(foreign, TENANT_A)).isEmpty();
+    }
+
+    @Test
+    void scopedNull_seesSharedOnly() {
+        UUID shared = stampProject("p-shared", null).getId();
+        UUID owned = stampProject("p-owned", "tenant-a").getId();
+
+        assertThat(projectRepository.findById(shared, ANONYMOUS)).isPresent();
+        assertThat(projectRepository.findById(owned, ANONYMOUS)).isEmpty();
+    }
+
+    @Test
+    void unrestricted_seesEveryTenant() {
+        UUID a = stampProject("p-a", "tenant-a").getId();
+        UUID b = stampProject("p-b", "tenant-b").getId();
+        UUID shared = stampProject("p-s", null).getId();
+
+        assertThat(projectRepository.findById(a, WORKER)).isPresent();
+        assertThat(projectRepository.findById(b, WORKER)).isPresent();
+        assertThat(projectRepository.findById(shared, WORKER)).isPresent();
+    }
+
+    @Test
+    void projectCountAggregate_isScoped() {
+        stampProject("a1", "tenant-a");
+        stampProject("a2", "tenant-a");
+        stampProject("s1", null);
+        stampProject("b1", "tenant-b");
+
+        // tenant A sees its own two plus the one shared row, never tenant B's.
+        assertThat(projectService.listProjects(TENANT_A)).hasSize(3);
+        // anonymous sees the shared row only.
+        assertThat(projectService.listProjects(ANONYMOUS)).hasSize(1);
+        // a worker sees all four.
+        assertThat(projectService.listProjects(WORKER)).hasSize(4);
+    }
+
+    @Test
+    void twoTenants_canEachOwnDefaultProject() {
+        Project a = projectService.getOrCreateProject("default", TENANT_A);
+        Project b = projectService.getOrCreateProject("default", TENANT_B);
+
+        assertThat(a.getId()).isNotEqualTo(b.getId());
+        assertThat(a.getTenantId()).isEqualTo("tenant-a");
+        assertThat(b.getTenantId()).isEqualTo("tenant-b");
+        // Each resolves only its own row on a second lookup.
+        assertThat(projectService.getOrCreateProject("default", TENANT_A).getId())
+                .isEqualTo(a.getId());
+        assertThat(projectService.getOrCreateProject("default", TENANT_B).getId())
+                .isEqualTo(b.getId());
+    }
+
+    @Test
+    void crossTenantById_returnsNotFoundForExperimentAndRun() {
+        Project projectB = stampProject("p-b", "tenant-b");
+        Experiment experimentB = experimentRepository.save(stamp(new Experiment(projectB, "e"), "tenant-b"));
+        ExperimentRun runB = runRepository.save(stamp(new ExperimentRun(experimentB, null), "tenant-b"));
+
+        // Tenant A cannot see tenant B's experiment or run by id; both surface as a 404 (IllegalArgument).
+        assertThatThrownBy(() -> experimentService.getExperiment(experimentB.getId(), TENANT_A))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not found");
+        assertThat(runRepository.findById(runB.getId(), TENANT_A)).isEmpty();
+        // The owning tenant and a worker still see them.
+        assertThat(experimentService.getExperiment(experimentB.getId(), TENANT_B))
+                .isNotNull();
+        assertThat(runRepository.findById(runB.getId(), WORKER)).isPresent();
+    }
+
+    @Test
+    void worker_unrestrictedSeesAllTenantsRuns() {
+        Project pa = stampProject("pa", "tenant-a");
+        Project pb = stampProject("pb", "tenant-b");
+        Experiment ea = experimentRepository.save(stamp(new Experiment(pa, "ea"), "tenant-a"));
+        Experiment eb = experimentRepository.save(stamp(new Experiment(pb, "eb"), "tenant-b"));
+        runRepository.save(stamp(new ExperimentRun(ea, null), "tenant-a"));
+        runRepository.save(stamp(new ExperimentRun(eb, null), "tenant-b"));
+
+        List<ExperimentRun> aRuns = runRepository.findByExperiment(ea, WORKER);
+        List<ExperimentRun> bRuns = runRepository.findByExperiment(eb, WORKER);
+        assertThat(aRuns).hasSize(1);
+        assertThat(bRuns).hasSize(1);
+    }
+
+    private Project stampProject(String name, String tenantId) {
+        Project project = new Project(name);
+        project.setTenantId(tenantId);
+        return projectRepository.save(project);
+    }
+
+    private static Experiment stamp(Experiment experiment, String tenantId) {
+        experiment.setTenantId(tenantId);
+        return experiment;
+    }
+
+    private static ExperimentRun stamp(ExperimentRun run, String tenantId) {
+        run.setTenantId(tenantId);
+        return run;
+    }
+}

--- a/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantScopingTest.java
+++ b/dokimos-server/src/test/java/dev/dokimos/server/tenant/TenantScopingTest.java
@@ -21,13 +21,10 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * Proves the tenant isolation boundary at the repository and service layers. Each scoped read takes a
- * {@link TenantScope}; this verifies that own-plus-shared visibility, foreign-tenant invisibility,
- * shared-only ({@code scoped(null)}) visibility, unrestricted visibility, the project-count aggregate,
- * per-tenant naming, the worker (unrestricted) path, and the cross-tenant by-id 404 all behave per the
- * plan. Backed by the in-memory H2 DataJpaTest stack the rest of the suite uses; the scope predicate is
- * plain JPQL/Criteria, so the behavior matches Postgres (which the migration and Postgres-backed tests
- * cover separately).
+ * Proves the tenant isolation boundary at the repository and service layers: own-plus-shared visibility,
+ * foreign-tenant invisibility, shared-only ({@code scoped(null)}) visibility, unrestricted visibility,
+ * the project-count aggregate, per-tenant naming, the worker path, and the cross-tenant by-id 404. The
+ * scope predicate is plain Criteria, so H2 here matches Postgres (covered separately).
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -107,11 +104,8 @@ class TenantScopingTest {
         stampProject("s1", null);
         stampProject("b1", "tenant-b");
 
-        // tenant A sees its own two plus the one shared row, never tenant B's.
         assertThat(projectService.listProjects(TENANT_A)).hasSize(3);
-        // anonymous sees the shared row only.
         assertThat(projectService.listProjects(ANONYMOUS)).hasSize(1);
-        // a worker sees all four.
         assertThat(projectService.listProjects(WORKER)).hasSize(4);
     }
 
@@ -123,7 +117,6 @@ class TenantScopingTest {
         assertThat(a.getId()).isNotEqualTo(b.getId());
         assertThat(a.getTenantId()).isEqualTo("tenant-a");
         assertThat(b.getTenantId()).isEqualTo("tenant-b");
-        // Each resolves only its own row on a second lookup.
         assertThat(projectService.getOrCreateProject("default", TENANT_A).getId())
                 .isEqualTo(a.getId());
         assertThat(projectService.getOrCreateProject("default", TENANT_B).getId())
@@ -136,12 +129,10 @@ class TenantScopingTest {
         Experiment experimentB = experimentRepository.save(stamp(new Experiment(projectB, "e"), "tenant-b"));
         ExperimentRun runB = runRepository.save(stamp(new ExperimentRun(experimentB, null), "tenant-b"));
 
-        // Tenant A cannot see tenant B's experiment or run by id; both surface as a 404 (IllegalArgument).
         assertThatThrownBy(() -> experimentService.getExperiment(experimentB.getId(), TENANT_A))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("not found");
         assertThat(runRepository.findById(runB.getId(), TENANT_A)).isEmpty();
-        // The owning tenant and a worker still see them.
         assertThat(experimentService.getExperiment(experimentB.getId(), TENANT_B))
                 .isNotNull();
         assertThat(runRepository.findById(runB.getId(), WORKER)).isPresent();


### PR DESCRIPTION
Scoped API keys carried a tenant id but nothing enforced it, so a key could read or mutate another tenant's data by id. This makes the isolation real.

A `TenantScope` (own plus shared rows, or unrestricted for the system principal and background workers) is derived from the authenticated principal and threaded through every read and write. Tenant repositories expose only scoped finders, so an unscoped load does not compile, and an anonymous keyless read collapses to shared rows only. No-key and legacy single-key deployments behave exactly as before.

V14 adds `tenant_id` to the child and config tables that lacked it and makes project, dataset, and connection names unique per tenant.

Covered by a per-repository scope suite, a cross-tenant by-id matrix (including the child entities and the review queue), and worker and backward-compatibility guards. Tenant management, sharing, and accounts are out of scope; API key management stays admin-only.
