### PR TITLE
Fix RecallEvaluator returning scores above 1.0 on duplicate retrieved items

### DIFF
--- a/dokimos-core/src/main/java/dev/dokimos/core/MatchingStrategy.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/MatchingStrategy.java
@@ -26,18 +26,36 @@ public interface MatchingStrategy {
     boolean matches(Object retrieved, Object expected);
 
     /**
-     * Counts how many retrieved items match any expected item.
+     * Counts how many distinct retrieved items match any expected item.
      * <p>
      * Default implementation iterates through all pairs. Implementations may
      * override for better performance with specific data structures.
      *
      * @param retrieved the retrieved items
      * @param expected  the expected (ground truth) items
-     * @return the number of retrieved items that match at least one expected item
+     * @return the number of distinct retrieved items that match at least one expected item
      */
     default long countMatches(Collection<?> retrieved, Collection<?> expected) {
         return retrieved.stream()
+                .distinct()
                 .filter(r -> expected.stream().anyMatch(e -> matches(r, e)))
+                .count();
+    }
+
+    /**
+     * Counts how many distinct expected items are covered by any retrieved item.
+     * <p>
+     * Default implementation iterates through all pairs. Implementations may
+     * override for better performance with specific data structures.
+     *
+     * @param retrieved the retrieved items
+     * @param expected  the expected (ground truth) items
+     * @return the number of distinct expected items covered by at least one retrieved item
+     */
+    default long countCovered(Collection<?> retrieved, Collection<?> expected) {
+        return expected.stream()
+                .distinct()
+                .filter(e -> retrieved.stream().anyMatch(r -> matches(r, e)))
                 .count();
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/PrecisionEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/PrecisionEvaluator.java
@@ -88,10 +88,12 @@ public class PrecisionEvaluator extends BaseEvaluator {
                     .build();
         }
 
+        // Set-based precision: distinct relevant retrieved items, over distinct retrieved items.
+        int retrievedCount = (int) retrieved.stream().distinct().count();
         long truePositives = matchingStrategy.countMatches(retrieved, expected);
-        double precision = (double) truePositives / retrieved.size();
+        double precision = Math.max(0.0, Math.min(1.0, (double) truePositives / retrievedCount));
 
-        String reason = generateReason(truePositives, retrieved.size(), precision);
+        String reason = generateReason(truePositives, retrievedCount, precision);
 
         return EvalResult.builder()
                 .name(name)
@@ -99,7 +101,7 @@ public class PrecisionEvaluator extends BaseEvaluator {
                 .threshold(threshold)
                 .reason(reason)
                 .metadata(Map.of(
-                        "retrieved", retrieved.size(),
+                        "retrieved", retrievedCount,
                         "relevant", expected.size(),
                         "truePositives", truePositives))
                 .build();

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/RecallEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/RecallEvaluator.java
@@ -87,10 +87,12 @@ public class RecallEvaluator extends BaseEvaluator {
                     .build();
         }
 
-        long truePositives = matchingStrategy.countMatches(retrieved, expected);
-        double recall = (double) truePositives / expected.size();
+        // Set-based recall: distinct relevant items covered, over distinct relevant items.
+        int relevant = (int) expected.stream().distinct().count();
+        long truePositives = matchingStrategy.countCovered(retrieved, expected);
+        double recall = Math.max(0.0, Math.min(1.0, (double) truePositives / relevant));
 
-        String reason = generateReason(truePositives, expected.size(), recall);
+        String reason = generateReason(truePositives, relevant, recall);
 
         return EvalResult.builder()
                 .name(name)
@@ -99,7 +101,7 @@ public class RecallEvaluator extends BaseEvaluator {
                 .reason(reason)
                 .metadata(Map.of(
                         "retrieved", retrieved.size(),
-                        "relevant", expected.size(),
+                        "relevant", relevant,
                         "truePositives", truePositives))
                 .build();
     }

--- a/dokimos-core/src/test/java/dev/dokimos/core/MatchingStrategyTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/MatchingStrategyTest.java
@@ -142,6 +142,46 @@ class MatchingStrategyTest {
     }
 
     @Test
+    void countMatchesShouldDeduplicateRetrieved() {
+        var strategy = MatchingStrategy.byEquality();
+
+        // "a" appears twice but must only be counted once.
+        long matches = strategy.countMatches(List.of("a", "a", "b"), List.of("a"));
+
+        assertThat(matches).isEqualTo(1);
+    }
+
+    @Test
+    void countCoveredShouldCountDistinctExpectedItems() {
+        var strategy = MatchingStrategy.byEquality();
+
+        var retrieved = List.of("a", "a", "b");
+        var expected = List.of("a", "c");
+
+        // Only "a" is covered; duplicate retrieved "a" does not double-count.
+        assertThat(strategy.countCovered(retrieved, expected)).isEqualTo(1);
+    }
+
+    @Test
+    void countCoveredShouldNeverExceedDistinctExpectedSize() {
+        var strategy = MatchingStrategy.byEquality();
+
+        var retrieved = List.of("a", "a", "a", "a", "b");
+        var expected = List.of("a");
+
+        assertThat(strategy.countCovered(retrieved, expected)).isEqualTo(1);
+    }
+
+    @Test
+    void countCoveredShouldHandleEmptyCollections() {
+        var strategy = MatchingStrategy.byEquality();
+
+        assertThat(strategy.countCovered(List.of(), List.of("a", "b"))).isEqualTo(0);
+        assertThat(strategy.countCovered(List.of("a", "b"), List.of())).isEqualTo(0);
+        assertThat(strategy.countCovered(List.of(), List.of())).isEqualTo(0);
+    }
+
+    @Test
     void countMatchesShouldHandleEmptyCollections() {
         var strategy = MatchingStrategy.byEquality();
 

--- a/dokimos-core/src/test/java/dev/dokimos/core/PrecisionEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/PrecisionEvaluatorTest.java
@@ -234,6 +234,46 @@ class PrecisionEvaluatorTest {
     }
 
     @Test
+    void shouldDeduplicateRetrievedForDocumentLevelPrecision() {
+        var evaluator = PrecisionEvaluator.builder()
+                .retrievedKey("retrieved")
+                .expectedKey("relevant")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("retrieved", List.of("a", "a", "c")) // "a" retrieved twice
+                .expectedOutput("relevant", List.of("a"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Distinct retrieved set is {a, c}; "a" is relevant -> 1/2, not 2/3.
+        assertThat(result.score()).isCloseTo(0.5, within(0.001));
+        assertThat(result.score()).isBetween(0.0, 1.0);
+        assertThat(result.metadata().get("retrieved")).isEqualTo(2);
+        assertThat(result.metadata().get("truePositives")).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldStayInRangeWhenAllRetrievedAreDuplicateRelevant() {
+        var evaluator = PrecisionEvaluator.builder()
+                .retrievedKey("retrieved")
+                .expectedKey("relevant")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("retrieved", List.of("a", "a", "a"))
+                .expectedOutput("relevant", List.of("a"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
     void shouldRespectCustomThreshold() {
         var evaluator = PrecisionEvaluator.builder()
                 .retrievedKey("retrieved")

--- a/dokimos-core/src/test/java/dev/dokimos/core/RecallEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/RecallEvaluatorTest.java
@@ -232,6 +232,90 @@ class RecallEvaluatorTest {
     }
 
     @Test
+    void shouldNotExceedOneWhenRetrievedContainsDuplicates() {
+        var evaluator = RecallEvaluator.builder()
+                .name("r")
+                .retrievedKey("retrieved")
+                .expectedKey("relevant")
+                .matchingStrategy(MatchingStrategy.caseInsensitive())
+                .threshold(1.0)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("retrieved", List.of("a", "a", "b")) // "a" retrieved twice
+                .expectedOutput("relevant", List.of("a"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // The single relevant item "a" was found: recall must be exactly 1.0, not 2.0.
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.score()).isBetween(0.0, 1.0);
+        assertThat(result.metadata().get("truePositives")).isEqualTo(1L);
+        assertThat(result.metadata().get("relevant")).isEqualTo(1);
+    }
+
+    @Test
+    void shouldStayInRangeRegardlessOfDuplicateCount() {
+        var evaluator = RecallEvaluator.builder()
+                .retrievedKey("retrieved")
+                .expectedKey("relevant")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("retrieved", List.of("a", "a", "a", "a", "b"))
+                .expectedOutput("relevant", List.of("a"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Four duplicate matches previously produced recall = 4.0.
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.score()).isLessThanOrEqualTo(1.0);
+    }
+
+    @Test
+    void shouldComputeDistinctRecallWithDuplicatesAndAMiss() {
+        var evaluator = RecallEvaluator.builder()
+                .retrievedKey("retrieved")
+                .expectedKey("relevant")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("retrieved", List.of("a", "a", "b")) // covers "a" only
+                .expectedOutput("relevant", List.of("a", "c")) // "c" is missed
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // 1 of 2 distinct relevant items covered.
+        assertThat(result.score()).isCloseTo(0.5, within(0.001));
+    }
+
+    @Test
+    void shouldDeduplicateRelevantItemsInDenominator() {
+        var evaluator = RecallEvaluator.builder()
+                .retrievedKey("retrieved")
+                .expectedKey("relevant")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("retrieved", List.of("a"))
+                .expectedOutput("relevant", List.of("a", "a", "b")) // duplicate relevant "a"
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Distinct relevant set is {a, b}; "a" is found -> 1/2.
+        assertThat(result.score()).isCloseTo(0.5, within(0.001));
+        assertThat(result.metadata().get("relevant")).isEqualTo(2);
+    }
+
+    @Test
     void shouldRespectCustomThreshold() {
         var evaluator = RecallEvaluator.builder()
                 .retrievedKey("retrieved")


### PR DESCRIPTION
RecallEvaluator divided the count of every matching retrieved element by the number of relevant items, so duplicate retrieved documents inflated recall above 1.0 (`["a","a","b"]` against `["a"]` scored 2.0). PrecisionEvaluator shared the root cause through MatchingStrategy.countMatches: it stayed in range but counted a repeated relevant document as several true positives.

Both metrics are now set-based, which is the correct document-level semantics for retrieval. A new MatchingStrategy.countCovered counts distinct expected items covered by at least one retrieved item (recall's numerator), countMatches dedupes the retrieved side (precision's), and both scores are clamped to [0, 1] as a safety net.

Adds duplicate-handling tests across RecallEvaluatorTest, PrecisionEvaluatorTest, and MatchingStrategyTest. Existing tests use distinct inputs and are unchanged; the whole dokimos-core suite passes (542 tests). Fixes #110.