### PR TITLE
Deterministic trajectory and tool-result evaluators

### DIFF
--- a/docs/docs/evaluation/agent-evaluation.md
+++ b/docs/docs/evaluation/agent-evaluation.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 AI agents autonomously use tools, reason through multi-step problems, and interact with external APIs. Evaluating them requires more than checking a single response — you need to assess **what tools they used**, **how they used them**, and **whether they accomplished the task**.
 
-Dokimos provides a framework-agnostic agent evaluation system with six evaluators and a portable data model for tool calls and tool definitions.
+Dokimos provides a framework-agnostic agent evaluation system with nine evaluators and a portable data model for tool calls and tool definitions. Five of them are deterministic and need no LLM, so they run in a unit test or CI gate with no API key.
 
 ## Quick Start
 
@@ -88,6 +88,9 @@ val result = experiment {
 |-----------|---------------|:---:|:---:|
 | `ToolCallValidityEvaluator` | Tool calls match their JSON schema (names, required params, types, enums) | No | 1.0 |
 | `ToolCorrectnessEvaluator` | Agent used the expected set of tools | No | 1.0 |
+| `ToolTrajectoryEvaluator` | Tool-call sequence matches an expected trajectory | No | 1.0 |
+| `ToolErrorEvaluator` | Tool calls succeeded (no error results) | No | 1.0 |
+| `ToolEfficiencyEvaluator` | No redundant tool calls | No | 1.0 |
 | `TaskCompletionEvaluator` | Agent completed the user's requested tasks | Yes | 0.5 |
 | `ToolArgumentHallucinationEvaluator` | Tool call arguments are grounded in user input | Yes | 0.8 |
 | `ToolNameReliabilityEvaluator` | Tool names follow naming conventions (snake_case, conciseness, clarity, ordering, intent) | Optional | 0.8 |
@@ -108,6 +111,128 @@ Compares actual vs expected tool usage. Three match modes:
 | `NAMES_ONLY` (default) | Set of tool names (F1 score) |
 | `NAMES_AND_ORDER` | Names + invocation order (LCS similarity) |
 | `NAMES_AND_ARGS` | Full structural comparison including arguments |
+
+In `NAMES_AND_ARGS` mode, arguments are compared with a tolerant matcher by default, so numerically equal values like `1` and `1.0` are treated as equal. See [Argument Matching](#argument-matching) below.
+
+### ToolTrajectoryEvaluator
+
+Scores the agent's tool-call *sequence* against an expected one, with a selectable match mode. Deterministic, no LLM. Use it to assert how an agent should move through a task while choosing how strict the order and arguments need to be.
+
+| Mode | Meaning | Score |
+|------|---------|-------|
+| `STRICT` | Same calls, same order, arguments match | 0 or 1 |
+| `IN_ORDER` | Expected appears as an ordered subsequence | graded (LCS) |
+| `ANY_ORDER` | Same calls in any order | graded |
+| `SUPERSET` | Actual contains every expected call (extras allowed) | 0 or 1 |
+| `SUBSET` | Every actual call is in expected (omissions allowed) | 0 or 1 |
+| `PRECISION` | Matched / number of actual calls | graded |
+| `RECALL` | Matched / number of expected calls | graded |
+
+Reads `toolCalls` from `actualOutputs` and `expectedOutputs`. The unordered modes use a maximum bipartite matching, so repeated tool names are counted optimally.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+ToolTrajectoryEvaluator trajectory = ToolTrajectoryEvaluator.builder()
+    .matchMode(ToolTrajectoryEvaluator.MatchMode.IN_ORDER)
+    .build();
+
+var testCase = EvalTestCase.builder()
+    .actualOutput("toolCalls", trace.toolCalls())
+    .expectedOutput("toolCalls", List.of(
+        ToolCall.of("search_flights", Map.of()),
+        ToolCall.of("book_hotel", Map.of())
+    ))
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val trajectory = toolTrajectory {
+    matchMode = ToolTrajectoryEvaluator.MatchMode.IN_ORDER
+}
+```
+
+  </TabItem>
+</Tabs>
+
+By default only tool names and order are compared. Supply an [argument matcher](#argument-matching) to also assert arguments, optionally overriding it per tool:
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+ToolTrajectoryEvaluator trajectory = ToolTrajectoryEvaluator.builder()
+    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+    .argumentMatcher(ArgumentMatcher.tolerant())                            // default for every tool
+    .argumentMatcher("book_hotel", ArgumentMatcher.of(ArgMatchMode.SUBSET)) // override one tool
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val trajectory = toolTrajectory {
+    matchMode = ToolTrajectoryEvaluator.MatchMode.ANY_ORDER
+    argumentMatcher = ArgumentMatcher.tolerant()                  // default for every tool
+    argumentMatcher("book_hotel", ArgumentMatcher.of(ArgMatchMode.SUBSET)) // override one tool
+}
+```
+
+  </TabItem>
+</Tabs>
+
+### ToolErrorEvaluator
+
+Inspects each tool call's result and scores the fraction that succeeded. Deterministic, no LLM. A call counts as failed when its result is null or blank, is a JSON object with a top-level `error` field, or matches a custom predicate you supply.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+ToolErrorEvaluator toolError = ToolErrorEvaluator.builder()
+    .errorDetector(result -> result.contains("HTTP 500")) // optional, on top of the defaults
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val toolError = toolError {
+    errorDetector = { it.contains("HTTP 500") } // optional, on top of the defaults
+}
+```
+
+  </TabItem>
+</Tabs>
+
+### ToolEfficiencyEvaluator
+
+Detects redundant tool calls. The score is the ratio of distinct calls to total calls, so `1.0` means no redundancy. Two calls are redundant when they share a name and matching arguments; consecutive duplicates are also flagged in the result metadata as a loop signal. Deterministic, no LLM.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+ToolEfficiencyEvaluator efficiency = ToolEfficiencyEvaluator.builder().build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val efficiency = toolEfficiency { }
+```
+
+  </TabItem>
+</Tabs>
+
+Efficiency is a signal, not a hard gate: a legitimately repeated call (a retry, say) lowers the score, so tune the threshold to your case.
 
 ### TaskCompletionEvaluator
 
@@ -130,6 +255,50 @@ Without a judge, only the 3 rule-based checks run. Score is based on checks that
 Evaluates tool descriptions with 13 checks. Rule-based checks (always run): `input_arguments_clarity` (params have descriptions), `input_arguments_types` (params have types), `max_num_input_arguments` (≤ 5 by default), `max_optional_input_arguments` (≤ 3 by default). LLM checks (require judge): `general_structure`, `has_examples`, `has_usage_notes`, `intent_over_implementation`, `clarity`, `redundancy`, `input_arguments_enum`, `input_arguments_format`, `return_statement_quality`.
 
 Without a judge, only the 4 rule-based checks run. Score is based on checks that actually ran.
+
+## Argument Matching
+
+`ToolTrajectoryEvaluator` and `ToolCorrectnessEvaluator` (in `NAMES_AND_ARGS` mode) compare arguments through an `ArgumentMatcher`. The default, `TolerantArgumentMatcher`, compares structurally with a few deliberate tolerances:
+
+- **Numbers** compare by value, so `1`, `1.0`, and `1L` are equal. This is always on, because exact map equality treating `1` and `1.0` as different is a JSON number-widening artifact, not a real difference.
+- **Strings** compare exactly by default. Whitespace trimming and case-insensitivity are opt-in, so turning them on never silently changes existing pass/fail outcomes.
+- **Maps and lists** compare recursively with the same rules.
+
+How the key sets are compared is set by `ArgMatchMode`:
+
+| Mode | Actual arguments must... |
+|------|--------------------------|
+| `EXACT` | have the same keys as expected, all values matching |
+| `SUBSET` | contain every expected entry (extra keys allowed) |
+| `SUPERSET` | be contained in expected (omissions allowed) |
+| `IGNORE` | not be compared at all |
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+ArgumentMatcher matcher = TolerantArgumentMatcher.builder()
+    .mode(ArgMatchMode.SUBSET)   // only the expected arguments must be present and correct
+    .trimStrings(true)
+    .caseInsensitive(true)
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val matcher = TolerantArgumentMatcher.builder()
+    .mode(ArgMatchMode.SUBSET)   // only the expected arguments must be present and correct
+    .trimStrings(true)
+    .caseInsensitive(true)
+    .build()
+```
+
+  </TabItem>
+</Tabs>
+
+Shortcuts: `ArgumentMatcher.tolerant()` for the default `EXACT` matcher, and `ArgumentMatcher.of(mode)` for a tolerant matcher in another mode. For anything custom, pass a lambda: `(expected, actual) -> ...`.
 
 ## Data Model
 
@@ -178,15 +347,48 @@ Task agentTask = example -> {
 };
 ```
 
+When evaluating a single trace directly, `toTestCase()` is a shortcut that builds a ready-to-use `EvalTestCase`: the tool calls, final response, and reasoning steps go into the actual outputs, and the tool definitions and tasks go into metadata. Use it so the validity and completion evaluators don't fail just because the `tools` or `tasks` entries were left out.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+EvalTestCase testCase = trace.toTestCase(
+    "Find flights from NYC to Paris", // user input
+    tools,                            // List<ToolDefinition>, optional
+    List.of("Search flights"));       // tasks, optional
+
+// Shorter overloads when you don't need every part:
+EvalTestCase justInput = trace.toTestCase("Find flights from NYC to Paris");
+EvalTestCase withTools = trace.toTestCase("Find flights from NYC to Paris", tools);
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val testCase = trace.toTestCase(
+    "Find flights from NYC to Paris", // user input
+    tools,                            // List<ToolDefinition>, optional
+    listOf("Search flights"))         // tasks, optional
+
+// Shorter overloads when you don't need every part:
+val justInput = trace.toTestCase("Find flights from NYC to Paris")
+val withTools = trace.toTestCase("Find flights from NYC to Paris", tools)
+```
+
+  </TabItem>
+</Tabs>
+
 ## EvalTestCase Keys
 
 Agent evaluators use these keys in `EvalTestCase`:
 
 | Map | Key | Type | Used by |
 |-----|-----|------|---------|
-| `actualOutputs` | `"toolCalls"` | `List<ToolCall>` | Validity, Correctness, Hallucination |
+| `actualOutputs` | `"toolCalls"` | `List<ToolCall>` | Validity, Correctness, Trajectory, Tool Error, Tool Efficiency, Hallucination |
 | `actualOutputs` | `"output"` | `String` | Task Completion |
-| `expectedOutputs` | `"toolCalls"` | `List<ToolCall>` | Correctness |
+| `expectedOutputs` | `"toolCalls"` | `List<ToolCall>` | Correctness, Trajectory |
 | `metadata` | `"tools"` | `List<ToolDefinition>` | Validity, Name Reliability, Description Reliability |
 | `metadata` | `"tasks"` | `List<String>` | Task Completion |
 | `metadata` | `"constraints"` | `String` | Task Completion |

--- a/dokimos-core/src/main/java/dev/dokimos/core/agents/AgentTrace.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/agents/AgentTrace.java
@@ -1,5 +1,6 @@
 package dev.dokimos.core.agents;
 
+import dev.dokimos.core.EvalTestCase;
 import java.util.*;
 
 /**
@@ -35,6 +36,56 @@ public record AgentTrace(
                 "output", finalResponse != null ? finalResponse : "",
                 "toolCalls", toolCalls,
                 "reasoningSteps", reasoningSteps);
+    }
+
+    /**
+     * Builds an {@link EvalTestCase} from this trace for the given user input.
+     *
+     * @param input the user input the agent responded to
+     * @return a test case carrying this trace's outputs
+     * @see #toTestCase(String, List, List)
+     */
+    public EvalTestCase toTestCase(String input) {
+        return toTestCase(input, List.of(), List.of());
+    }
+
+    /**
+     * Builds an {@link EvalTestCase} from this trace, also wiring the available tool
+     * definitions into metadata.
+     *
+     * @param input the user input the agent responded to
+     * @param tools the tool definitions available to the agent
+     * @return a test case carrying this trace's outputs and tool definitions
+     * @see #toTestCase(String, List, List)
+     */
+    public EvalTestCase toTestCase(String input, List<ToolDefinition> tools) {
+        return toTestCase(input, tools, List.of());
+    }
+
+    /**
+     * Builds an {@link EvalTestCase} from this trace with everything the agent
+     * evaluators need in one call.
+     * <p>
+     * This populates {@code output}, {@code toolCalls} and {@code reasoningSteps} in
+     * actual outputs, and {@code tools} and {@code tasks} in metadata. It exists so
+     * callers stop hitting {@code EvaluationException} when they forget to add the
+     * {@code tools} or {@code tasks} entries that {@link dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator}
+     * and {@link dev.dokimos.core.evaluators.agents.TaskCompletionEvaluator} require.
+     *
+     * @param input the user input the agent responded to (may be null)
+     * @param tools the tool definitions available to the agent (may be null)
+     * @param tasks the tasks the agent was asked to complete (may be null)
+     * @return a fully-populated test case
+     */
+    public EvalTestCase toTestCase(String input, List<ToolDefinition> tools, List<String> tasks) {
+        var builder = EvalTestCase.builder()
+                .actualOutputs(toOutputMap())
+                .metadata("tools", tools != null ? List.copyOf(tools) : List.of())
+                .metadata("tasks", tasks != null ? List.copyOf(tasks) : List.of());
+        if (input != null) {
+            builder.input(input);
+        }
+        return builder.build();
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/AgentEvalCasts.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/AgentEvalCasts.java
@@ -1,0 +1,69 @@
+package dev.dokimos.core.evaluators.agents;
+
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared coercion helpers for agent evaluators.
+ * <p>
+ * Agent evaluators read tool calls and tool definitions from an
+ * {@link dev.dokimos.core.EvalTestCase}, where a value may already be a typed
+ * {@link ToolCall} / {@link ToolDefinition} list (programmatic use) or a list of
+ * maps (deserialized from a JSON or CSV dataset). These helpers normalize either
+ * form into the typed list every evaluator expects.
+ */
+final class AgentEvalCasts {
+
+    private AgentEvalCasts() {}
+
+    /**
+     * Coerces a raw value into a list of {@link ToolCall}.
+     *
+     * @param raw the value read from the test case (a list of {@link ToolCall} or of maps)
+     * @param key the key the value was read from, used for error messages
+     * @return the typed list, or an empty list when the input list is empty
+     * @throws EvaluationException if the value is not a list of tool calls or maps
+     */
+    @SuppressWarnings("unchecked")
+    static List<ToolCall> toolCalls(Object raw, String key) {
+        if (raw instanceof List<?> list) {
+            if (list.isEmpty()) return List.of();
+            if (list.get(0) instanceof ToolCall) {
+                return (List<ToolCall>) raw;
+            }
+            if (list.get(0) instanceof Map) {
+                return list.stream()
+                        .map(item -> ToolCall.fromMap((Map<String, Object>) item))
+                        .toList();
+            }
+        }
+        throw new EvaluationException("Expected a List of ToolCall objects for key '%s'".formatted(key));
+    }
+
+    /**
+     * Coerces a raw value into a list of {@link ToolDefinition}.
+     *
+     * @param raw the value read from the test case (a list of {@link ToolDefinition} or of maps)
+     * @param key the key the value was read from, used for error messages
+     * @return the typed list, or an empty list when the input list is empty
+     * @throws EvaluationException if the value is not a list of tool definitions or maps
+     */
+    @SuppressWarnings("unchecked")
+    static List<ToolDefinition> toolDefinitions(Object raw, String key) {
+        if (raw instanceof List<?> list) {
+            if (list.isEmpty()) return List.of();
+            if (list.get(0) instanceof ToolDefinition) {
+                return (List<ToolDefinition>) raw;
+            }
+            if (list.get(0) instanceof Map) {
+                return list.stream()
+                        .map(item -> ToolDefinition.fromMap((Map<String, Object>) item))
+                        .toList();
+            }
+        }
+        throw new EvaluationException("Expected a List of ToolDefinition objects for key '%s'".formatted(key));
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ArgMatchMode.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ArgMatchMode.java
@@ -1,0 +1,27 @@
+package dev.dokimos.core.evaluators.agents;
+
+/**
+ * Controls how a tool call's arguments are compared against the expected arguments.
+ * <p>
+ * Key-set semantics are defined relative to the expected arguments:
+ * <ul>
+ *   <li>{@link #EXACT} — the actual arguments must have the same keys as expected,
+ *       and every value must match.</li>
+ *   <li>{@link #SUBSET} — every expected entry must be present and matching in the
+ *       actual arguments; the actual arguments may contain additional keys. Use this
+ *       when you only care that specific arguments are correct.</li>
+ *   <li>{@link #SUPERSET} — every actual entry must be present and matching in the
+ *       expected arguments; the actual arguments may omit some expected keys.</li>
+ *   <li>{@link #IGNORE} — arguments are not compared at all (name/order only).</li>
+ * </ul>
+ */
+public enum ArgMatchMode {
+    /** Same key set as expected, all values match. */
+    EXACT,
+    /** Expected entries are a subset of the actual arguments (extras allowed). */
+    SUBSET,
+    /** Actual entries are a subset of the expected arguments (omissions allowed). */
+    SUPERSET,
+    /** Do not compare arguments. */
+    IGNORE
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ArgumentMatcher.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ArgumentMatcher.java
@@ -1,0 +1,50 @@
+package dev.dokimos.core.evaluators.agents;
+
+import java.util.Map;
+
+/**
+ * Strategy for comparing a tool call's actual arguments against the expected arguments.
+ * <p>
+ * Tool-call evaluators ({@link ToolTrajectoryEvaluator}, {@link ToolCorrectnessEvaluator},
+ * {@link ToolEfficiencyEvaluator}) delegate argument comparison to an
+ * {@code ArgumentMatcher} so the matching policy is decoupled from the evaluation
+ * logic. The default implementation, {@link TolerantArgumentMatcher}, treats
+ * numerically equal values such as {@code 1}, {@code 1.0} and {@code 1L} as equal,
+ * which avoids spurious mismatches from JSON number widening.
+ *
+ * @see TolerantArgumentMatcher
+ * @see ArgMatchMode
+ */
+@FunctionalInterface
+public interface ArgumentMatcher {
+
+    /**
+     * Determines whether the actual arguments match the expected arguments.
+     *
+     * @param expected the expected arguments
+     * @param actual   the actual arguments produced by the agent
+     * @return {@code true} if the arguments match under this matcher's policy
+     */
+    boolean matches(Map<String, Object> expected, Map<String, Object> actual);
+
+    /**
+     * Returns the default tolerant matcher using {@link ArgMatchMode#EXACT}.
+     * <p>
+     * Numerically equal values are treated as equal; string comparison is exact.
+     *
+     * @return a tolerant exact-match argument matcher
+     */
+    static ArgumentMatcher tolerant() {
+        return TolerantArgumentMatcher.builder().build();
+    }
+
+    /**
+     * Returns a tolerant matcher using the given key-set mode.
+     *
+     * @param mode the key-set comparison mode
+     * @return a tolerant argument matcher for the given mode
+     */
+    static ArgumentMatcher of(ArgMatchMode mode) {
+        return TolerantArgumentMatcher.builder().mode(mode).build();
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/TolerantArgumentMatcher.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/TolerantArgumentMatcher.java
@@ -1,0 +1,193 @@
+package dev.dokimos.core.evaluators.agents;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Default {@link ArgumentMatcher} that compares arguments structurally with a few
+ * deliberate tolerances.
+ * <p>
+ * Value comparison rules:
+ * <ul>
+ *   <li><b>Numbers</b> are compared by numeric value, so {@code 1}, {@code 1.0} and
+ *       {@code 1L} are equal. This is always on, because exact {@code Map.equals}
+ *       treating {@code 1} and {@code 1.0} as different is a JSON-widening artifact,
+ *       not intended behavior.</li>
+ *   <li><b>Strings</b> are compared exactly by default. {@link Builder#trimStrings(boolean)}
+ *       and {@link Builder#caseInsensitive(boolean)} relax this, but both are off by
+ *       default so existing pass/fail outcomes are never silently changed.</li>
+ *   <li><b>Maps and lists</b> are compared recursively using the same rules.</li>
+ * </ul>
+ * Key-set handling follows the configured {@link ArgMatchMode}.
+ *
+ * <pre>{@code
+ * ArgumentMatcher matcher = TolerantArgumentMatcher.builder()
+ *         .mode(ArgMatchMode.SUBSET)   // only expected keys must be present and correct
+ *         .trimStrings(true)
+ *         .build();
+ * }</pre>
+ */
+public final class TolerantArgumentMatcher implements ArgumentMatcher {
+
+    private final ArgMatchMode mode;
+    private final boolean trimStrings;
+    private final boolean caseInsensitive;
+
+    private TolerantArgumentMatcher(Builder builder) {
+        this.mode = builder.mode;
+        this.trimStrings = builder.trimStrings;
+        this.caseInsensitive = builder.caseInsensitive;
+    }
+
+    /**
+     * Creates a new builder for constructing the matcher.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public boolean matches(Map<String, Object> expected, Map<String, Object> actual) {
+        Map<String, Object> exp = expected != null ? expected : Map.of();
+        Map<String, Object> act = actual != null ? actual : Map.of();
+
+        return switch (mode) {
+            case IGNORE -> true;
+            case EXACT -> exp.keySet().equals(act.keySet()) && allEntriesMatch(exp, act);
+            case SUBSET -> act.keySet().containsAll(exp.keySet()) && allEntriesMatch(exp, act);
+            case SUPERSET -> exp.keySet().containsAll(act.keySet()) && allEntriesMatch(act, exp);
+        };
+    }
+
+    /**
+     * Returns true when every entry in {@code lhs} has a value-equal entry in {@code rhs}.
+     */
+    private boolean allEntriesMatch(Map<String, Object> lhs, Map<String, Object> rhs) {
+        for (Map.Entry<String, Object> entry : lhs.entrySet()) {
+            if (!rhs.containsKey(entry.getKey())) {
+                return false;
+            }
+            if (!valuesEqual(entry.getValue(), rhs.get(entry.getKey()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean valuesEqual(Object a, Object b) {
+        if (a == null || b == null) {
+            return a == b;
+        }
+        if (a instanceof Number na && b instanceof Number nb) {
+            return numbersEqual(na, nb);
+        }
+        if (a instanceof String sa && b instanceof String sb) {
+            return stringsEqual(sa, sb);
+        }
+        if (a instanceof Map<?, ?> ma && b instanceof Map<?, ?> mb) {
+            return mapsEqual((Map<String, Object>) ma, (Map<String, Object>) mb);
+        }
+        if (a instanceof List<?> la && b instanceof List<?> lb) {
+            return listsEqual(la, lb);
+        }
+        return Objects.equals(a, b);
+    }
+
+    private boolean numbersEqual(Number a, Number b) {
+        if (isNonFinite(a) || isNonFinite(b)) {
+            // BigDecimal cannot parse "NaN" / "Infinity"; compare these directly.
+            return Double.compare(a.doubleValue(), b.doubleValue()) == 0;
+        }
+        return new BigDecimal(a.toString()).compareTo(new BigDecimal(b.toString())) == 0;
+    }
+
+    private boolean isNonFinite(Number n) {
+        return (n instanceof Double d && !Double.isFinite(d)) || (n instanceof Float f && !Float.isFinite(f));
+    }
+
+    private boolean stringsEqual(String a, String b) {
+        String left = trimStrings ? a.trim() : a;
+        String right = trimStrings ? b.trim() : b;
+        return caseInsensitive ? left.equalsIgnoreCase(right) : left.equals(right);
+    }
+
+    private boolean mapsEqual(Map<String, Object> a, Map<String, Object> b) {
+        if (!a.keySet().equals(b.keySet())) {
+            return false;
+        }
+        for (Map.Entry<String, Object> entry : a.entrySet()) {
+            if (!valuesEqual(entry.getValue(), b.get(entry.getKey()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean listsEqual(List<?> a, List<?> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < a.size(); i++) {
+            if (!valuesEqual(a.get(i), b.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Builder for constructing the matcher.
+     */
+    public static final class Builder {
+        private ArgMatchMode mode = ArgMatchMode.EXACT;
+        private boolean trimStrings = false;
+        private boolean caseInsensitive = false;
+
+        /**
+         * Sets the key-set comparison mode.
+         *
+         * @param mode the mode (default {@link ArgMatchMode#EXACT})
+         * @return this builder
+         */
+        public Builder mode(ArgMatchMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        /**
+         * Trims leading and trailing whitespace from strings before comparison.
+         *
+         * @param trimStrings true to trim strings (default false)
+         * @return this builder
+         */
+        public Builder trimStrings(boolean trimStrings) {
+            this.trimStrings = trimStrings;
+            return this;
+        }
+
+        /**
+         * Compares strings case-insensitively.
+         *
+         * @param caseInsensitive true for case-insensitive comparison (default false)
+         * @return this builder
+         */
+        public Builder caseInsensitive(boolean caseInsensitive) {
+            this.caseInsensitive = caseInsensitive;
+            return this;
+        }
+
+        /**
+         * Builds the matcher.
+         *
+         * @return a new matcher
+         */
+        public TolerantArgumentMatcher build() {
+            return new TolerantArgumentMatcher(this);
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluator.java
@@ -60,7 +60,7 @@ public class ToolArgumentHallucinationEvaluator extends BaseEvaluator {
                     "ToolArgumentHallucinationEvaluator requires '%s' in actualOutputs".formatted(toolCallsKey));
         }
 
-        List<ToolCall> toolCalls = castToolCalls(rawToolCalls);
+        List<ToolCall> toolCalls = AgentEvalCasts.toolCalls(rawToolCalls, toolCallsKey);
         String userInput = testCase.input();
 
         if (toolCalls.isEmpty()) {
@@ -149,22 +149,6 @@ public class ToolArgumentHallucinationEvaluator extends BaseEvaluator {
             return response.substring(start, end + 1);
         }
         return response;
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<ToolCall> castToolCalls(Object raw) {
-        if (raw instanceof List<?> list) {
-            if (list.isEmpty()) return List.of();
-            if (list.get(0) instanceof ToolCall) {
-                return (List<ToolCall>) raw;
-            }
-            if (list.get(0) instanceof Map) {
-                return list.stream()
-                        .map(item -> ToolCall.fromMap((Map<String, Object>) item))
-                        .toList();
-            }
-        }
-        throw new EvaluationException("Expected a List of ToolCall objects for key '%s'".formatted(toolCallsKey));
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolCallValidityEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolCallValidityEvaluator.java
@@ -58,8 +58,8 @@ public class ToolCallValidityEvaluator extends BaseEvaluator {
             throw new EvaluationException("ToolCallValidityEvaluator requires '%s' in metadata".formatted(toolsKey));
         }
 
-        List<ToolCall> toolCalls = castToolCalls(rawToolCalls);
-        List<ToolDefinition> tools = castToolDefinitions(rawTools);
+        List<ToolCall> toolCalls = AgentEvalCasts.toolCalls(rawToolCalls, toolCallsKey);
+        List<ToolDefinition> tools = AgentEvalCasts.toolDefinitions(rawTools, toolsKey);
 
         if (toolCalls.isEmpty()) {
             return EvalResult.builder()
@@ -183,38 +183,6 @@ public class ToolCallValidityEvaluator extends BaseEvaluator {
                         "Parameter '%s' value '%s' is not in allowed values: %s".formatted(paramName, value, allowed));
             }
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<ToolCall> castToolCalls(Object raw) {
-        if (raw instanceof List<?> list) {
-            if (list.isEmpty()) return List.of();
-            if (list.get(0) instanceof ToolCall) {
-                return (List<ToolCall>) raw;
-            }
-            if (list.get(0) instanceof Map) {
-                return list.stream()
-                        .map(item -> ToolCall.fromMap((Map<String, Object>) item))
-                        .toList();
-            }
-        }
-        throw new EvaluationException("Expected a List of ToolCall objects for key '%s'".formatted(toolCallsKey));
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<ToolDefinition> castToolDefinitions(Object raw) {
-        if (raw instanceof List<?> list) {
-            if (list.isEmpty()) return List.of();
-            if (list.get(0) instanceof ToolDefinition) {
-                return (List<ToolDefinition>) raw;
-            }
-            if (list.get(0) instanceof Map) {
-                return list.stream()
-                        .map(item -> ToolDefinition.fromMap((Map<String, Object>) item))
-                        .toList();
-            }
-        }
-        throw new EvaluationException("Expected a List of ToolDefinition objects for key '%s'".formatted(toolsKey));
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolCorrectnessEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolCorrectnessEvaluator.java
@@ -39,12 +39,14 @@ public class ToolCorrectnessEvaluator extends BaseEvaluator {
     private final String toolCallsKey;
     private final String expectedToolCallsKey;
     private final MatchMode matchMode;
+    private final ArgumentMatcher argumentMatcher;
 
     private ToolCorrectnessEvaluator(Builder builder) {
         super(builder.name, builder.threshold, builder.evaluationParams);
         this.toolCallsKey = builder.toolCallsKey;
         this.expectedToolCallsKey = builder.expectedToolCallsKey;
         this.matchMode = builder.matchMode;
+        this.argumentMatcher = builder.argumentMatcher;
     }
 
     /**
@@ -70,8 +72,8 @@ public class ToolCorrectnessEvaluator extends BaseEvaluator {
                     "ToolCorrectnessEvaluator requires '%s' in expectedOutputs".formatted(expectedToolCallsKey));
         }
 
-        List<ToolCall> actualCalls = castToolCalls(rawActual, toolCallsKey);
-        List<ToolCall> expectedCalls = castToolCalls(rawExpected, expectedToolCallsKey);
+        List<ToolCall> actualCalls = AgentEvalCasts.toolCalls(rawActual, toolCallsKey);
+        List<ToolCall> expectedCalls = AgentEvalCasts.toolCalls(rawExpected, expectedToolCallsKey);
 
         return switch (matchMode) {
             case NAMES_ONLY -> evaluateNameSets(actualCalls, expectedCalls);
@@ -177,8 +179,9 @@ public class ToolCorrectnessEvaluator extends BaseEvaluator {
                 .build();
     }
 
-    private boolean toolCallsMatch(ToolCall a, ToolCall b) {
-        return a.name().equals(b.name()) && a.arguments().equals(b.arguments());
+    private boolean toolCallsMatch(ToolCall actual, ToolCall expected) {
+        return actual.name().equals(expected.name())
+                && argumentMatcher.matches(expected.arguments(), actual.arguments());
     }
 
     private Set<String> extractNames(List<ToolCall> calls) {
@@ -216,22 +219,6 @@ public class ToolCorrectnessEvaluator extends BaseEvaluator {
         return dp[m][n];
     }
 
-    @SuppressWarnings("unchecked")
-    private List<ToolCall> castToolCalls(Object raw, String key) {
-        if (raw instanceof List<?> list) {
-            if (list.isEmpty()) return List.of();
-            if (list.get(0) instanceof ToolCall) {
-                return (List<ToolCall>) raw;
-            }
-            if (list.get(0) instanceof Map) {
-                return list.stream()
-                        .map(item -> ToolCall.fromMap((Map<String, Object>) item))
-                        .toList();
-            }
-        }
-        throw new EvaluationException("Expected a List of ToolCall objects for key '%s'".formatted(key));
-    }
-
     /**
      * Builder for constructing the evaluator.
      */
@@ -242,6 +229,7 @@ public class ToolCorrectnessEvaluator extends BaseEvaluator {
         private String toolCallsKey = "toolCalls";
         private String expectedToolCallsKey = "toolCalls";
         private MatchMode matchMode = MatchMode.NAMES_ONLY;
+        private ArgumentMatcher argumentMatcher = ArgumentMatcher.tolerant();
 
         /**
          * Sets the evaluator name.
@@ -306,6 +294,20 @@ public class ToolCorrectnessEvaluator extends BaseEvaluator {
          */
         public Builder matchMode(MatchMode matchMode) {
             this.matchMode = matchMode;
+            return this;
+        }
+
+        /**
+         * Sets the argument matcher used by {@link MatchMode#NAMES_AND_ARGS}.
+         * <p>
+         * Defaults to {@link ArgumentMatcher#tolerant()}, which treats numerically
+         * equal values such as {@code 1} and {@code 1.0} as equal.
+         *
+         * @param argumentMatcher the argument matcher
+         * @return this builder
+         */
+        public Builder argumentMatcher(ArgumentMatcher argumentMatcher) {
+            this.argumentMatcher = argumentMatcher;
             return this;
         }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolEfficiencyEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolEfficiencyEvaluator.java
@@ -1,0 +1,180 @@
+package dev.dokimos.core.evaluators.agents;
+
+import dev.dokimos.core.BaseEvaluator;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Measures how efficiently an agent used its tools by detecting redundant calls.
+ * <p>
+ * This is a deterministic, glass-box evaluator (no LLM). Two calls are redundant when
+ * they share a name and their arguments match under the configured
+ * {@link ArgumentMatcher} (default {@link ArgumentMatcher#tolerant()}). The score is
+ * the ratio of distinct calls to total calls, so {@code 1.0} means no redundancy.
+ * Consecutive identical calls are additionally flagged as a loop signal in the result
+ * metadata. An empty tool-call list scores {@code 1.0}.
+ * <p>
+ * Efficiency is a signal, not a hard correctness gate: a legitimately repeated call
+ * (for example a retry) lowers the score. Tune the threshold accordingly.
+ */
+public class ToolEfficiencyEvaluator extends BaseEvaluator {
+
+    private final String toolCallsKey;
+    private final ArgumentMatcher argumentMatcher;
+
+    private ToolEfficiencyEvaluator(Builder builder) {
+        super(builder.name, builder.threshold, builder.evaluationParams);
+        this.toolCallsKey = builder.toolCallsKey;
+        this.argumentMatcher = builder.argumentMatcher;
+    }
+
+    /**
+     * Creates a new builder for constructing the evaluator.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected EvalResult runEvaluation(EvalTestCase testCase) {
+        Object rawToolCalls = testCase.actualOutputs().get(toolCallsKey);
+        if (rawToolCalls == null) {
+            throw new EvaluationException(
+                    "ToolEfficiencyEvaluator requires '%s' in actualOutputs".formatted(toolCallsKey));
+        }
+
+        List<ToolCall> toolCalls = AgentEvalCasts.toolCalls(rawToolCalls, toolCallsKey);
+        if (toolCalls.isEmpty()) {
+            return EvalResult.builder()
+                    .name(name)
+                    .score(1.0)
+                    .threshold(threshold)
+                    .reason("No tool calls to inspect.")
+                    .metadata(Map.of("redundantCalls", List.of(), "consecutiveDuplicates", List.of()))
+                    .build();
+        }
+
+        List<ToolCall> distinct = new ArrayList<>();
+        List<String> redundant = new ArrayList<>();
+        List<String> consecutive = new ArrayList<>();
+
+        for (int i = 0; i < toolCalls.size(); i++) {
+            ToolCall call = toolCalls.get(i);
+            boolean isDuplicate = distinct.stream().anyMatch(seen -> sameCall(seen, call));
+            if (isDuplicate) {
+                redundant.add(call.name());
+            } else {
+                distinct.add(call);
+            }
+            if (i > 0 && sameCall(toolCalls.get(i - 1), call)) {
+                consecutive.add(call.name());
+            }
+        }
+
+        double score = (double) distinct.size() / toolCalls.size();
+        String reason = "%d/%d calls were distinct (%d redundant)."
+                .formatted(distinct.size(), toolCalls.size(), redundant.size());
+        return EvalResult.builder()
+                .name(name)
+                .score(score)
+                .threshold(threshold)
+                .reason(reason)
+                .metadata(Map.of(
+                        "totalCalls",
+                        toolCalls.size(),
+                        "distinctCalls",
+                        distinct.size(),
+                        "redundantCalls",
+                        redundant,
+                        "consecutiveDuplicates",
+                        consecutive))
+                .build();
+    }
+
+    private boolean sameCall(ToolCall a, ToolCall b) {
+        return a.name().equals(b.name()) && argumentMatcher.matches(a.arguments(), b.arguments());
+    }
+
+    /**
+     * Builder for constructing the evaluator.
+     */
+    public static class Builder {
+        private String name = "Tool Efficiency";
+        private double threshold = 1.0;
+        private List<EvalTestCaseParam> evaluationParams = List.of();
+        private String toolCallsKey = "toolCalls";
+        private ArgumentMatcher argumentMatcher = ArgumentMatcher.tolerant();
+
+        /**
+         * Sets the evaluator name.
+         *
+         * @param name the evaluator name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the minimum score threshold for success.
+         *
+         * @param threshold the threshold value
+         * @return this builder
+         */
+        public Builder threshold(double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets which test case parameters to validate.
+         *
+         * @param params the parameters
+         * @return this builder
+         */
+        public Builder evaluationParams(List<EvalTestCaseParam> params) {
+            this.evaluationParams = List.copyOf(params);
+            return this;
+        }
+
+        /**
+         * Sets the key used to retrieve tool calls from actualOutputs.
+         *
+         * @param toolCallsKey the key
+         * @return this builder
+         */
+        public Builder toolCallsKey(String toolCallsKey) {
+            this.toolCallsKey = toolCallsKey;
+            return this;
+        }
+
+        /**
+         * Sets the argument matcher used to decide whether two calls are duplicates.
+         *
+         * @param argumentMatcher the argument matcher (default {@link ArgumentMatcher#tolerant()})
+         * @return this builder
+         */
+        public Builder argumentMatcher(ArgumentMatcher argumentMatcher) {
+            this.argumentMatcher = argumentMatcher;
+            return this;
+        }
+
+        /**
+         * Builds the evaluator.
+         *
+         * @return a new evaluator
+         */
+        public ToolEfficiencyEvaluator build() {
+            return new ToolEfficiencyEvaluator(this);
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolErrorEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolErrorEvaluator.java
@@ -1,0 +1,215 @@
+package dev.dokimos.core.evaluators.agents;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.BaseEvaluator;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Detects tool execution failures by inspecting {@link ToolCall#result()}.
+ * <p>
+ * This is a deterministic, glass-box evaluator (no LLM). A tool call is considered
+ * failed when any of the configured detectors fire:
+ * <ul>
+ *   <li>the result is {@code null} or blank (when {@code treatBlankAsError}, the default);</li>
+ *   <li>the result is a JSON object with a non-null top-level {@code "error"} field
+ *       (when {@code detectJsonErrorField}, the default);</li>
+ *   <li>a custom {@link Predicate} supplied via {@link Builder#errorDetector(Predicate)} matches.</li>
+ * </ul>
+ * The score is the fraction of tool calls that did not fail. An empty tool-call list
+ * scores {@code 1.0}, consistent with the other agent evaluators.
+ */
+public class ToolErrorEvaluator extends BaseEvaluator {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final String toolCallsKey;
+    private final boolean treatBlankAsError;
+    private final boolean detectJsonErrorField;
+    private final Predicate<String> errorDetector;
+
+    private ToolErrorEvaluator(Builder builder) {
+        super(builder.name, builder.threshold, builder.evaluationParams);
+        this.toolCallsKey = builder.toolCallsKey;
+        this.treatBlankAsError = builder.treatBlankAsError;
+        this.detectJsonErrorField = builder.detectJsonErrorField;
+        this.errorDetector = builder.errorDetector;
+    }
+
+    /**
+     * Creates a new builder for constructing the evaluator.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected EvalResult runEvaluation(EvalTestCase testCase) {
+        Object rawToolCalls = testCase.actualOutputs().get(toolCallsKey);
+        if (rawToolCalls == null) {
+            throw new EvaluationException("ToolErrorEvaluator requires '%s' in actualOutputs".formatted(toolCallsKey));
+        }
+
+        List<ToolCall> toolCalls = AgentEvalCasts.toolCalls(rawToolCalls, toolCallsKey);
+        if (toolCalls.isEmpty()) {
+            return EvalResult.builder()
+                    .name(name)
+                    .score(1.0)
+                    .threshold(threshold)
+                    .reason("No tool calls to inspect.")
+                    .metadata(Map.of("results", List.of()))
+                    .build();
+        }
+
+        List<Map<String, Object>> perCall = new ArrayList<>();
+        int succeeded = 0;
+        for (ToolCall call : toolCalls) {
+            String reason = errorReason(call.result());
+            boolean errored = reason != null;
+            if (!errored) succeeded++;
+            perCall.add(Map.of("toolName", call.name(), "errored", errored, "reason", errored ? reason : ""));
+        }
+
+        double score = (double) succeeded / toolCalls.size();
+        String reason = "%d/%d tool calls succeeded.".formatted(succeeded, toolCalls.size());
+        return EvalResult.builder()
+                .name(name)
+                .score(score)
+                .threshold(threshold)
+                .reason(reason)
+                .metadata(Map.of("results", perCall))
+                .build();
+    }
+
+    /**
+     * Returns a human-readable reason if the result indicates an error, or null if it succeeded.
+     */
+    private String errorReason(String result) {
+        if (result == null || result.isBlank()) {
+            return treatBlankAsError ? "Result was null or blank." : null;
+        }
+        if (errorDetector != null && errorDetector.test(result)) {
+            return "Matched custom error detector.";
+        }
+        if (detectJsonErrorField) {
+            try {
+                JsonNode node = OBJECT_MAPPER.readTree(result);
+                if (node.isObject() && node.hasNonNull("error")) {
+                    return "Result contains a top-level 'error' field: " + node.get("error");
+                }
+            } catch (Exception ignored) {
+                // Not JSON: nothing to detect here.
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builder for constructing the evaluator.
+     */
+    public static class Builder {
+        private String name = "Tool Error";
+        private double threshold = 1.0;
+        private List<EvalTestCaseParam> evaluationParams = List.of();
+        private String toolCallsKey = "toolCalls";
+        private boolean treatBlankAsError = true;
+        private boolean detectJsonErrorField = true;
+        private Predicate<String> errorDetector;
+
+        /**
+         * Sets the evaluator name.
+         *
+         * @param name the evaluator name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the minimum score threshold for success.
+         *
+         * @param threshold the threshold value
+         * @return this builder
+         */
+        public Builder threshold(double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets which test case parameters to validate.
+         *
+         * @param params the parameters
+         * @return this builder
+         */
+        public Builder evaluationParams(List<EvalTestCaseParam> params) {
+            this.evaluationParams = List.copyOf(params);
+            return this;
+        }
+
+        /**
+         * Sets the key used to retrieve tool calls from actualOutputs.
+         *
+         * @param toolCallsKey the key
+         * @return this builder
+         */
+        public Builder toolCallsKey(String toolCallsKey) {
+            this.toolCallsKey = toolCallsKey;
+            return this;
+        }
+
+        /**
+         * Controls whether a null or blank result counts as an error.
+         *
+         * @param treatBlankAsError true to treat blank results as errors (default true)
+         * @return this builder
+         */
+        public Builder treatBlankAsError(boolean treatBlankAsError) {
+            this.treatBlankAsError = treatBlankAsError;
+            return this;
+        }
+
+        /**
+         * Controls whether a JSON object with a top-level {@code "error"} field counts as an error.
+         *
+         * @param detectJsonErrorField true to detect JSON error fields (default true)
+         * @return this builder
+         */
+        public Builder detectJsonErrorField(boolean detectJsonErrorField) {
+            this.detectJsonErrorField = detectJsonErrorField;
+            return this;
+        }
+
+        /**
+         * Sets a custom predicate that flags a result string as an error.
+         *
+         * @param errorDetector the predicate (receives the raw result string)
+         * @return this builder
+         */
+        public Builder errorDetector(Predicate<String> errorDetector) {
+            this.errorDetector = errorDetector;
+            return this;
+        }
+
+        /**
+         * Builds the evaluator.
+         *
+         * @return a new evaluator
+         */
+        public ToolErrorEvaluator build() {
+            return new ToolErrorEvaluator(this);
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluator.java
@@ -1,0 +1,403 @@
+package dev.dokimos.core.evaluators.agents;
+
+import dev.dokimos.core.BaseEvaluator;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Evaluates an agent's tool-call trajectory against an expected trajectory using a
+ * selectable match mode.
+ * <p>
+ * This is a deterministic, glass-box evaluator. It compares the sequence of tool
+ * calls the agent made against an expected sequence, where two calls match when
+ * their names are equal and their arguments match under an {@link ArgumentMatcher}.
+ * Argument matching is configurable per tool via
+ * {@link Builder#argumentMatcher(String, ArgumentMatcher)}; the default matcher
+ * compares names only ({@link ArgMatchMode#IGNORE}).
+ * <p>
+ * Match modes:
+ * <ul>
+ *   <li>{@link MatchMode#STRICT} — same length, same order, each position matches. Binary score.</li>
+ *   <li>{@link MatchMode#IN_ORDER} — expected appears as an ordered subsequence; graded by
+ *       longest common subsequence.</li>
+ *   <li>{@link MatchMode#ANY_ORDER} — order-independent overlap; graded.</li>
+ *   <li>{@link MatchMode#SUPERSET} — every expected call has a distinct match in actual
+ *       (extra actual calls allowed). Binary score.</li>
+ *   <li>{@link MatchMode#SUBSET} — every actual call has a distinct match in expected
+ *       (missing expected calls allowed). Binary score.</li>
+ *   <li>{@link MatchMode#PRECISION} — matched / number of actual calls.</li>
+ *   <li>{@link MatchMode#RECALL} — matched / number of expected calls.</li>
+ * </ul>
+ * The unordered modes use a maximum bipartite matching, so repeated tool names are
+ * counted optimally even with a stricter per-tool argument matcher. No LLM is required.
+ */
+public class ToolTrajectoryEvaluator extends BaseEvaluator {
+
+    /**
+     * The comparison mode for evaluating a trajectory.
+     */
+    public enum MatchMode {
+        /** Same length, same order, each position matches. */
+        STRICT,
+        /** Expected is an ordered subsequence of actual; graded by LCS. */
+        IN_ORDER,
+        /** Order-independent overlap; graded. */
+        ANY_ORDER,
+        /** Every expected call has a distinct match in actual. */
+        SUPERSET,
+        /** Every actual call has a distinct match in expected. */
+        SUBSET,
+        /** Matched divided by the number of actual calls. */
+        PRECISION,
+        /** Matched divided by the number of expected calls. */
+        RECALL
+    }
+
+    private final String toolCallsKey;
+    private final String expectedToolCallsKey;
+    private final MatchMode matchMode;
+    private final ArgumentMatcher defaultMatcher;
+    private final Map<String, ArgumentMatcher> perToolMatchers;
+
+    private ToolTrajectoryEvaluator(Builder builder) {
+        super(builder.name, builder.threshold, builder.evaluationParams);
+        this.toolCallsKey = builder.toolCallsKey;
+        this.expectedToolCallsKey = builder.expectedToolCallsKey;
+        this.matchMode = builder.matchMode;
+        this.defaultMatcher = builder.defaultMatcher;
+        this.perToolMatchers = Map.copyOf(builder.perToolMatchers);
+    }
+
+    /**
+     * Creates a new builder for constructing the evaluator.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected EvalResult runEvaluation(EvalTestCase testCase) {
+        Object rawActual = testCase.actualOutputs().get(toolCallsKey);
+        if (rawActual == null) {
+            throw new EvaluationException(
+                    "ToolTrajectoryEvaluator requires '%s' in actualOutputs".formatted(toolCallsKey));
+        }
+        Object rawExpected = testCase.expectedOutputs().get(expectedToolCallsKey);
+        if (rawExpected == null) {
+            throw new EvaluationException(
+                    "ToolTrajectoryEvaluator requires '%s' in expectedOutputs".formatted(expectedToolCallsKey));
+        }
+
+        List<ToolCall> actual = AgentEvalCasts.toolCalls(rawActual, toolCallsKey);
+        List<ToolCall> expected = AgentEvalCasts.toolCalls(rawExpected, expectedToolCallsKey);
+
+        if (actual.isEmpty() && expected.isEmpty()) {
+            return result(1.0, "Both actual and expected trajectories are empty.", actual, expected, 0);
+        }
+
+        return switch (matchMode) {
+            case STRICT -> strict(actual, expected);
+            case IN_ORDER -> inOrder(actual, expected);
+            case ANY_ORDER -> anyOrder(actual, expected);
+            case SUPERSET -> superset(actual, expected);
+            case SUBSET -> subset(actual, expected);
+            case PRECISION -> precision(actual, expected);
+            case RECALL -> recall(actual, expected);
+        };
+    }
+
+    private EvalResult strict(List<ToolCall> actual, List<ToolCall> expected) {
+        boolean ok = actual.size() == expected.size();
+        if (ok) {
+            for (int i = 0; i < actual.size(); i++) {
+                if (!callsMatch(actual.get(i), expected.get(i))) {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        String reason = ok
+                ? "Trajectory matches exactly (%d calls).".formatted(expected.size())
+                : "Trajectory differs from expected (strict order and arguments).";
+        return result(ok ? 1.0 : 0.0, reason, actual, expected, ok ? expected.size() : 0);
+    }
+
+    private EvalResult inOrder(List<ToolCall> actual, List<ToolCall> expected) {
+        int lcs = longestCommonSubsequence(actual, expected);
+        int maxLen = Math.max(actual.size(), expected.size());
+        double score = maxLen == 0 ? 1.0 : (double) lcs / maxLen;
+        String reason = "Ordered subsequence match: %d/%d (LCS).".formatted(lcs, maxLen);
+        return result(score, reason, actual, expected, lcs);
+    }
+
+    private EvalResult anyOrder(List<ToolCall> actual, List<ToolCall> expected) {
+        int matched = maxMatched(expected, actual);
+        int maxLen = Math.max(actual.size(), expected.size());
+        double score = maxLen == 0 ? 1.0 : (double) matched / maxLen;
+        String reason = "Unordered match: %d/%d calls matched.".formatted(matched, maxLen);
+        return result(score, reason, actual, expected, matched);
+    }
+
+    private EvalResult superset(List<ToolCall> actual, List<ToolCall> expected) {
+        int matched = maxMatched(expected, actual);
+        boolean ok = matched == expected.size();
+        String reason = ok
+                ? "Actual trajectory contains all %d expected calls.".formatted(expected.size())
+                : "Actual trajectory is missing %d expected calls.".formatted(expected.size() - matched);
+        return result(ok ? 1.0 : 0.0, reason, actual, expected, matched);
+    }
+
+    private EvalResult subset(List<ToolCall> actual, List<ToolCall> expected) {
+        int matched = maxMatched(expected, actual);
+        boolean ok = matched == actual.size();
+        String reason = ok
+                ? "All %d actual calls are within the expected trajectory.".formatted(actual.size())
+                : "Actual trajectory has %d calls not in expected.".formatted(actual.size() - matched);
+        return result(ok ? 1.0 : 0.0, reason, actual, expected, matched);
+    }
+
+    private EvalResult precision(List<ToolCall> actual, List<ToolCall> expected) {
+        int matched = maxMatched(expected, actual);
+        double score = actual.isEmpty() ? (expected.isEmpty() ? 1.0 : 0.0) : (double) matched / actual.size();
+        return result(
+                score,
+                "Precision: %d/%d actual calls matched.".formatted(matched, actual.size()),
+                actual,
+                expected,
+                matched);
+    }
+
+    private EvalResult recall(List<ToolCall> actual, List<ToolCall> expected) {
+        int matched = maxMatched(expected, actual);
+        double score = expected.isEmpty() ? (actual.isEmpty() ? 1.0 : 0.0) : (double) matched / expected.size();
+        return result(
+                score,
+                "Recall: %d/%d expected calls matched.".formatted(matched, expected.size()),
+                actual,
+                expected,
+                matched);
+    }
+
+    /**
+     * Returns the maximum number of expected calls that can be paired with distinct
+     * actual calls, where a pair is allowed when their names are equal and their
+     * arguments match. This is a maximum bipartite matching computed with augmenting
+     * paths (Kuhn's algorithm), so repeated tool names with a stricter per-tool matcher
+     * are counted optimally rather than greedily.
+     * <p>
+     * Every call site passes {@code (expected, actual)} in this order, so the argument
+     * matcher always sees the expected call as the expected side and the actual call as
+     * the actual side. The maximum matching size is the same regardless of which side is
+     * iterated, so this single orientation serves precision, recall, subset, superset,
+     * and any-order alike.
+     */
+    private int maxMatched(List<ToolCall> expected, List<ToolCall> actual) {
+        int[] matchedActual = new int[actual.size()];
+        Arrays.fill(matchedActual, -1);
+        int matched = 0;
+        for (int i = 0; i < expected.size(); i++) {
+            if (augment(i, expected, actual, matchedActual, new boolean[actual.size()])) {
+                matched++;
+            }
+        }
+        return matched;
+    }
+
+    private boolean augment(
+            int expectedIndex, List<ToolCall> expected, List<ToolCall> actual, int[] matchedActual, boolean[] visited) {
+        for (int j = 0; j < actual.size(); j++) {
+            if (visited[j] || !callsMatch(actual.get(j), expected.get(expectedIndex))) {
+                continue;
+            }
+            visited[j] = true;
+            if (matchedActual[j] == -1 || augment(matchedActual[j], expected, actual, matchedActual, visited)) {
+                matchedActual[j] = expectedIndex;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int longestCommonSubsequence(List<ToolCall> actual, List<ToolCall> expected) {
+        int m = actual.size();
+        int n = expected.size();
+        int[][] dp = new int[m + 1][n + 1];
+        for (int i = 1; i <= m; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (callsMatch(actual.get(i - 1), expected.get(j - 1))) {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                }
+            }
+        }
+        return dp[m][n];
+    }
+
+    /**
+     * Two calls match when their names are equal and the actual call's arguments match
+     * the expected call's arguments under the matcher for the expected call's tool
+     * (per-tool override, falling back to the default matcher).
+     *
+     * @param actual   the actual call produced by the agent
+     * @param expected the expected call
+     * @return true if the calls match
+     */
+    private boolean callsMatch(ToolCall actual, ToolCall expected) {
+        if (!actual.name().equals(expected.name())) {
+            return false;
+        }
+        ArgumentMatcher matcher = perToolMatchers.getOrDefault(expected.name(), defaultMatcher);
+        return matcher.matches(expected.arguments(), actual.arguments());
+    }
+
+    private EvalResult result(
+            double score, String reason, List<ToolCall> actual, List<ToolCall> expected, int matched) {
+        return EvalResult.builder()
+                .name(name)
+                .score(score)
+                .threshold(threshold)
+                .reason(reason)
+                .metadata(Map.of(
+                        "matchMode", matchMode.name(),
+                        "matchedCount", matched,
+                        "actualCount", actual.size(),
+                        "expectedCount", expected.size(),
+                        "actualTools", names(actual),
+                        "expectedTools", names(expected)))
+                .build();
+    }
+
+    private List<String> names(List<ToolCall> calls) {
+        List<String> names = new ArrayList<>(calls.size());
+        for (ToolCall call : calls) {
+            names.add(call.name());
+        }
+        return names;
+    }
+
+    /**
+     * Builder for constructing the evaluator.
+     */
+    public static class Builder {
+        private String name = "Trajectory";
+        private double threshold = 1.0;
+        private List<EvalTestCaseParam> evaluationParams = List.of();
+        private String toolCallsKey = "toolCalls";
+        private String expectedToolCallsKey = "toolCalls";
+        private MatchMode matchMode = MatchMode.IN_ORDER;
+        private ArgumentMatcher defaultMatcher = ArgumentMatcher.of(ArgMatchMode.IGNORE);
+        private final Map<String, ArgumentMatcher> perToolMatchers = new HashMap<>();
+
+        /**
+         * Sets the evaluator name.
+         *
+         * @param name the evaluator name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the minimum score threshold for success.
+         *
+         * @param threshold the threshold value
+         * @return this builder
+         */
+        public Builder threshold(double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets which test case parameters to validate.
+         *
+         * @param params the parameters
+         * @return this builder
+         */
+        public Builder evaluationParams(List<EvalTestCaseParam> params) {
+            this.evaluationParams = List.copyOf(params);
+            return this;
+        }
+
+        /**
+         * Sets the key used to retrieve actual tool calls from actualOutputs.
+         *
+         * @param toolCallsKey the key
+         * @return this builder
+         */
+        public Builder toolCallsKey(String toolCallsKey) {
+            this.toolCallsKey = toolCallsKey;
+            return this;
+        }
+
+        /**
+         * Sets the key used to retrieve expected tool calls from expectedOutputs.
+         *
+         * @param expectedToolCallsKey the key
+         * @return this builder
+         */
+        public Builder expectedToolCallsKey(String expectedToolCallsKey) {
+            this.expectedToolCallsKey = expectedToolCallsKey;
+            return this;
+        }
+
+        /**
+         * Sets the trajectory match mode.
+         *
+         * @param matchMode the match mode (default {@link MatchMode#IN_ORDER})
+         * @return this builder
+         */
+        public Builder matchMode(MatchMode matchMode) {
+            this.matchMode = matchMode;
+            return this;
+        }
+
+        /**
+         * Sets the default argument matcher applied to every tool unless overridden.
+         * <p>
+         * Defaults to {@link ArgMatchMode#IGNORE}, so by default only tool names and
+         * order are compared. Supply a tolerant or exact matcher to also assert arguments.
+         *
+         * @param matcher the default argument matcher
+         * @return this builder
+         */
+        public Builder argumentMatcher(ArgumentMatcher matcher) {
+            this.defaultMatcher = matcher;
+            return this;
+        }
+
+        /**
+         * Overrides the argument matcher for a specific tool by name.
+         *
+         * @param toolName the tool name
+         * @param matcher  the argument matcher to use for that tool
+         * @return this builder
+         */
+        public Builder argumentMatcher(String toolName, ArgumentMatcher matcher) {
+            this.perToolMatchers.put(toolName, matcher);
+            return this;
+        }
+
+        /**
+         * Builds the evaluator.
+         *
+         * @return a new evaluator
+         */
+        public ToolTrajectoryEvaluator build() {
+            return new ToolTrajectoryEvaluator(this);
+        }
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/TolerantArgumentMatcherTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/TolerantArgumentMatcherTest.java
@@ -1,0 +1,285 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TolerantArgumentMatcherTest {
+
+    @Nested
+    @DisplayName("EXACT mode")
+    class Exact {
+
+        private final ArgumentMatcher matcher = ArgumentMatcher.tolerant();
+
+        @Test
+        @DisplayName("equal maps match")
+        void equalMatch() {
+            assertThat(matcher.matches(Map.of("a", "x", "n", 1), Map.of("a", "x", "n", 1)))
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("numerically equal values match across int, long and double")
+        void numericTolerance() {
+            assertThat(matcher.matches(Map.of("n", 1), Map.of("n", 1.0))).isTrue();
+            assertThat(matcher.matches(Map.of("n", 1L), Map.of("n", 1))).isTrue();
+            assertThat(matcher.matches(Map.of("n", 1.50), Map.of("n", 1.5))).isTrue();
+        }
+
+        @Test
+        @DisplayName("different numeric values do not match")
+        void numericMismatch() {
+            assertThat(matcher.matches(Map.of("n", 1), Map.of("n", 2))).isFalse();
+        }
+
+        @Test
+        @DisplayName("extra or missing keys do not match")
+        void keySetMismatch() {
+            assertThat(matcher.matches(Map.of("a", "x"), Map.of("a", "x", "b", "y")))
+                    .isFalse();
+            assertThat(matcher.matches(Map.of("a", "x", "b", "y"), Map.of("a", "x")))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("strings are case-sensitive and whitespace-sensitive by default")
+        void strictStringsByDefault() {
+            assertThat(matcher.matches(Map.of("a", "X"), Map.of("a", "x"))).isFalse();
+            assertThat(matcher.matches(Map.of("a", " x "), Map.of("a", "x"))).isFalse();
+        }
+
+        @Test
+        @DisplayName("nested maps and lists compare recursively with numeric tolerance")
+        void nestedStructures() {
+            Map<String, Object> expected = Map.of("o", Map.of("n", 1), "l", List.of(1, 2));
+            Map<String, Object> actual = Map.of("o", Map.of("n", 1.0), "l", List.of(1.0, 2.0));
+            assertThat(matcher.matches(expected, actual)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("opt-in string tolerances")
+    class StringTolerances {
+
+        @Test
+        @DisplayName("trim and case-insensitive match when enabled")
+        void trimAndCase() {
+            ArgumentMatcher matcher = TolerantArgumentMatcher.builder()
+                    .trimStrings(true)
+                    .caseInsensitive(true)
+                    .build();
+            assertThat(matcher.matches(Map.of("a", "Hello"), Map.of("a", " hello ")))
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("key-set modes")
+    class KeySetModes {
+
+        @Test
+        @DisplayName("SUBSET requires expected keys present, allows extras")
+        void subset() {
+            ArgumentMatcher matcher = ArgumentMatcher.of(ArgMatchMode.SUBSET);
+            assertThat(matcher.matches(Map.of("a", "x"), Map.of("a", "x", "b", "y")))
+                    .isTrue();
+            assertThat(matcher.matches(Map.of("a", "x", "c", "z"), Map.of("a", "x")))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("SUPERSET allows omissions, rejects unexpected keys")
+        void superset() {
+            ArgumentMatcher matcher = ArgumentMatcher.of(ArgMatchMode.SUPERSET);
+            assertThat(matcher.matches(Map.of("a", "x", "b", "y"), Map.of("a", "x")))
+                    .isTrue();
+            assertThat(matcher.matches(Map.of("a", "x"), Map.of("a", "x", "b", "y")))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("IGNORE always matches")
+        void ignore() {
+            ArgumentMatcher matcher = ArgumentMatcher.of(ArgMatchMode.IGNORE);
+            assertThat(matcher.matches(Map.of("a", "x"), Map.of("totally", "different")))
+                    .isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("null argument maps are treated as empty")
+    void nullMaps() {
+        assertThat(ArgumentMatcher.tolerant().matches(null, null)).isTrue();
+        assertThat(ArgumentMatcher.tolerant().matches(null, Map.of("a", "x"))).isFalse();
+    }
+
+    @Test
+    @DisplayName("non-finite doubles compare without throwing")
+    void nonFiniteNumbers() {
+        var matcher = ArgumentMatcher.tolerant();
+        assertThat(matcher.matches(Map.of("n", Double.NaN), Map.of("n", Double.NaN)))
+                .isTrue();
+        assertThat(matcher.matches(Map.of("n", Double.POSITIVE_INFINITY), Map.of("n", Double.POSITIVE_INFINITY)))
+                .isTrue();
+        assertThat(matcher.matches(Map.of("n", Double.POSITIVE_INFINITY), Map.of("n", 1.0)))
+                .isFalse();
+    }
+
+    @Nested
+    @DisplayName("numeric edge cases")
+    class NumericEdges {
+
+        private final ArgumentMatcher matcher = ArgumentMatcher.tolerant();
+
+        @Test
+        @DisplayName("BigDecimal and BigInteger compare by value with the boxed primitives")
+        void bigNumbers() {
+            assertThat(matcher.matches(Map.of("n", new BigDecimal("1.0")), Map.of("n", 1)))
+                    .isTrue();
+            assertThat(matcher.matches(Map.of("n", new BigInteger("42")), Map.of("n", 42L)))
+                    .isTrue();
+            assertThat(matcher.matches(Map.of("n", new BigDecimal("1.5")), Map.of("n", 2)))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("very large doubles in scientific notation compare correctly")
+        void scientificNotation() {
+            assertThat(matcher.matches(Map.of("n", 1.0e10), Map.of("n", 10_000_000_000L)))
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("a number and its string form do not match")
+        void numberVsStringDoesNotMatch() {
+            assertThat(matcher.matches(Map.of("n", 1), Map.of("n", "1"))).isFalse();
+        }
+
+        @Test
+        @DisplayName("NaN does not match a finite number")
+        void nanVsFinite() {
+            assertThat(matcher.matches(Map.of("n", Double.NaN), Map.of("n", 1.0)))
+                    .isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("structural edge cases")
+    class Structural {
+
+        private final ArgumentMatcher matcher = ArgumentMatcher.tolerant();
+
+        @Test
+        @DisplayName("empty maps match")
+        void emptyMaps() {
+            assertThat(matcher.matches(Map.of(), Map.of())).isTrue();
+        }
+
+        @Test
+        @DisplayName("lists of different sizes do not match")
+        void listSizeMismatch() {
+            assertThat(matcher.matches(Map.of("l", List.of(1, 2)), Map.of("l", List.of(1, 2, 3))))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("list element order is significant")
+        void listOrderMatters() {
+            assertThat(matcher.matches(Map.of("l", List.of(1, 2)), Map.of("l", List.of(2, 1))))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("a map value and a scalar value of the same key do not match")
+        void typeMismatch() {
+            assertThat(matcher.matches(Map.of("a", Map.of("x", 1)), Map.of("a", "scalar")))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("deeply nested mismatch is detected")
+        void deepNestedMismatch() {
+            Map<String, Object> expected = Map.of("o", Map.of("p", List.of(Map.of("n", 1))));
+            Map<String, Object> actual = Map.of("o", Map.of("p", List.of(Map.of("n", 2))));
+            assertThat(matcher.matches(expected, actual)).isFalse();
+        }
+
+        @Test
+        @DisplayName("a null value matches only another null value")
+        void nullValues() {
+            Map<String, Object> expectedNull = new HashMap<>();
+            expectedNull.put("a", null);
+            Map<String, Object> actualNull = new HashMap<>();
+            actualNull.put("a", null);
+            assertThat(matcher.matches(expectedNull, actualNull)).isTrue();
+
+            Map<String, Object> actualValue = new HashMap<>();
+            actualValue.put("a", "x");
+            assertThat(matcher.matches(expectedNull, actualValue)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("string tolerance combinations")
+    class StringToleranceCombos {
+
+        @Test
+        @DisplayName("trim only does not relax case")
+        void trimOnly() {
+            ArgumentMatcher matcher =
+                    TolerantArgumentMatcher.builder().trimStrings(true).build();
+            assertThat(matcher.matches(Map.of("a", "Hello"), Map.of("a", " Hello ")))
+                    .isTrue();
+            assertThat(matcher.matches(Map.of("a", "Hello"), Map.of("a", " hello ")))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("case-insensitive only does not trim")
+        void caseOnly() {
+            ArgumentMatcher matcher =
+                    TolerantArgumentMatcher.builder().caseInsensitive(true).build();
+            assertThat(matcher.matches(Map.of("a", "Hello"), Map.of("a", "hello")))
+                    .isTrue();
+            assertThat(matcher.matches(Map.of("a", "Hello"), Map.of("a", " hello")))
+                    .isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("key-set modes still compare values on shared keys")
+    void keySetModesCompareValues() {
+        ArgumentMatcher subset = ArgumentMatcher.of(ArgMatchMode.SUBSET);
+        // expected key present in actual but with a different value -> no match
+        assertThat(subset.matches(Map.of("a", "x"), Map.of("a", "y", "b", "z"))).isFalse();
+
+        ArgumentMatcher superset = ArgumentMatcher.of(ArgMatchMode.SUPERSET);
+        assertThat(superset.matches(Map.of("a", "x", "b", "z"), Map.of("a", "y")))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("a custom matcher lambda is honored")
+    void customLambda() {
+        ArgumentMatcher anySize = (expected, actual) -> expected.size() == actual.size();
+        assertThat(anySize.matches(Map.of("a", 1), Map.of("z", 99))).isTrue();
+        assertThat(anySize.matches(Map.of("a", 1), Map.of("a", 1, "b", 2))).isFalse();
+    }
+
+    @Test
+    @DisplayName("nested array contents compare with numeric tolerance via java arrays as lists")
+    void listsAreCheckedElementwise() {
+        var matcher = ArgumentMatcher.tolerant();
+        assertThat(matcher.matches(Map.of("l", Arrays.asList(1, 2, 3)), Map.of("l", Arrays.asList(1.0, 2.0, 3.0))))
+                .isTrue();
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolCorrectnessEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolCorrectnessEvaluatorTest.java
@@ -234,4 +234,91 @@ class ToolCorrectnessEvaluatorTest {
                 .isInstanceOf(EvaluationException.class)
                 .hasMessageContaining("toolCalls");
     }
+
+    @Test
+    void namesAndArgsRegressionNumericallyEqualArgsMatch() {
+        // REGRESSION: prior exact Map.equals reported 1 vs 1.0 as a mismatch.
+        var evaluator = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("book", Map.of("nights", 1.0))))
+                .expectedOutput("toolCalls", List.of(ToolCall.of("book", Map.of("nights", 1))))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void namesAndArgsExactArgsStillMatch() {
+        var evaluator = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("book", Map.of("city", "Paris"))))
+                .expectedOutput("toolCalls", List.of(ToolCall.of("book", Map.of("city", "Paris"))))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void namesAndArgsDifferentArgsStillFail() {
+        var evaluator = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("book", Map.of("nights", 2))))
+                .expectedOutput("toolCalls", List.of(ToolCall.of("book", Map.of("nights", 3))))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void namesAndArgsStringCaseStillStrictByDefault() {
+        var evaluator = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("book", Map.of("city", "paris"))))
+                .expectedOutput("toolCalls", List.of(ToolCall.of("book", Map.of("city", "Paris"))))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void namesAndArgsNumericToleranceAppliesInsideNestedArgs() {
+        var evaluator = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("search", Map.of("filter", Map.of("maxPrice", 500.0)))))
+                .expectedOutput("toolCalls", List.of(ToolCall.of("search", Map.of("filter", Map.of("maxPrice", 500)))))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void namesAndArgsHonorsACustomArgumentMatcher() {
+        // A SUBSET matcher lets the actual call carry extra arguments the expected spec omits.
+        var evaluator = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.SUBSET))
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("book", Map.of("id", "X", "seat", "12A"))))
+                .expectedOutput("toolCalls", List.of(ToolCall.of("book", Map.of("id", "X"))))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolEfficiencyEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolEfficiencyEvaluatorTest.java
@@ -1,0 +1,148 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ToolEfficiencyEvaluatorTest {
+
+    private static EvalTestCase of(List<ToolCall> calls) {
+        return EvalTestCase.builder().actualOutput("toolCalls", calls).build();
+    }
+
+    @Test
+    @DisplayName("no duplicates scores 1.0")
+    void noDuplicates() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(ToolCall.of("a", Map.of()), ToolCall.of("b", Map.of()))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("exact duplicate call lowers the score")
+    void exactDuplicate() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(
+                        of(List.of(ToolCall.of("search", Map.of("q", "x")), ToolCall.of("search", Map.of("q", "x")))));
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("argument-tolerant duplicate is detected")
+    void tolerantDuplicate() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(ToolCall.of("page", Map.of("n", 1)), ToolCall.of("page", Map.of("n", 1.0)))));
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("same name different args is not a duplicate")
+    void differentArgsNotDuplicate() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(
+                        of(List.of(ToolCall.of("search", Map.of("q", "x")), ToolCall.of("search", Map.of("q", "y")))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("consecutive identical calls are flagged as a loop")
+    void consecutiveFlagged() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(ToolCall.of("a", Map.of()), ToolCall.of("a", Map.of()))));
+        @SuppressWarnings("unchecked")
+        List<String> consecutive = (List<String>) result.metadata().get("consecutiveDuplicates");
+        assertThat(consecutive).containsExactly("a");
+    }
+
+    @Test
+    @DisplayName("empty tool calls score 1.0")
+    void empty() {
+        EvalResult result = ToolEfficiencyEvaluator.builder().build().evaluate(of(List.of()));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("three identical calls score one third")
+    void threeIdentical() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(of(
+                        List.of(ToolCall.of("a", Map.of()), ToolCall.of("a", Map.of()), ToolCall.of("a", Map.of()))));
+        assertThat(result.score()).isEqualTo(1.0 / 3.0);
+    }
+
+    @Test
+    @DisplayName("a non-consecutive duplicate counts as redundant but not as a loop")
+    void nonConsecutiveDuplicate() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(of(
+                        List.of(ToolCall.of("a", Map.of()), ToolCall.of("b", Map.of()), ToolCall.of("a", Map.of()))));
+
+        assertThat(result.score()).isEqualTo(2.0 / 3.0);
+        @SuppressWarnings("unchecked")
+        List<String> redundant = (List<String>) result.metadata().get("redundantCalls");
+        @SuppressWarnings("unchecked")
+        List<String> consecutive = (List<String>) result.metadata().get("consecutiveDuplicates");
+        assertThat(redundant).containsExactly("a");
+        assertThat(consecutive).isEmpty();
+    }
+
+    @Test
+    @DisplayName("metadata reports total, distinct, and redundant counts")
+    void metadataCounts() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .build()
+                .evaluate(of(
+                        List.of(ToolCall.of("a", Map.of()), ToolCall.of("a", Map.of()), ToolCall.of("b", Map.of()))));
+
+        assertThat(result.metadata().get("totalCalls")).isEqualTo(3);
+        assertThat(result.metadata().get("distinctCalls")).isEqualTo(2);
+        @SuppressWarnings("unchecked")
+        List<String> redundant = (List<String>) result.metadata().get("redundantCalls");
+        assertThat(redundant).containsExactly("a");
+    }
+
+    @Test
+    @DisplayName("an IGNORE matcher treats same-name calls as duplicates regardless of args")
+    void ignoreMatcherCollapsesByName() {
+        var result = ToolEfficiencyEvaluator.builder()
+                .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
+                .build()
+                .evaluate(
+                        of(List.of(ToolCall.of("search", Map.of("q", "x")), ToolCall.of("search", Map.of("q", "y")))));
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("tool calls supplied as maps are accepted")
+    void mapInput() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(Map.of("name", "a"), Map.of("name", "a")))
+                .build();
+        var result = ToolEfficiencyEvaluator.builder().build().evaluate(testCase);
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("missing toolCalls throws EvaluationException")
+    void missingKey() {
+        var testCase = EvalTestCase.builder().actualOutput("output", "x").build();
+        assertThatThrownBy(() -> ToolEfficiencyEvaluator.builder().build().evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("toolCalls");
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolErrorEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolErrorEvaluatorTest.java
@@ -1,0 +1,167 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ToolErrorEvaluatorTest {
+
+    private static EvalTestCase of(List<ToolCall> calls) {
+        return EvalTestCase.builder().actualOutput("toolCalls", calls).build();
+    }
+
+    private static ToolCall withResult(String name, String result) {
+        return ToolCall.builder().name(name).result(result).build();
+    }
+
+    @Test
+    @DisplayName("all successful results score 1.0")
+    void allSucceed() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("a", "{\"ok\":true}"), withResult("b", "done"))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("null or blank result counts as error by default")
+    void blankIsError() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("a", "done"), ToolCall.of("b", Map.of()))));
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("blank tolerated when treatBlankAsError is false")
+    void blankTolerated() {
+        var result = ToolErrorEvaluator.builder()
+                .treatBlankAsError(false)
+                .build()
+                .evaluate(of(List.of(ToolCall.of("b", Map.of()))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("JSON top-level error field is detected")
+    void jsonErrorField() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("a", "{\"error\":\"not found\"}"), withResult("b", "ok"))));
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("the word error inside a value is not a false positive")
+    void noSubstringFalsePositive() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("a", "{\"message\":\"no error occurred\"}"))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("custom error detector fires")
+    void customDetector() {
+        var result = ToolErrorEvaluator.builder()
+                .errorDetector(r -> r.contains("HTTP 500"))
+                .build()
+                .evaluate(of(List.of(withResult("a", "HTTP 500 internal"), withResult("b", "HTTP 200"))));
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("empty tool calls score 1.0")
+    void empty() {
+        EvalResult result = ToolErrorEvaluator.builder().build().evaluate(of(List.of()));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("a JSON error field set to null is not treated as an error")
+    void jsonErrorFieldNull() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("a", "{\"error\":null,\"data\":1}"))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("a JSON array result is not treated as an error")
+    void jsonArrayResult() {
+        var result = ToolErrorEvaluator.builder().build().evaluate(of(List.of(withResult("a", "[{\"error\":\"x\"}]"))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("all calls failing scores 0.0")
+    void allFail() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("a", "{\"error\":\"boom\"}"), ToolCall.of("b", Map.of()))));
+        assertThat(result.score()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("JSON error detection can be disabled")
+    void jsonDetectionDisabled() {
+        var result = ToolErrorEvaluator.builder()
+                .detectJsonErrorField(false)
+                .build()
+                .evaluate(of(List.of(withResult("a", "{\"error\":\"ignored\"}"))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("a custom tool calls key is honored")
+    void customKey() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("calls", List.of(withResult("a", "done"), ToolCall.of("b", Map.of())))
+                .build();
+        var result = ToolErrorEvaluator.builder().toolCallsKey("calls").build().evaluate(testCase);
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("per-call metadata records the failing tool and reason")
+    void perCallMetadata() {
+        var result = ToolErrorEvaluator.builder()
+                .build()
+                .evaluate(of(List.of(withResult("ok_tool", "fine"), withResult("bad_tool", "{\"error\":\"nope\"}"))));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> perCall =
+                (List<Map<String, Object>>) result.metadata().get("results");
+        assertThat(perCall).hasSize(2);
+        assertThat(perCall.get(0)).containsEntry("toolName", "ok_tool").containsEntry("errored", false);
+        assertThat(perCall.get(1)).containsEntry("toolName", "bad_tool").containsEntry("errored", true);
+        assertThat(perCall.get(1).get("reason").toString()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("tool calls supplied as maps are accepted")
+    void mapInput() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(Map.of("name", "a", "result", "done")))
+                .build();
+        var result = ToolErrorEvaluator.builder().build().evaluate(testCase);
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("missing toolCalls throws EvaluationException")
+    void missingKey() {
+        var testCase = EvalTestCase.builder().actualOutput("output", "x").build();
+        assertThatThrownBy(() -> ToolErrorEvaluator.builder().build().evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("toolCalls");
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluatorTest.java
@@ -1,0 +1,372 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ToolTrajectoryEvaluatorTest {
+
+    private static EvalTestCase testCase(List<ToolCall> actual, List<ToolCall> expected) {
+        return EvalTestCase.builder()
+                .actualOutput("toolCalls", actual)
+                .expectedOutput("toolCalls", expected)
+                .build();
+    }
+
+    private static ToolCall call(String name) {
+        return ToolCall.of(name, Map.of());
+    }
+
+    @Nested
+    @DisplayName("STRICT")
+    class Strict {
+        @Test
+        @DisplayName("identical sequence scores 1.0")
+        void exact() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("b")), List.of(call("a"), call("b"))));
+            assertThat(result.score()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("wrong order fails")
+        void wrongOrder() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .build()
+                    .evaluate(testCase(List.of(call("b"), call("a")), List.of(call("a"), call("b"))));
+            assertThat(result.score()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("IN_ORDER")
+    class InOrder {
+        @Test
+        @DisplayName("ordered subsequence with extras is graded by LCS")
+        void graded() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.IN_ORDER)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("x"), call("b")), List.of(call("a"), call("b"))));
+            // LCS=2, maxLen=3
+            assertThat(result.score()).isEqualTo(2.0 / 3.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("ANY_ORDER")
+    class AnyOrder {
+        @Test
+        @DisplayName("same set different order scores 1.0")
+        void multiset() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                    .build()
+                    .evaluate(testCase(List.of(call("b"), call("a")), List.of(call("a"), call("b"))));
+            assertThat(result.score()).isEqualTo(1.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("SUPERSET and SUBSET")
+    class SuperSub {
+        @Test
+        @DisplayName("SUPERSET passes when actual contains all expected")
+        void superset() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.SUPERSET)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("b"), call("c")), List.of(call("a"), call("c"))));
+            assertThat(result.score()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("SUBSET fails when actual has a call not in expected")
+        void subsetFails() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.SUBSET)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("z")), List.of(call("a"), call("b"), call("c"))));
+            assertThat(result.score()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("PRECISION and RECALL")
+    class PrecisionRecall {
+        @Test
+        @DisplayName("precision is matched over actual count")
+        void precision() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.PRECISION)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("x")), List.of(call("a"))));
+            assertThat(result.score()).isEqualTo(0.5);
+        }
+
+        @Test
+        @DisplayName("recall is matched over expected count")
+        void recall() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.RECALL)
+                    .build()
+                    .evaluate(testCase(List.of(call("a")), List.of(call("a"), call("b"))));
+            assertThat(result.score()).isEqualTo(0.5);
+        }
+    }
+
+    @Nested
+    @DisplayName("argument matching")
+    class Arguments {
+        @Test
+        @DisplayName("default ignores arguments")
+        void ignoresArgsByDefault() {
+            var actual = List.of(ToolCall.of("search", Map.of("q", "shoes")));
+            var expected = List.of(ToolCall.of("search", Map.of("q", "boots")));
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .build()
+                    .evaluate(testCase(actual, expected));
+            assertThat(result.score()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("per-tool override enforces arguments for one tool only")
+        void perToolOverride() {
+            var actual = List.of(ToolCall.of("search", Map.of("q", "shoes")), ToolCall.of("book", Map.of("id", "X")));
+            var expected = List.of(ToolCall.of("search", Map.of("q", "boots")), ToolCall.of("book", Map.of("id", "X")));
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .argumentMatcher("search", ArgumentMatcher.tolerant())
+                    .build()
+                    .evaluate(testCase(actual, expected));
+            // search args differ -> strict fails
+            assertThat(result.score()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("duplicate tool names")
+    class DuplicateNames {
+        @Test
+        @DisplayName("ANY_ORDER counts repeated names by multiplicity")
+        void repeatedMultiplicity() {
+            var oneVsTwo = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("a")), List.of(call("a"))));
+            // one expected 'a' matches one of two actual 'a' -> 1/2
+            assertThat(oneVsTwo.score()).isEqualTo(0.5);
+
+            var twoVsTwo = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("a")), List.of(call("a"), call("a"))));
+            assertThat(twoVsTwo.score()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("SUPERSET requires a distinct actual for each repeated expected")
+        void supersetDistinct() {
+            var enough = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.SUPERSET)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("a"), call("b")), List.of(call("a"), call("a"))));
+            assertThat(enough.score()).isEqualTo(1.0);
+
+            var notEnough = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.SUPERSET)
+                    .build()
+                    .evaluate(testCase(List.of(call("a"), call("b")), List.of(call("a"), call("a"))));
+            assertThat(notEnough.score()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("maximum matching pairs repeated names where greedy first-fit would undercount")
+        void optimalUnderSubsetMatcher() {
+            // A per-tool SUBSET matcher makes the two 'page' candidates non-interchangeable.
+            // Ordered so greedy first-fit would strand a pair; maximum matching pairs all four.
+            var actual = List.of(ToolCall.of("page", Map.of("n", 1, "size", 10)), ToolCall.of("page", Map.of("n", 1)));
+            var expected =
+                    List.of(ToolCall.of("page", Map.of("n", 1)), ToolCall.of("page", Map.of("n", 1, "size", 10)));
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                    .argumentMatcher("page", ArgumentMatcher.of(ArgMatchMode.SUBSET))
+                    .build()
+                    .evaluate(testCase(actual, expected));
+            assertThat(result.score()).isEqualTo(1.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("argument matcher orientation")
+    class ArgumentOrientation {
+        // SUBSET is asymmetric: matches(expected, actual) holds iff actual's keys cover expected's.
+        // These pin the direction so expected and actual are never swapped between modes.
+        @Test
+        @DisplayName("ANY_ORDER applies the matcher as matches(expected, actual)")
+        void anyOrderOrientation() {
+            var pass = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                    .argumentMatcher("t", ArgumentMatcher.of(ArgMatchMode.SUBSET))
+                    .build()
+                    .evaluate(testCase(
+                            List.of(ToolCall.of("t", Map.of("a", 1, "b", 2))),
+                            List.of(ToolCall.of("t", Map.of("a", 1)))));
+            // expected {a:1} is covered by actual {a:1,b:2} -> match
+            assertThat(pass.score()).isEqualTo(1.0);
+
+            var fail = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                    .argumentMatcher("t", ArgumentMatcher.of(ArgMatchMode.SUBSET))
+                    .build()
+                    .evaluate(testCase(
+                            List.of(ToolCall.of("t", Map.of("a", 1))),
+                            List.of(ToolCall.of("t", Map.of("a", 1, "b", 2)))));
+            // expected {a:1,b:2} is NOT covered by actual {a:1} -> no match
+            assertThat(fail.score()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("RECALL keeps the same orientation as ANY_ORDER")
+        void recallOrientation() {
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.RECALL)
+                    .argumentMatcher("t", ArgumentMatcher.of(ArgMatchMode.SUBSET))
+                    .build()
+                    .evaluate(testCase(
+                            List.of(ToolCall.of("t", Map.of("a", 1))),
+                            List.of(ToolCall.of("t", Map.of("a", 1, "b", 2)))));
+            assertThat(result.score()).isEqualTo(0.0);
+        }
+    }
+
+    @Test
+    @DisplayName("both empty scores 1.0")
+    void bothEmpty() {
+        var result = ToolTrajectoryEvaluator.builder().build().evaluate(testCase(List.of(), List.of()));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("missing expected key throws EvaluationException")
+    void missingKey() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(call("a")))
+                .build();
+        assertThatThrownBy(() -> ToolTrajectoryEvaluator.builder().build().evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("expectedOutputs");
+    }
+
+    @Test
+    @DisplayName("accepts tool calls supplied as maps")
+    void mapInput() {
+        var actual = List.of(Map.of("name", "a"), Map.of("name", "b"));
+        var expected = List.of(Map.of("name", "a"), Map.of("name", "b"));
+        EvalResult result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                .build()
+                .evaluate(EvalTestCase.builder()
+                        .actualOutput("toolCalls", actual)
+                        .expectedOutput("toolCalls", expected)
+                        .build());
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("missing actual key throws EvaluationException")
+    void missingActualKey() {
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("toolCalls", List.of(call("a")))
+                .build();
+        assertThatThrownBy(() -> ToolTrajectoryEvaluator.builder().build().evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("actualOutputs");
+    }
+
+    @Test
+    @DisplayName("custom keys are honored")
+    void customKeys() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("got", List.of(call("a")))
+                .expectedOutput("want", List.of(call("a")))
+                .build();
+        var result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                .toolCallsKey("got")
+                .expectedToolCallsKey("want")
+                .build()
+                .evaluate(testCase);
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("metadata carries the per-run diff for downstream rendering")
+    void metadataContent() {
+        var result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                .build()
+                .evaluate(testCase(List.of(call("a"), call("x")), List.of(call("a"), call("b"))));
+
+        assertThat(result.metadata().get("matchMode")).isEqualTo("ANY_ORDER");
+        assertThat(result.metadata().get("actualCount")).isEqualTo(2);
+        assertThat(result.metadata().get("expectedCount")).isEqualTo(2);
+        assertThat(result.metadata().get("matchedCount")).isEqualTo(1);
+        @SuppressWarnings("unchecked")
+        List<String> actualTools = (List<String>) result.metadata().get("actualTools");
+        assertThat(actualTools).containsExactly("a", "x");
+    }
+
+    @Test
+    @DisplayName("STRICT fails when actual has extra trailing calls")
+    void strictLengthMismatch() {
+        var result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                .build()
+                .evaluate(testCase(List.of(call("a"), call("b"), call("c")), List.of(call("a"), call("b"))));
+        assertThat(result.score()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("IN_ORDER scores 1.0 when sequences are identical")
+    void inOrderIdentical() {
+        var result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.IN_ORDER)
+                .build()
+                .evaluate(testCase(List.of(call("a"), call("b")), List.of(call("a"), call("b"))));
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("RECALL with empty expected and non-empty actual scores 0.0")
+    void recallEmptyExpected() {
+        var result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.RECALL)
+                .build()
+                .evaluate(testCase(List.of(call("a")), List.of()));
+        assertThat(result.score()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("PRECISION with empty actual and non-empty expected scores 0.0")
+    void precisionEmptyActual() {
+        var result = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.PRECISION)
+                .build()
+                .evaluate(testCase(List.of(), List.of(call("a"))));
+        assertThat(result.score()).isEqualTo(0.0);
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/integration/AgentEvaluatorIT.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/integration/AgentEvaluatorIT.java
@@ -133,6 +133,40 @@ class AgentEvaluatorIT {
     }
 
     @Test
+    void shouldEvaluateTrajectoryAndToolSuccess() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", trace.toolCalls())
+                .expectedOutput(
+                        "toolCalls",
+                        List.of(ToolCall.of("search_flights", Map.of()), ToolCall.of("book_hotel", Map.of())))
+                .build();
+
+        // ANY_ORDER tolerates whichever sequence the model picks for these two independent tools.
+        var trajectory = ToolTrajectoryEvaluator.builder()
+                .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                .build()
+                .evaluate(testCase);
+        assertThat(trajectory.score()).isGreaterThanOrEqualTo(0.5);
+
+        // The canned tool results are all success payloads, so no call should be flagged as an error.
+        var toolError = ToolErrorEvaluator.builder().build().evaluate(testCase);
+        assertThat(toolError.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldEvaluateToolEfficiency() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", trace.toolCalls())
+                .build();
+
+        // A well-behaved agent should not repeat identical calls for this single, unambiguous request.
+        var efficiency = ToolEfficiencyEvaluator.builder().build().evaluate(testCase);
+        assertThat(efficiency.score())
+                .as("Redundant calls: %s", efficiency.metadata().get("redundantCalls"))
+                .isEqualTo(1.0);
+    }
+
+    @Test
     void shouldDetectTaskCompletion() {
         var result = TaskCompletionEvaluator.builder().judge(judge).build().evaluate(buildTestCase());
 

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
@@ -52,6 +52,15 @@ fun toolArgumentHallucination(
 fun toolNameReliability(block: ToolNameReliabilityEvaluatorDsl.() -> Unit = {}): ToolNameReliabilityEvaluator =
     ToolNameReliabilityEvaluatorDsl().apply(block).build()
 
+fun toolTrajectory(block: ToolTrajectoryEvaluatorDsl.() -> Unit = {}): ToolTrajectoryEvaluator =
+    ToolTrajectoryEvaluatorDsl().apply(block).build()
+
+fun toolError(block: ToolErrorEvaluatorDsl.() -> Unit = {}): ToolErrorEvaluator =
+    ToolErrorEvaluatorDsl().apply(block).build()
+
+fun toolEfficiency(block: ToolEfficiencyEvaluatorDsl.() -> Unit = {}): ToolEfficiencyEvaluator =
+    ToolEfficiencyEvaluatorDsl().apply(block).build()
+
 fun toolDescriptionReliability(
     block: ToolDescriptionReliabilityEvaluatorDsl.() -> Unit = {
     },

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDsl.kt
@@ -12,13 +12,18 @@ import dev.dokimos.core.evaluators.LLMJudgeEvaluator
 import dev.dokimos.core.evaluators.PrecisionEvaluator
 import dev.dokimos.core.evaluators.RecallEvaluator
 import dev.dokimos.core.evaluators.RegexEvaluator
+import dev.dokimos.core.evaluators.agents.ArgumentMatcher
 import dev.dokimos.core.evaluators.agents.TaskCompletionEvaluator
 import dev.dokimos.core.evaluators.agents.ToolArgumentHallucinationEvaluator
 import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator
 import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator
 import dev.dokimos.core.evaluators.agents.ToolDescriptionReliabilityEvaluator
+import dev.dokimos.core.evaluators.agents.ToolEfficiencyEvaluator
+import dev.dokimos.core.evaluators.agents.ToolErrorEvaluator
 import dev.dokimos.core.evaluators.agents.ToolNameReliabilityEvaluator
+import dev.dokimos.core.evaluators.agents.ToolTrajectoryEvaluator
 import dev.dokimos.kotlin.dsl.DokimosDsl
+import java.util.function.Predicate
 
 @DokimosDsl
 class EvaluatorsDsl {
@@ -78,6 +83,18 @@ class EvaluatorsDsl {
 
     fun toolDescriptionReliability(block: ToolDescriptionReliabilityEvaluatorDsl.() -> Unit = {}) {
         evaluators += ToolDescriptionReliabilityEvaluatorDsl().apply(block).build()
+    }
+
+    fun toolTrajectory(block: ToolTrajectoryEvaluatorDsl.() -> Unit = {}) {
+        evaluators += ToolTrajectoryEvaluatorDsl().apply(block).build()
+    }
+
+    fun toolError(block: ToolErrorEvaluatorDsl.() -> Unit = {}) {
+        evaluators += ToolErrorEvaluatorDsl().apply(block).build()
+    }
+
+    fun toolEfficiency(block: ToolEfficiencyEvaluatorDsl.() -> Unit = {}) {
+        evaluators += ToolEfficiencyEvaluatorDsl().apply(block).build()
     }
 
     fun evaluator(evaluator: Evaluator) {
@@ -417,6 +434,72 @@ class ToolDescriptionReliabilityEvaluatorDsl {
             .maxInputArgs(maxInputArgs)
             .evaluationParams(evaluationParams)
         judge?.let { builder.judge(it) }
+        return builder.build()
+    }
+}
+
+@DokimosDsl
+class ToolTrajectoryEvaluatorDsl {
+    var name: String = "Trajectory"
+    var threshold: Double = 1.0
+    var toolCallsKey: String = "toolCalls"
+    var expectedToolCallsKey: String = "toolCalls"
+    var matchMode: ToolTrajectoryEvaluator.MatchMode = ToolTrajectoryEvaluator.MatchMode.IN_ORDER
+    var argumentMatcher: ArgumentMatcher? = null
+    private val toolArgumentMatchers: MutableMap<String, ArgumentMatcher> = mutableMapOf()
+
+    /** Overrides the argument matcher for a single tool by name. */
+    fun argumentMatcher(toolName: String, matcher: ArgumentMatcher) {
+        toolArgumentMatchers[toolName] = matcher
+    }
+
+    fun build(): ToolTrajectoryEvaluator {
+        val builder = ToolTrajectoryEvaluator.builder()
+            .name(name)
+            .threshold(threshold)
+            .toolCallsKey(toolCallsKey)
+            .expectedToolCallsKey(expectedToolCallsKey)
+            .matchMode(matchMode)
+        argumentMatcher?.let { builder.argumentMatcher(it) }
+        toolArgumentMatchers.forEach { (tool, matcher) -> builder.argumentMatcher(tool, matcher) }
+        return builder.build()
+    }
+}
+
+@DokimosDsl
+class ToolErrorEvaluatorDsl {
+    var name: String = "Tool Error"
+    var threshold: Double = 1.0
+    var toolCallsKey: String = "toolCalls"
+    var treatBlankAsError: Boolean = true
+    var detectJsonErrorField: Boolean = true
+    var errorDetector: ((String) -> Boolean)? = null
+
+    fun build(): ToolErrorEvaluator {
+        val builder = ToolErrorEvaluator.builder()
+            .name(name)
+            .threshold(threshold)
+            .toolCallsKey(toolCallsKey)
+            .treatBlankAsError(treatBlankAsError)
+            .detectJsonErrorField(detectJsonErrorField)
+        errorDetector?.let { detector -> builder.errorDetector(Predicate { detector(it) }) }
+        return builder.build()
+    }
+}
+
+@DokimosDsl
+class ToolEfficiencyEvaluatorDsl {
+    var name: String = "Tool Efficiency"
+    var threshold: Double = 1.0
+    var toolCallsKey: String = "toolCalls"
+    var argumentMatcher: ArgumentMatcher? = null
+
+    fun build(): ToolEfficiencyEvaluator {
+        val builder = ToolEfficiencyEvaluator.builder()
+            .name(name)
+            .threshold(threshold)
+            .toolCallsKey(toolCallsKey)
+        argumentMatcher?.let { builder.argumentMatcher(it) }
         return builder.build()
     }
 }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDslTest.kt
@@ -8,7 +8,10 @@ import dev.dokimos.core.JudgeLM
 import dev.dokimos.core.MatchingStrategy
 import dev.dokimos.core.agents.ToolCall
 import dev.dokimos.core.agents.ToolDefinition
+import dev.dokimos.core.evaluators.agents.ArgMatchMode
+import dev.dokimos.core.evaluators.agents.ArgumentMatcher
 import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator
+import dev.dokimos.core.evaluators.agents.ToolTrajectoryEvaluator
 import dev.dokimos.kotlin.core.EvalTestCase
 import dev.dokimos.kotlin.dsl.contextualRelevance
 import dev.dokimos.kotlin.dsl.evaluators
@@ -20,7 +23,10 @@ import dev.dokimos.kotlin.dsl.recall
 import dev.dokimos.kotlin.dsl.toolCallValidity
 import dev.dokimos.kotlin.dsl.toolCorrectness
 import dev.dokimos.kotlin.dsl.toolDescriptionReliability
+import dev.dokimos.kotlin.dsl.toolEfficiency
+import dev.dokimos.kotlin.dsl.toolError
 import dev.dokimos.kotlin.dsl.toolNameReliability
+import dev.dokimos.kotlin.dsl.toolTrajectory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -385,5 +391,65 @@ class EvaluatorDslTest {
 
         assertThat(result.score()).isGreaterThan(0.0)
         assertThat(result.success()).isTrue()
+    }
+
+    @Test
+    fun `toolTrajectory standalone DSL evaluates with match mode and per-tool matcher`() {
+        val evaluator = toolTrajectory {
+            matchMode = ToolTrajectoryEvaluator.MatchMode.ANY_ORDER
+            argumentMatcher = ArgumentMatcher.tolerant()
+            argumentMatcher("book", ArgumentMatcher.of(ArgMatchMode.SUBSET))
+        }
+
+        val testCase = EvalTestCase.builder()
+            .actualOutput("toolCalls", listOf(ToolCall.of("book", mapOf("id" to "X", "seat" to "A1"))))
+            .expectedOutput("toolCalls", listOf(ToolCall.of("book", mapOf("id" to "X"))))
+            .build()
+
+        val result = evaluator.evaluate(testCase)
+
+        assertThat(result.score()).isEqualTo(1.0)
+        assertThat(result.success()).isTrue()
+    }
+
+    @Test
+    fun `toolError standalone DSL detects failed results`() {
+        val evaluator = toolError {
+            errorDetector = { it.contains("HTTP 500") }
+        }
+
+        val testCase = EvalTestCase.builder()
+            .actualOutput(
+                "toolCalls",
+                listOf(
+                    ToolCall.builder().name("ok").result("done").build(),
+                    ToolCall.builder().name("bad").result("HTTP 500 internal").build(),
+                ),
+            )
+            .build()
+
+        val result = evaluator.evaluate(testCase)
+
+        assertThat(result.score()).isEqualTo(0.5)
+        assertThat(result.success()).isFalse()
+    }
+
+    @Test
+    fun `toolEfficiency standalone DSL flags redundant calls`() {
+        val evaluator = toolEfficiency { }
+
+        val testCase = EvalTestCase.builder()
+            .actualOutput(
+                "toolCalls",
+                listOf(
+                    ToolCall.of("search", mapOf("q" to "x")),
+                    ToolCall.of("search", mapOf("q" to "x")),
+                ),
+            )
+            .build()
+
+        val result = evaluator.evaluate(testCase)
+
+        assertThat(result.score()).isEqualTo(0.5)
     }
 }


### PR DESCRIPTION
Adds four deterministic agent evaluators on the existing AgentTrace and ToolCall model. None of them need an LLM, so they run in a unit test or CI gate with no API key.

ToolTrajectoryEvaluator scores an agent's tool-call sequence against an expected one. The match mode chooses how strict that is: strict order, in-order subsequence, any order, superset, subset, or a graded precision and recall. The unordered modes use a maximum bipartite matching, so repeated tool names are counted optimally rather than greedily. Argument comparison is pluggable per tool through ArgumentMatcher, and the default tolerant matcher treats numerically equal values like 1 and 1.0 as equal. String trimming and case-insensitivity are opt-in so existing results never shift silently.

ToolErrorEvaluator and ToolEfficiencyEvaluator read the tool results and the call list to score tool failures and redundant calls. This puts the previously unused result field on ToolCall to work.

ToolCorrectness in NAMES_AND_ARGS mode now uses the same tolerant matcher, so 1 versus 1.0 stops reporting a false mismatch while exact and string-case checks stay strict. AgentTrace.toTestCase wires the tools and tasks into the test case in one call, so the validity and completion evaluators no longer throw when those entries are left out. The duplicated tool-call coercion across the agent evaluators is consolidated into one place.

The Kotlin DSL gets toolTrajectory, toolError, and toolEfficiency builders alongside the existing agent ones, and the agent evaluation guide documents everything for both Java and Kotlin.

Scope is the core module, the Kotlin DSL, and docs. Framework trace extractors for Spring AI, Koog, and LangChain4j follow in a separate PR.