### PR TITLE
Fix verified bugs and add API improvements across modules

### DIFF
--- a/docs/docs/evaluation/agent-evaluation.md
+++ b/docs/docs/evaluation/agent-evaluation.md
@@ -159,7 +159,7 @@ val trajectory = toolTrajectory {
   </TabItem>
 </Tabs>
 
-By default only tool names and order are compared. Supply an [argument matcher](#argument-matching) to also assert arguments, optionally overriding it per tool:
+By default arguments are compared with a tolerant matcher, so numerically equal values like `1` and `1.0` match. To compare tool names and order only, pass `ArgumentMatcher.of(ArgMatchMode.IGNORE)`. You can also override the matcher per tool:
 
 <Tabs groupId="lang" defaultValue="java">
   <TabItem value="java" label="Java">

--- a/docs/docs/evaluation/datasets.md
+++ b/docs/docs/evaluation/datasets.md
@@ -274,12 +274,15 @@ val datasetFromString = Dataset.fromJsonl(jsonl, "greetings")
 
 CSV files work well for simpler datasets. You need at least an `input` column, and optionally an `expectedOutput` column (you can also use `expected_output` or `output` as the column name). Any additional columns are automatically treated as metadata.
 
+Parsing follows RFC 4180. A quoted field may contain the delimiter (`,`), embedded newlines, and doubled quotes (`""` becomes a single literal `"`). Whitespace inside quoted fields is preserved, while unquoted fields are trimmed. A leading UTF-8 byte order mark is stripped.
+
 #### Example CSV
 
 ```csv
 input,expectedOutput,category,priority
 How do I reset my password?,Click 'Forgot Password' on the login page,account,high
-Where can I find my order history?,Go to Account > Orders,account,medium
+What payment methods do you accept?,"We accept credit cards, PayPal, and bank transfers",payment,medium
+How do I quote a price?,"Wrap it in double quotes like ""this""",support,low
 How do I contact support?,Email us at support@example.com or use live chat,support,high
 ```
 
@@ -319,6 +322,35 @@ val datasetFromString = Dataset.fromCsv(csv, "payment-support")
 
   </TabItem>
 </Tabs>
+
+### One-call loading
+
+When you don't want to pick a format-specific method, `Dataset.load()` is a single entry point. It dispatches on `classpath:` and `file:` schemes and on the file extension for plain paths, then delegates to the resolver registry.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+// Resolves by extension and scheme
+Dataset fromJson = Dataset.load("path/to/dataset.json");
+Dataset fromCsv = Dataset.load("file:path/to/dataset.csv");
+Dataset fromClasspath = Dataset.load("classpath:datasets/qa-dataset.jsonl");
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+// Resolves by extension and scheme
+val fromJson = Dataset.load("path/to/dataset.json")
+val fromCsv = Dataset.load("file:path/to/dataset.csv")
+val fromClasspath = Dataset.load("classpath:datasets/qa-dataset.jsonl")
+```
+
+  </TabItem>
+</Tabs>
+
+Unlike `fromJson`, `fromCsv`, and `fromJsonl`, `Dataset.load()` does not throw a checked `IOException`. It throws `DatasetResolutionException` if no resolver supports the argument.
 
 ## Dataset Resolution
 

--- a/docs/docs/evaluation/evaluators.md
+++ b/docs/docs/evaluation/evaluators.md
@@ -192,7 +192,39 @@ val helpfulness: Evaluator = llmJudge(judge) {
   </TabItem>
 </Tabs>
 
-The evaluator sends your criteria along with the test case to the judge model, which returns a score between 0 and 1.
+The evaluator sends your criteria along with the test case to the judge model, which returns a score between 0 and 1. The reply is parsed leniently: a one-sentence preamble or trailing prose around the JSON is dropped, so a recoverable judgment is not lost to a formatting quirk.
+
+By default the judge scores on a 0..1 scale. To let the judge work on a different range, set `scoreRange(min, max)`. The reported score is then normalized back to 0..1, so your `threshold` always stays on the 0..1 scale:
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+Evaluator helpfulness = LLMJudgeEvaluator.builder()
+    .name("Helpfulness")
+    .criteria("Rate the answer's helpfulness.")
+    .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
+    .scoreRange(1, 5)  // judge replies 1..5; score is normalized to 0..1
+    .threshold(0.8)
+    .judge(judge)
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val helpfulness: Evaluator = llmJudge(judge) {
+    name = "Helpfulness"
+    criteria = "Rate the answer's helpfulness."
+    params(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT)
+    scoreRange(1.0, 5.0)  // judge replies 1..5; score is normalized to 0..1
+    threshold = 0.8
+}
+```
+
+  </TabItem>
+</Tabs>
 
 **When to use:** Checking semantic correctness, helpfulness, tone, clarity, or any quality dimension that's easier to describe in words than code.
 

--- a/docs/docs/evaluation/experiments.md
+++ b/docs/docs/evaluation/experiments.md
@@ -267,6 +267,46 @@ val ragTask = task { example ->
   </TabItem>
 </Tabs>
 
+### Capturing Call Metrics
+
+A plain `Task` returns only outputs, and the resulting `ItemResult` carries `null` metrics. To record tokens, cost, and latency for the underlying LLM call, use a `MeasuredTask`. It returns a `TaskResult` holding both the outputs and a `CallMetrics` record, which flows through to each `ItemResult.metrics()`.
+
+```java
+@FunctionalInterface
+public interface MeasuredTask {
+    TaskResult run(Example example);
+}
+```
+
+`CallMetrics` is a record with four nullable fields: `tokensIn`, `tokensOut`, `costUsd`, and `latencyMs`. Populate the ones you can measure and leave the rest null.
+
+```java
+MeasuredTask task = example -> {
+    long start = System.currentTimeMillis();
+    LlmResponse response = myLlmService.generate(example.input());
+    long latencyMs = System.currentTimeMillis() - start;
+
+    CallMetrics metrics = new CallMetrics(
+        response.promptTokens(),
+        response.completionTokens(),
+        response.costUsd(),
+        latencyMs
+    );
+
+    return new TaskResult(Map.of("output", response.text()), metrics);
+};
+
+ExperimentResult result = Experiment.builder()
+    .name("QA Evaluation")
+    .dataset(dataset)
+    .measuredTask(task)
+    .evaluators(evaluators)
+    .build()
+    .run();
+```
+
+The plain `task(Task)` path still works unchanged; reach for `measuredTask(MeasuredTask)` only when you want metrics attached to the results. Naming the builder method distinctly keeps a lambda passed to `task(...)` unambiguous between the two interfaces.
+
 ## Running Experiments on a Dataset
 
 ### Loading Datasets from Files
@@ -401,6 +441,10 @@ failures.forEach { failure ->
 
   </TabItem>
 </Tabs>
+
+### Per-Item Failure Isolation
+
+A task or evaluator that throws for one example does not abort the whole run. That example is recorded as a failed item (its `success()` is `false`, with no eval results) and execution continues with the next example. Sequential and parallel runs behave the same way, so a single flaky call or malformed output won't cost you the rest of the dataset. Filter for `!item.success()` as shown above to inspect the items that failed.
 
 ## Parallelism and Multiple Runs
 
@@ -592,6 +636,24 @@ experiment {
 
   </TabItem>
 </Tabs>
+
+`build()` validates the experiment before constructing it. It throws `IllegalStateException` if no dataset or task is set, if the dataset has no examples, or if no evaluators were added. This surfaces configuration mistakes up front rather than at run time.
+
+### Closing the Reporter
+
+When you attach a `Reporter` with `.reporter(...)`, you own its lifecycle by default. Set `.autoCloseReporter(true)` to have `run()` close the reporter once all runs finish, in addition to flushing it. The default is `false`, which leaves the reporter open for reuse across experiments.
+
+```java
+Experiment.builder()
+    .name("QA Evaluation")
+    .dataset(dataset)
+    .task(task)
+    .evaluators(evaluators)
+    .reporter(reporter)
+    .autoCloseReporter(true)  // run() closes the reporter when done
+    .build()
+    .run();
+```
 
 ### Tracking Experiment Configuration
 

--- a/docs/docs/integrations/junit.md
+++ b/docs/docs/integrations/junit.md
@@ -366,6 +366,61 @@ fun shouldAnswerQuestions(example: Example) {
   </TabItem>
 </Tabs>
 
+### Reporting Real Outputs
+
+When a test class declares a static `@DatasetReporter` field, `@DatasetSource` opens a run and reports each invocation as an item result. By default that item is empty. Declare a `DatasetItemRecorder` parameter on the test method and populate it so the reported item carries the actual outputs and eval results the test produced.
+
+```java
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.Reporter;
+import dev.dokimos.junit.DatasetItemRecorder;
+import dev.dokimos.junit.DatasetReporter;
+import dev.dokimos.junit.DatasetSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class SupportEvaluationTest {
+
+    @DatasetReporter
+    static final Reporter reporter = new DokimosServerReporter(serverConfig);
+
+    @ParameterizedTest
+    @DatasetSource("classpath:datasets/support-qa.json")
+    void shouldAnswerSupportQuestions(Example example, DatasetItemRecorder recorder) {
+        String answer = supportBot.generate(example.input());
+        EvalTestCase testCase = example.toTestCase(answer);
+
+        recorder.actualOutput("output", answer);
+        for (Evaluator evaluator : evaluators) {
+            EvalResult result = evaluator.evaluate(testCase);
+            recorder.evalResult(result);
+        }
+
+        Assertions.assertEval(testCase, evaluators);
+    }
+}
+```
+
+A fresh recorder is supplied per invocation, so you never reset it between examples. The recorder methods are chainable: `actualOutput(String key, Object value)`, `actualOutputs(Map<String, Object> outputs)`, `evalResult(EvalResult result)`, and `evalResults(List<EvalResult> results)`.
+
+### Run Metadata
+
+When a `@DatasetReporter` field is present, `@DatasetSource` forwards metadata to the reporter. Use `entries` for type-safe key-value pairs:
+
+```java
+@ParameterizedTest
+@DatasetSource(
+    value = "classpath:datasets/support-qa.json",
+    entries = {
+        @MetadataEntry(key = "model", value = "gpt-4"),
+        @MetadataEntry(key = "temperature", value = "0")
+    })
+void shouldAnswerSupportQuestions(Example example) {
+    // ...
+}
+```
+
+The alternating-string `metadata = {"model", "gpt-4", "temperature", "0"}` form also works. When both are set, `entries` takes precedence.
+
 ## CI/CD Integration
 
 ### Maven

--- a/docs/docs/integrations/langchain4j.md
+++ b/docs/docs/integrations/langchain4j.md
@@ -88,6 +88,27 @@ val result = experiment {
   </TabItem>
 </Tabs>
 
+`simpleTask(model)` writes the response under the default `"output"` key. To use a different key, pass it as the second argument:
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+// Writes the response under "answer" instead of "output"
+Task task = LangChain4jSupport.simpleTask(model, "answer");
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+// Writes the response under "answer" instead of "output"
+val task = LangChain4jSupport.simpleTask(model, "answer")
+```
+
+  </TabItem>
+</Tabs>
+
 ### Using ChatModel as LLM Judge
 
 Convert a `ChatModel` to a `JudgeLM` for evaluation:

--- a/docs/docs/server/client.md
+++ b/docs/docs/server/client.md
@@ -55,6 +55,8 @@ ExperimentResult result = Experiment.builder()
 |--------|-------------|---------|
 | `apiKey(String)` | API key for authentication | _(none)_ |
 | `apiVersion(String)` | API version to use | `v1` |
+| `onItemDeliveryFailure(Consumer<ItemDeliveryFailure>)` | Callback for batches permanently dropped after retries | _(none)_ |
+| `spoolDirectory(Path)` | Append permanently-failed batches to disk for later replay | _(off)_ |
 
 ### Example with All Options
 
@@ -109,6 +111,16 @@ Items are sent in batches to reduce HTTP overhead:
 
 Whichever threshold is reached first triggers a batch send.
 
+### Retries
+
+Failed sends are retried up to 3 times with exponential backoff (starting at 100ms). Each batch POST carries an `Idempotency-Key` reused across retries, so a successful retry of an already-recorded request deduplicates server-side.
+
+Retried status codes:
+
+- **`429 Too Many Requests`**: treated as transient and retried. When the response includes a `Retry-After` header (delay in seconds), that delay overrides the backoff for the next attempt.
+- **`5x`**: retried with backoff.
+- **Other `4xx`**: terminal. The batch is not retried.
+
 ## Error Handling
 
 ### Server Unavailable at Start
@@ -128,6 +140,50 @@ If API key authentication fails:
 
 - Server returns `401 Unauthorized`
 - Client logs warning: `Client error 401 for POST ...`
+
+### Permanently Dropped Items
+
+If a batch still fails after exhausting all retries, those items are dropped and never recorded. By default this only produces an error log, which can leave CI green while data is silently lost. Two opt-in mechanisms make dropped batches detectable.
+
+#### getFailedItemCount()
+
+`getFailedItemCount()` returns the total number of items dropped after retries. Check it after the run and fail the build if any items were lost:
+
+```java
+reporter.close();  // flushes and drains all pending batches
+
+if (reporter.getFailedItemCount() > 0) {
+    throw new IllegalStateException(
+        reporter.getFailedItemCount() + " items were not recorded by the server");
+}
+```
+
+#### onItemDeliveryFailure callback
+
+Register a callback to react to each dropped batch as it happens. It receives an `ItemDeliveryFailure` record carrying `runId()`, `itemCount()`, and the dropped `items()`:
+
+```java
+DokimosServerReporter reporter = DokimosServerReporter.builder()
+    .serverUrl("https://dokimos.example.com")
+    .projectName("my-project")
+    .onItemDeliveryFailure(failure ->
+        log.error("Dropped {} items for run {}", failure.itemCount(), failure.runId()))
+    .build();
+```
+
+The callback runs on the reporter's background worker thread, so keep it lightweight.
+
+#### Durable spooling
+
+Set `spoolDirectory(Path)` to persist permanently-failed batches to disk instead of losing them. Each dropped batch is appended as one JSON line to `failed-items.ndjson` in the directory, so a transient outage past all retries leaves a replayable record. Spooling is off by default.
+
+```java
+DokimosServerReporter reporter = DokimosServerReporter.builder()
+    .serverUrl("https://dokimos.example.com")
+    .projectName("my-project")
+    .spoolDirectory(Path.of("target/dokimos-spool"))
+    .build();
+```
 
 ## Lifecycle Methods
 

--- a/docs/src/components/ReleaseTimeline/index.tsx
+++ b/docs/src/components/ReleaseTimeline/index.tsx
@@ -6,9 +6,151 @@ type Release = { version: string; date: string; latest?: boolean; lead?: string;
 
 const RELEASES: Release[] = [
   {
+    version: "0.19.0",
+    date: "June 2, 2026",
+    latest: true,
+    lead: "Hardens the core: per-item failure isolation, RFC 4180 CSV, prose-tolerant judges, retry and observability for the server reporter, and a run of correctness fixes.",
+    groups: [
+      {
+        label: "Added",
+        items: [
+          {
+            title: "Dataset.load",
+            body: (
+              <>
+                <code>Dataset.load(uriOrPath)</code> resolves a dataset from a local path or a URI
+                through the same resolver registry the SDK uses, so a plain path and a{" "}
+                <code>dataset://name@version</code> URI load the same way.
+              </>
+            ),
+          },
+          {
+            title: "Measured tasks",
+            body: (
+              <>
+                <code>Experiment.builder().measuredTask(...)</code> takes a <code>MeasuredTask</code>{" "}
+                that returns outputs plus optional <code>CallMetrics</code>, carried through to each{" "}
+                <code>ItemResult</code> so cost, tokens, and latency land next to the score.
+              </>
+            ),
+          },
+          {
+            title: "Server reporter failure visibility",
+            body: (
+              <>
+                <code>DokimosServerReporter</code> exposes <code>getFailedItemCount()</code> and an{" "}
+                <code>onItemDeliveryFailure(...)</code> callback, plus an opt-in{" "}
+                <code>spoolDirectory(...)</code> that appends permanently undelivered batches to a
+                durable file.
+              </>
+            ),
+          },
+          {
+            title: "JUnit recorder and typed metadata",
+            body: (
+              <>
+                A test method can take a <code>DatasetItemRecorder</code> parameter to record actual
+                outputs and eval results per invocation, and <code>@MetadataEntry(key, value)</code>{" "}
+                replaces the alternating-string metadata form with a typed pair.
+              </>
+            ),
+          },
+          {
+            title: "Kotlin and LangChain4j helpers",
+            body: (
+              <>
+                Kotlin adds an <code>evalCase(input, actualOutput, expectedOutput)</code> factory and
+                a <code>metadata(Map)</code> DSL form; LangChain4j adds{" "}
+                <code>simpleTask(model, outputKey)</code> to name the output key, and{" "}
+                <code>AgentEvalCase.builder()</code> gives agent test cases a typed builder.
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        label: "Changed",
+        items: [
+          {
+            title: "Per-item failure isolation",
+            body: "An experiment isolates a failing example so one bad item records its error and the run continues instead of aborting.",
+          },
+          {
+            title: "RFC 4180 CSV",
+            body: "Dataset CSV loading parses quoted fields per RFC 4180, so a value may contain the delimiter, a newline, or a doubled quote.",
+          },
+          {
+            title: "Prose-tolerant judges",
+            body: (
+              <>
+                LLM judge replies are parsed by extracting the JSON, so a judge may wrap its verdict
+                in preamble or trailing prose, and <code>LLMJudgeEvaluator</code> normalizes a custom{" "}
+                <code>scoreRange</code> onto 0..1.
+              </>
+            ),
+          },
+          {
+            title: "Trajectory compares arguments",
+            body: (
+              <>
+                <code>ToolTrajectoryEvaluator</code> now defaults to a tolerant argument matcher;
+                pass <code>ArgumentMatcher.of(ArgMatchMode.IGNORE)</code> to compare tool names and
+                order only.
+              </>
+            ),
+          },
+          {
+            title: "Reporter retries and stricter builder",
+            body: (
+              <>
+                The server reporter retries an HTTP 429 with its <code>Retry-After</code> hint, and{" "}
+                <code>Experiment.builder()</code> rejects an empty dataset or zero evaluators.
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        label: "Fixed",
+        items: [
+          {
+            title: "Spring AI score",
+            body: (
+              <>
+                <code>EvaluationResponse.getScore()</code> returns the real evaluation score instead
+                of leaving the field unset.
+              </>
+            ),
+          },
+          {
+            title: "Null responses",
+            body: (
+              <>
+                LangChain4j <code>simpleTask</code> no longer throws on a null model response, and{" "}
+                <code>HallucinationEvaluator</code> reports a missing verdict instead of a raw
+                NullPointerException.
+              </>
+            ),
+          },
+          {
+            title: "Tool-call validity numerics",
+            body: "Tool-call validity accepts whole-number doubles for integer parameters and matches numeric enums by value.",
+          },
+          {
+            title: "MCP store and client",
+            body: "The MCP result store writes atomically, and the per-call OpenAI client is closed after each run.",
+          },
+          {
+            title: "JUnit reported example",
+            body: "The example reported by the JUnit extension is tied to the actual invocation.",
+          },
+        ],
+      },
+    ],
+  },
+  {
     version: "0.17.0",
     date: "May 31, 2026",
-    latest: true,
     lead: "Closes the production evaluation loop end to end, with full multi-tenant data isolation and standards-based OTLP trace ingestion.",
     groups: [
       {

--- a/dokimos-core/src/main/java/dev/dokimos/core/Dataset.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Dataset.java
@@ -32,6 +32,20 @@ public record Dataset(String name, String description, List<Example> examples) i
     }
 
     /**
+     * Loads a dataset from a URI or path through the resolver registry.
+     * <p>
+     * A single entry point that dispatches {@code classpath:} URIs, {@code file:} URIs,
+     * and plain filesystem paths (resolved by file extension) to the appropriate resolver.
+     *
+     * @param uriOrPath the dataset URI or filesystem path
+     * @return the resolved dataset
+     * @throws DatasetResolutionException if no resolver supports the URI
+     */
+    public static Dataset load(String uriOrPath) {
+        return DatasetResolverRegistry.getInstance().resolve(uriOrPath);
+    }
+
+    /**
      * Loads a dataset from a JSON file.
      *
      * @param path the file path

--- a/dokimos-core/src/main/java/dev/dokimos/core/DatasetParser.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/DatasetParser.java
@@ -12,15 +12,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 public final class DatasetParser {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final char BOM = '﻿';
 
     private DatasetParser() {}
 
     public static Dataset parseJson(String json) {
+        json = stripBom(json);
         try {
             Map<String, Object> root = MAPPER.readValue(json, new TypeReference<>() {});
 
@@ -87,7 +88,7 @@ public final class DatasetParser {
      * @return the parsed dataset
      */
     public static Dataset parseJsonl(String jsonl, String name) {
-        try (BufferedReader reader = new BufferedReader(new StringReader(jsonl))) {
+        try (BufferedReader reader = new BufferedReader(new StringReader(stripBom(jsonl)))) {
             return parseJsonl(reader, name);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to parse JSONL dataset", e);
@@ -101,6 +102,9 @@ public final class DatasetParser {
 
         while ((line = reader.readLine()) != null) {
             lineNumber++;
+            if (lineNumber == 1) {
+                line = stripBom(line);
+            }
             if (line.isBlank()) continue;
 
             try {
@@ -124,52 +128,51 @@ public final class DatasetParser {
     }
 
     public static Dataset parseCsv(String csv, String name, char delimiter) {
-        try (BufferedReader reader = new BufferedReader(new StringReader(csv))) {
-            String headerLine = reader.readLine();
-            if (headerLine == null) {
-                throw new IllegalArgumentException("The provided CSV is empty");
-            }
-
-            String[] headers = headerLine.split(Pattern.quote(String.valueOf(delimiter)));
-            int inputIdx = findColumnIndex(headers, "input");
-            int outputIdx = findColumnIndex(headers, "expectedOutput", "expected_output", "output");
-
-            if (inputIdx == -1) {
-                throw new IllegalArgumentException("CSV must have an 'input' column");
-            }
-
-            List<Example> examples = new ArrayList<>();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                if (line.isBlank()) continue;
-
-                String[] values = parseCsvLine(line, delimiter);
-
-                Map<String, Object> inputs = new HashMap<>();
-                Map<String, Object> expectedOutputs = new HashMap<>();
-                Map<String, Object> metadata = new HashMap<>();
-
-                for (int i = 0; i < headers.length && i < values.length; i++) {
-                    String header = headers[i].trim();
-                    String value = values[i].trim();
-
-                    if (i == inputIdx) {
-                        inputs.put("input", value);
-                    } else if (i == outputIdx) {
-                        expectedOutputs.put("output", value);
-                    } else {
-                        metadata.put(header, value);
-                    }
-                }
-
-                examples.add(new Example(inputs, expectedOutputs, metadata));
-            }
-
-            return Dataset.builder().name(name).addExamples(examples).build();
-
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to parse CSV dataset", e);
+        List<List<String>> rows = parseCsvRecords(stripBom(csv), delimiter);
+        if (rows.isEmpty()) {
+            throw new IllegalArgumentException("The provided CSV is empty");
         }
+
+        List<String> headerRow = rows.get(0);
+        String[] headers = headerRow.toArray(new String[0]);
+        // Headers are unquoted identifiers, so trim them for matching.
+        for (int i = 0; i < headers.length; i++) {
+            headers[i] = headers[i].trim();
+        }
+
+        int inputIdx = findColumnIndex(headers, "input");
+        int outputIdx = findColumnIndex(headers, "expectedOutput", "expected_output", "output");
+
+        if (inputIdx == -1) {
+            throw new IllegalArgumentException(
+                    "CSV must have an 'input' column. Found columns: " + String.join(", ", headers));
+        }
+
+        List<Example> examples = new ArrayList<>();
+        for (int r = 1; r < rows.size(); r++) {
+            List<String> values = rows.get(r);
+
+            Map<String, Object> inputs = new HashMap<>();
+            Map<String, Object> expectedOutputs = new HashMap<>();
+            Map<String, Object> metadata = new HashMap<>();
+
+            for (int i = 0; i < headers.length && i < values.size(); i++) {
+                String header = headers[i];
+                String value = values.get(i);
+
+                if (i == inputIdx) {
+                    inputs.put("input", value);
+                } else if (i == outputIdx) {
+                    expectedOutputs.put("output", value);
+                } else {
+                    metadata.put(header, value);
+                }
+            }
+
+            examples.add(new Example(inputs, expectedOutputs, metadata));
+        }
+
+        return Dataset.builder().name(name).addExamples(examples).build();
     }
 
     private static int findColumnIndex(String[] headers, String... candidates) {
@@ -184,23 +187,83 @@ public final class DatasetParser {
         return -1;
     }
 
-    private static String[] parseCsvLine(String line, char delimiter) {
-        List<String> values = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
+    /**
+     * Parses CSV text into rows of fields using a single stateful scanner over the
+     * entire text (RFC 4180). A quoted field may contain the delimiter, a newline,
+     * and doubled quotes (two double-quote chars collapse to one literal quote).
+     * Whitespace inside quoted fields is preserved; unquoted fields are trimmed.
+     */
+    private static List<List<String>> parseCsvRecords(String csv, char delimiter) {
+        List<List<String>> rows = new ArrayList<>();
+        List<String> current = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
         boolean inQuotes = false;
+        boolean quotedField = false;
+        boolean rowHasContent = false;
 
-        for (char c : line.toCharArray()) {
+        int len = csv.length();
+        for (int i = 0; i < len; i++) {
+            char c = csv.charAt(i);
+
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < len && csv.charAt(i + 1) == '"') {
+                        field.append('"');
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    field.append(c);
+                }
+                continue;
+            }
+
             if (c == '"') {
-                inQuotes = !inQuotes;
-            } else if (c == delimiter && !inQuotes) {
-                values.add(current.toString());
-                current = new StringBuilder();
+                inQuotes = true;
+                quotedField = true;
+                rowHasContent = true;
+            } else if (c == delimiter) {
+                current.add(finishField(field, quotedField));
+                field.setLength(0);
+                quotedField = false;
+                rowHasContent = true;
+            } else if (c == '\n' || c == '\r') {
+                // Swallow a CRLF pair as a single line terminator.
+                if (c == '\r' && i + 1 < len && csv.charAt(i + 1) == '\n') {
+                    i++;
+                }
+                if (rowHasContent || !current.isEmpty() || field.length() > 0) {
+                    current.add(finishField(field, quotedField));
+                    rows.add(current);
+                    current = new ArrayList<>();
+                    field.setLength(0);
+                    quotedField = false;
+                    rowHasContent = false;
+                }
             } else {
-                current.append(c);
+                field.append(c);
+                rowHasContent = true;
             }
         }
-        values.add(current.toString());
 
-        return values.toArray(new String[0]);
+        if (rowHasContent || !current.isEmpty() || field.length() > 0) {
+            current.add(finishField(field, quotedField));
+            rows.add(current);
+        }
+
+        return rows;
+    }
+
+    private static String finishField(StringBuilder field, boolean quoted) {
+        String value = field.toString();
+        return quoted ? value : value.trim();
+    }
+
+    private static String stripBom(String text) {
+        if (text != null && !text.isEmpty() && text.charAt(0) == BOM) {
+            return text.substring(1);
+        }
+        return text;
     }
 }

--- a/dokimos-core/src/main/java/dev/dokimos/core/DatasetResolverRegistry.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/DatasetResolverRegistry.java
@@ -1,8 +1,8 @@
 package dev.dokimos.core;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Singleton registry for dataset resolvers.
@@ -15,9 +15,17 @@ public class DatasetResolverRegistry {
 
     private static final DatasetResolverRegistry INSTANCE = new DatasetResolverRegistry();
 
-    private final List<DatasetResolver> resolvers = new ArrayList<>();
+    private final List<DatasetResolver> resolvers = new CopyOnWriteArrayList<>();
 
-    private DatasetResolverRegistry() {
+    /**
+     * Creates a fresh, independent registry.
+     * <p>
+     * The new instance is seeded the same way as the global singleton: SPI resolvers
+     * are auto-discovered via {@link ServiceLoader} and the built-in resolvers are added.
+     * It maintains its own resolver chain, so {@link #register(DatasetResolver)} on this
+     * instance does not affect the global singleton returned by {@link #getInstance()}.
+     */
+    public DatasetResolverRegistry() {
         // Load the SPI resolvers
         ServiceLoader.load(DatasetResolver.class).forEach(resolvers::add);
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An evaluation experiment that runs a task against a dataset and evaluates the
@@ -17,15 +19,18 @@ import java.util.concurrent.Executors;
  */
 public class Experiment {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Experiment.class);
+
     private final String name;
     private final String description;
     private final Dataset dataset;
-    private final Task task;
+    private final MeasuredTask task;
     private final List<Evaluator> evaluators;
     private final Map<String, Object> metadata;
     private final Reporter reporter;
     private final int parallelism;
     private final int runs;
+    private final boolean autoCloseReporter;
 
     private Experiment(Builder builder) {
         this.name = builder.name;
@@ -37,6 +42,7 @@ public class Experiment {
         this.reporter = builder.reporter;
         this.parallelism = builder.parallelism;
         this.runs = builder.runs;
+        this.autoCloseReporter = builder.autoCloseReporter;
     }
 
     public static Builder builder() {
@@ -56,9 +62,15 @@ public class Experiment {
     public ExperimentResult run() {
         List<RunResult> runResults = new ArrayList<>();
 
-        for (int runIndex = 0; runIndex < runs; runIndex++) {
-            RunResult runResult = executeSingleRun(runIndex);
-            runResults.add(runResult);
+        try {
+            for (int runIndex = 0; runIndex < runs; runIndex++) {
+                RunResult runResult = executeSingleRun(runIndex);
+                runResults.add(runResult);
+            }
+        } finally {
+            if (autoCloseReporter) {
+                reporter.close();
+            }
         }
 
         return new ExperimentResult(name, description, metadata, runResults);
@@ -114,14 +126,22 @@ public class Experiment {
     }
 
     private ItemResult runSingleExample(Example example) {
-        Map<String, Object> actualOutputs = task.run(example);
-        EvalTestCase testCase = example.toTestCase(actualOutputs);
+        Map<String, Object> actualOutputs = null;
+        try {
+            TaskResult taskResult = task.run(example);
+            actualOutputs = taskResult.outputs();
+            EvalTestCase testCase = example.toTestCase(actualOutputs);
 
-        List<EvalResult> evalResults = evaluators.stream()
-                .map(evaluator -> evaluator.evaluate(testCase))
-                .toList();
+            List<EvalResult> evalResults = evaluators.stream()
+                    .map(evaluator -> evaluator.evaluate(testCase))
+                    .toList();
 
-        return new ItemResult(example, actualOutputs, evalResults);
+            return new ItemResult(example, actualOutputs, evalResults, taskResult.metrics());
+        } catch (RuntimeException e) {
+            // Isolate per-example failures so one bad item does not abort the whole run.
+            LOGGER.warn("Evaluation failed for example, recording it as failed: {}", example.input(), e);
+            return new ItemResult(example, actualOutputs, List.of());
+        }
     }
 
     public static class Builder {
@@ -130,10 +150,11 @@ public class Experiment {
         private String name = "unnamed";
         private String description = "";
         private Dataset dataset;
-        private Task task;
+        private MeasuredTask task;
         private Reporter reporter = NoOpReporter.INSTANCE;
         private int parallelism = 1;
         private int runs = 1;
+        private boolean autoCloseReporter = false;
 
         /**
          * Sets the experiment name.
@@ -175,7 +196,21 @@ public class Experiment {
          * @return builder
          */
         public Builder task(Task task) {
-            this.task = task;
+            this.task = task != null ? example -> TaskResult.of(task.run(example)) : null;
+            return this;
+        }
+
+        /**
+         * Sets a measured task that carries {@link CallMetrics} through to each {@link ItemResult}.
+         * <p>
+         * Named distinctly from {@link #task(Task)} so a lambda passed to {@code task(...)} is never
+         * ambiguous between the two functional interfaces.
+         *
+         * @param measuredTask The task to generate outputs and metrics from examples.
+         * @return builder
+         */
+        public Builder measuredTask(MeasuredTask measuredTask) {
+            this.task = measuredTask;
             return this;
         }
 
@@ -283,10 +318,26 @@ public class Experiment {
         }
 
         /**
+         * Controls whether {@link Experiment#run()} closes the reporter after the run completes.
+         * <p>
+         * When enabled, the reporter is closed (in addition to being flushed) once all runs
+         * finish. Defaults to {@code false} so the caller retains ownership of the reporter
+         * lifecycle.
+         *
+         * @param autoCloseReporter whether to close the reporter after the run completes
+         * @return builder
+         */
+        public Builder autoCloseReporter(boolean autoCloseReporter) {
+            this.autoCloseReporter = autoCloseReporter;
+            return this;
+        }
+
+        /**
          * Builds the experiment.
          *
          * @return a new experiment
-         * @throws IllegalStateException if dataset or task is not set
+         * @throws IllegalStateException if dataset or task is not set, the dataset has no
+         *                               examples, or no evaluators were added
          */
         public Experiment build() {
             if (dataset == null) {
@@ -294,6 +345,12 @@ public class Experiment {
             }
             if (task == null) {
                 throw new IllegalStateException("Task is required");
+            }
+            if (dataset.examples().isEmpty()) {
+                throw new IllegalStateException("Dataset must contain at least one example");
+            }
+            if (evaluators.isEmpty()) {
+                throw new IllegalStateException("At least one evaluator is required");
             }
 
             return new Experiment(this);

--- a/dokimos-core/src/main/java/dev/dokimos/core/ItemResult.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/ItemResult.java
@@ -1,5 +1,7 @@
 package dev.dokimos.core;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +17,8 @@ import java.util.Map;
 public record ItemResult(
         Example example, Map<String, Object> actualOutputs, List<EvalResult> evalResults, CallMetrics metrics) {
     public ItemResult {
-        actualOutputs = actualOutputs != null ? Map.copyOf(actualOutputs) : Map.of();
+        // Tolerate null values in the task outputs (Map.copyOf rejects them).
+        actualOutputs = actualOutputs != null ? Collections.unmodifiableMap(new HashMap<>(actualOutputs)) : Map.of();
         evalResults = evalResults != null ? List.copyOf(evalResults) : List.of();
     }
 
@@ -31,7 +34,7 @@ public record ItemResult(
     }
 
     public boolean success() {
-        return evalResults.stream().allMatch(EvalResult::success);
+        return !evalResults.isEmpty() && evalResults.stream().allMatch(EvalResult::success);
     }
 
     public EvalTestCase toTestCase() {

--- a/dokimos-core/src/main/java/dev/dokimos/core/LlmResponseUtils.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/LlmResponseUtils.java
@@ -1,6 +1,9 @@
 package dev.dokimos.core;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
@@ -98,5 +101,31 @@ public final class LlmResponseUtils {
             return stripped.substring(start, end + 1);
         }
         return stripped;
+    }
+
+    /**
+     * Extracts the JSON payload from an LLM response (dropping any surrounding prose or code fence)
+     * and parses it leniently into the requested type.
+     *
+     * @param response the LLM response that may wrap JSON in prose or a code fence
+     * @param type     the target type to deserialize into
+     * @param <T>      the deserialized type
+     * @return the parsed value
+     * @throws JsonProcessingException if the extracted payload cannot be parsed
+     */
+    public static <T> T parse(String response, TypeReference<T> type) throws JsonProcessingException {
+        return LENIENT_MAPPER.readValue(extractJson(response), type);
+    }
+
+    /**
+     * Extracts the JSON payload from an LLM response (dropping any surrounding prose or code fence)
+     * and parses it leniently into a tree.
+     *
+     * @param response the LLM response that may wrap JSON in prose or a code fence
+     * @return the parsed JSON tree
+     * @throws JsonProcessingException if the extracted payload cannot be parsed
+     */
+    public static JsonNode parseTree(String response) throws JsonProcessingException {
+        return LENIENT_MAPPER.readTree(extractJson(response));
     }
 }

--- a/dokimos-core/src/main/java/dev/dokimos/core/MeasuredTask.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/MeasuredTask.java
@@ -1,0 +1,18 @@
+package dev.dokimos.core;
+
+/**
+ * A task that produces outputs together with optional {@link CallMetrics} describing the
+ * underlying LLM call. The returned {@link TaskResult} carries the metrics through to the
+ * resulting {@link ItemResult}.
+ */
+@FunctionalInterface
+public interface MeasuredTask {
+
+    /**
+     * Run the task on the given {@link Example} and produce a result with optional metrics.
+     *
+     * @param example the example containing inputs and expected outputs
+     * @return the task result produced by the task
+     */
+    TaskResult run(Example example);
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/TaskResult.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/TaskResult.java
@@ -1,0 +1,29 @@
+package dev.dokimos.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The outcome of executing a {@link MeasuredTask}: the actual outputs and optional metrics
+ * describing the underlying LLM call.
+ *
+ * @param outputs the outputs the task produced, never null (empty map if absent)
+ * @param metrics optional metrics for the underlying LLM call, or null if not measured
+ */
+public record TaskResult(Map<String, Object> outputs, CallMetrics metrics) {
+    public TaskResult {
+        // Tolerate null values in the task outputs (Map.copyOf rejects them).
+        outputs = outputs != null ? Collections.unmodifiableMap(new HashMap<>(outputs)) : Map.of();
+    }
+
+    /**
+     * Creates a result without call metrics.
+     *
+     * @param outputs the outputs the task produced
+     * @return a task result with null metrics
+     */
+    public static TaskResult of(Map<String, Object> outputs) {
+        return new TaskResult(outputs, null);
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/comparison/RunComparison.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/comparison/RunComparison.java
@@ -12,6 +12,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Regression-comparison engine that compares a baseline set of runs against a candidate set.
@@ -30,6 +32,8 @@ import java.util.function.Function;
  * p-values of the others.
  */
 public final class RunComparison {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RunComparison.class);
 
     private static final double PRECISION_SCALE = 1_000_000.0;
 
@@ -75,6 +79,8 @@ public final class RunComparison {
 
         Map<String, ItemAggregate> baselineItems = aggregate(baseline);
         Map<String, ItemAggregate> candidateItems = aggregate(candidate);
+
+        warnOnPositionPairingMismatch(baseline, candidate);
 
         Set<String> allKeys = new LinkedHashSet<>();
         allKeys.addAll(baselineItems.keySet());
@@ -491,8 +497,55 @@ public final class RunComparison {
         return "item-" + index;
     }
 
+    // With no itemKey, items are paired by position: baseline item i pairs with candidate item i.
+    // When the sides have different item counts only the overlapping prefix is paired and the trailing
+    // items surface as ADDED/REMOVED. Surface that so an accidental length mismatch is not silent. The
+    // position assumption only holds when an item count is stable across a side's runs, so this checks
+    // the maximum per-side item count.
+    private void warnOnPositionPairingMismatch(List<RunResult> baseline, List<RunResult> candidate) {
+        if (itemKey != null) {
+            return;
+        }
+        int baselineMax = maxItemCount(baseline);
+        int candidateMax = maxItemCount(candidate);
+        if (baselineMax != candidateMax) {
+            int matched = Math.min(baselineMax, candidateMax);
+            int unmatched = Math.abs(baselineMax - candidateMax);
+            LOGGER.warn(
+                    "Position-based item pairing: baseline has {} items, candidate has {}; pairing the {}"
+                            + " overlapping positions and reporting {} unmatched item(s) as ADDED/REMOVED."
+                            + " Configure itemKey(...) to pair by item identity instead of position.",
+                    baselineMax,
+                    candidateMax,
+                    matched,
+                    unmatched);
+        }
+    }
+
+    private static int maxItemCount(List<RunResult> runs) {
+        int max = 0;
+        for (RunResult run : runs) {
+            max = Math.max(max, run.itemResults().size());
+        }
+        return max;
+    }
+
+    // A single run only qualifies for the McNemar pass-rate path when its per-item scores are
+    // genuinely binary. Otherwise the McNemar binarization (passProbability >= 0.5) would discard
+    // the magnitude of continuous scores, so we fall back to the continuous permutation path.
     private boolean isBinarySingleRun(List<RunResult> runs) {
-        return runs.size() == 1;
+        if (runs.size() != 1) {
+            return false;
+        }
+        for (ItemResult item : runs.get(0).itemResults()) {
+            for (EvalResult er : item.evalResults()) {
+                double score = er.score();
+                if (score != 0.0 && score != 1.0) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private static double[] pairedDeltas(List<Double> baseline, List<Double> candidate) {

--- a/dokimos-core/src/main/java/dev/dokimos/core/conversation/ConversationSimulator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/conversation/ConversationSimulator.java
@@ -75,20 +75,34 @@ public class ConversationSimulator {
         for (int turn = 0; turn < maxTurns; turn++) {
             // Generate user message
             Message userMessage;
-            if (turn == 0 && initialMessage != null && !initialMessage.isEmpty()) {
-                userMessage = Message.user(initialMessage);
-            } else {
-                userMessage = simulatedUser.generateMessage(trajectory);
+            try {
+                if (turn == 0 && initialMessage != null && !initialMessage.isEmpty()) {
+                    userMessage = Message.user(initialMessage);
+                } else {
+                    userMessage = simulatedUser.generateMessage(trajectory);
+                }
+            } catch (RuntimeException e) {
+                // Preserve the turns gathered so far rather than losing the whole trajectory
+                return withError(trajectory, "simulatedUser", e);
             }
             trajectory = trajectory.withMessage(userMessage);
 
-            // Check stopping condition after user message
+            // Check stopping condition after user message. A trailing user message with no
+            // assistant reply is intentional here, so turnCount() omits it.
             if (stoppingCondition != null && stoppingCondition.test(trajectory)) {
                 break;
             }
 
             // Get application response
-            Message assistantMessage = application.respond(trajectory);
+            Message assistantMessage;
+            try {
+                assistantMessage = application.respond(trajectory);
+                if (assistantMessage == null) {
+                    throw new IllegalStateException("ConversationalApplication returned a null response message");
+                }
+            } catch (RuntimeException e) {
+                return withError(trajectory, "application", e);
+            }
             trajectory = trajectory.withMessage(assistantMessage);
 
             // Check stopping condition after assistant response
@@ -98,6 +112,16 @@ public class ConversationSimulator {
         }
 
         return trajectory;
+    }
+
+    private ConversationTrajectory withError(ConversationTrajectory trajectory, String source, RuntimeException e) {
+        return ConversationTrajectory.builder()
+                .scenario(trajectory.scenario())
+                .messages(trajectory.messages())
+                .metadata(trajectory.metadata())
+                .metadata("error", e.getMessage() != null ? e.getMessage() : e.toString())
+                .metadata("errorSource", source)
+                .build();
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/conversation/LLMSimulatedUser.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/conversation/LLMSimulatedUser.java
@@ -57,6 +57,9 @@ public class LLMSimulatedUser implements SimulatedUser {
         // Generate dynamic response using LLM
         String prompt = buildPrompt(trajectory);
         String response = judge.generate(prompt);
+        if (response == null) {
+            throw new IllegalStateException("JudgeLM returned a null response while generating a user message");
+        }
         return Message.user(response.trim());
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/conversation/TrajectoryEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/conversation/TrajectoryEvaluator.java
@@ -1,7 +1,6 @@
 package dev.dokimos.core.conversation;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.BaseEvaluator;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
@@ -48,7 +47,6 @@ import org.slf4j.LoggerFactory;
 public class TrajectoryEvaluator extends BaseEvaluator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TrajectoryEvaluator.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final JudgeLM judge;
     private final List<EvaluationCriterion> criteria;
@@ -89,11 +87,13 @@ public class TrajectoryEvaluator extends BaseEvaluator {
 
         // Evaluate each criterion
         List<Map.Entry<EvaluationCriterion, Double>> criterionScores = new ArrayList<>();
+        List<CriterionResult> criterionResults = new ArrayList<>();
         Map<String, Object> criterionDetails = new HashMap<>();
 
         for (EvaluationCriterion criterion : criteria) {
             CriterionResult result = evaluateCriterion(trajectory, criterion);
             criterionScores.add(new AbstractMap.SimpleEntry<>(criterion, result.score()));
+            criterionResults.add(result);
 
             if (includePerCriterionScores) {
                 criterionDetails.put(
@@ -108,7 +108,7 @@ public class TrajectoryEvaluator extends BaseEvaluator {
         double aggregatedScore = aggregationStrategy.aggregate(criterionScores);
 
         // Generate overall reason
-        String reason = generateOverallReason(criterionScores);
+        String reason = generateOverallReason(criterionScores, criterionResults);
 
         // Build metadata
         Map<String, Object> metadata = new HashMap<>();
@@ -148,10 +148,15 @@ public class TrajectoryEvaluator extends BaseEvaluator {
         String response = judge.generate(prompt);
 
         try {
-            String json = LlmResponseUtils.stripMarkdown(response);
-            JsonNode node = OBJECT_MAPPER.readTree(json);
+            JsonNode node = LlmResponseUtils.parseTree(response);
 
-            double score = node.get("score").asDouble();
+            JsonNode scoreNode = node.get("score");
+            if (scoreNode == null || !scoreNode.isNumber()) {
+                // A missing or non-numeric score is a parse failure, not a genuine 0.0
+                throw new IllegalArgumentException("score field is missing or not a number");
+            }
+
+            double score = scoreNode.asDouble();
             // Normalize score to 0-1 range if needed
             if (score > 1.0) {
                 score = score / 10.0; // Handle 0-10 scale
@@ -160,10 +165,10 @@ public class TrajectoryEvaluator extends BaseEvaluator {
 
             String reason = node.has("reason") ? node.get("reason").asText() : "No reason provided";
 
-            return new CriterionResult(score, reason);
+            return new CriterionResult(score, reason, true);
         } catch (Exception e) {
             LOGGER.error("Failed to parse criterion evaluation response: {}", response, e);
-            return new CriterionResult(0.0, "Failed to parse evaluation: " + e.getMessage());
+            return new CriterionResult(0.0, "Failed to parse evaluation: " + e.getMessage(), false);
         }
     }
 
@@ -198,10 +203,16 @@ public class TrajectoryEvaluator extends BaseEvaluator {
         return sb.toString().trim();
     }
 
-    private String generateOverallReason(List<Map.Entry<EvaluationCriterion, Double>> criterionScores) {
+    private String generateOverallReason(
+            List<Map.Entry<EvaluationCriterion, Double>> criterionScores, List<CriterionResult> criterionResults) {
         if (criteria.size() == 1) {
             // If only one criterion, use its score directly in the reason
             Map.Entry<EvaluationCriterion, Double> entry = criterionScores.get(0);
+            CriterionResult result = criterionResults.get(0);
+            if (!result.parsed()) {
+                return "Evaluated '%s' criterion: %.2f (%s)"
+                        .formatted(entry.getKey().name(), entry.getValue(), result.reason());
+            }
             return "Evaluated '%s' criterion: %.2f".formatted(entry.getKey().name(), entry.getValue());
         }
 
@@ -224,7 +235,7 @@ public class TrajectoryEvaluator extends BaseEvaluator {
         return sb.toString();
     }
 
-    private record CriterionResult(double score, String reason) {}
+    private record CriterionResult(double score, String reason, boolean parsed) {}
 
     /**
      * Builder for constructing trajectory evaluators.

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/ContextualRelevanceEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/ContextualRelevanceEvaluator.java
@@ -1,7 +1,6 @@
 package dev.dokimos.core.evaluators;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.BaseEvaluator;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
@@ -42,7 +41,6 @@ import java.util.Map;
  */
 public class ContextualRelevanceEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private static final String DEFAULT_RETRIEVAL_CONTEXT_KEY = "retrievalContext";
 
     private final String retrievalContextKey;
@@ -154,10 +152,9 @@ public class ContextualRelevanceEvaluator extends BaseEvaluator {
                 {"score": <number between 0.0 and 1.0>, "reason": "<brief explanation>"}
                 """.formatted(input, context);
 
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
-
         try {
-            Map<String, Object> parsed = OBJECT_MAPPER.readValue(response, new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> parsed =
+                    LlmResponseUtils.parse(judge.generate(prompt), new TypeReference<Map<String, Object>>() {});
 
             double score = parseScore(parsed.get("score"));
             String reason = parsed.getOrDefault("reason", "No reason provided").toString();

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/FaithfulnessEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/FaithfulnessEvaluator.java
@@ -1,7 +1,6 @@
 package dev.dokimos.core.evaluators;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.BaseEvaluator;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
@@ -15,7 +14,6 @@ import java.util.*;
  */
 public class FaithfulnessEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private final String contextKey;
     private final JudgeLM judge;
     private final boolean includeReason;
@@ -77,10 +75,8 @@ public class FaithfulnessEvaluator extends BaseEvaluator {
                 [{"verdict": "...", "reasoning": "...", ...}]
                 """.formatted(truths, extractedClaims);
 
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
-
         try {
-            return OBJECT_MAPPER.readValue(response, new TypeReference<List<ClaimVerdict>>() {});
+            return LlmResponseUtils.parse(judge.generate(prompt), new TypeReference<List<ClaimVerdict>>() {});
         } catch (Exception e) {
             throw new EvaluationException("Failed to parse verdict response from LLM judge", e);
         }
@@ -116,10 +112,8 @@ public class FaithfulnessEvaluator extends BaseEvaluator {
                 Context: %s
                 """.formatted(context);
 
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
-
         try {
-            return OBJECT_MAPPER.readValue(response, new TypeReference<List<String>>() {});
+            return LlmResponseUtils.parse(judge.generate(prompt), new TypeReference<List<String>>() {});
         } catch (Exception e) {
             throw new EvaluationException("Could not parse JSON response to extract truths", e);
         }
@@ -138,10 +132,8 @@ public class FaithfulnessEvaluator extends BaseEvaluator {
                 AI Output: %s
                 """.formatted(actualOutput);
 
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
-
         try {
-            return OBJECT_MAPPER.readValue(response, new TypeReference<List<String>>() {});
+            return LlmResponseUtils.parse(judge.generate(prompt), new TypeReference<List<String>>() {});
         } catch (Exception e) {
             throw new EvaluationException("Could not parse JSON response to extract statements", e);
         }
@@ -225,6 +217,9 @@ public class FaithfulnessEvaluator extends BaseEvaluator {
         }
 
         public FaithfulnessEvaluator build() {
+            if (judge == null) {
+                throw new IllegalStateException("JudgeLM is required");
+            }
             return new FaithfulnessEvaluator(this);
         }
     }

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/HallucinationEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/HallucinationEvaluator.java
@@ -1,7 +1,6 @@
 package dev.dokimos.core.evaluators;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.BaseEvaluator;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
@@ -20,7 +19,6 @@ import java.util.List;
  */
 public class HallucinationEvaluator extends BaseEvaluator {
 
-    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private final String contextKey;
     private final JudgeLM judge;
     private final boolean includeReason;
@@ -79,10 +77,8 @@ public class HallucinationEvaluator extends BaseEvaluator {
                 [{"verdict": "yes", "reason": "..."}, {"verdict": "no", "reason": "..."}]
                 """.formatted(context, actualOutput);
 
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
-
         try {
-            return OBJECT_MAPPER.readValue(response, new TypeReference<List<HallucinationVerdict>>() {});
+            return LlmResponseUtils.parse(judge.generate(prompt), new TypeReference<List<HallucinationVerdict>>() {});
         } catch (Exception e) {
             throw new EvaluationException("Failed to parse verdict response from LLM judge", e);
         }
@@ -93,11 +89,16 @@ public class HallucinationEvaluator extends BaseEvaluator {
             return 0.0;
         }
 
-        long hallucinationCount = verdicts.stream()
-                .filter(v -> "no".equalsIgnoreCase(v.verdict().strip()))
-                .count();
+        long hallucinationCount =
+                verdicts.stream().filter(v -> isHallucination(v.verdict())).count();
 
         return (double) hallucinationCount / verdicts.size();
+    }
+
+    // A judge that omits the verdict field leaves it null; treat that as not a hallucination
+    // rather than letting it count as "no".
+    private boolean isHallucination(String verdict) {
+        return verdict != null && "no".equalsIgnoreCase(verdict.strip());
     }
 
     private String generateReason(List<HallucinationVerdict> verdicts, double score) {
@@ -109,7 +110,11 @@ public class HallucinationEvaluator extends BaseEvaluator {
         var contradictions = new StringBuilder();
 
         for (var verdict : verdicts) {
-            if ("yes".equalsIgnoreCase(verdict.verdict().strip())) {
+            String value = verdict.verdict();
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            if ("yes".equalsIgnoreCase(value.strip())) {
                 if (factualAlignments.length() > 0) factualAlignments.append("; ");
                 factualAlignments.append(verdict.reason());
             } else {

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
@@ -1,7 +1,6 @@
 package dev.dokimos.core.evaluators;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.BaseEvaluator;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
@@ -18,7 +17,6 @@ import org.slf4j.LoggerFactory;
  */
 public class LLMJudgeEvaluator extends BaseEvaluator {
     private static final Logger LOGGER = LoggerFactory.getLogger(LLMJudgeEvaluator.class);
-    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
     private final String criteria;
     private final double minScore;
     private final double maxScore;
@@ -73,21 +71,29 @@ public class LLMJudgeEvaluator extends BaseEvaluator {
 
     private EvalResult parseResponse(String response) {
         try {
-            String json = LlmResponseUtils.stripMarkdown(response);
-            JsonNode node = OBJECT_MAPPER.readTree(json);
-            double score = node.get("score").asDouble();
+            JsonNode node = LlmResponseUtils.parseTree(response);
+            double score = normalizeScore(node.get("score").asDouble());
             String reason = node.has("reason") ? node.get("reason").asText() : "No reason provided.";
 
             return EvalResult.builder()
                     .name(name)
                     .score(score)
-                    .threshold(threshold)
+                    .threshold(normalizeScore(threshold))
                     .reason(reason)
                     .build();
         } catch (Exception e) {
             LOGGER.error("Error parsing LLM judge response: {}", response, e);
             return EvalResult.failure(name, 0.0, "Failed to parse LLM response: " + e.getMessage());
         }
+    }
+
+    private double normalizeScore(double raw) {
+        // A default 0..1 range leaves scores untouched; a custom range maps onto [0,1].
+        if (minScore == 0.0 && maxScore == 1.0) {
+            return raw;
+        }
+        double normalized = (raw - minScore) / (maxScore - minScore);
+        return Math.max(0.0, Math.min(1.0, normalized));
     }
 
     public static class Builder {
@@ -147,10 +153,15 @@ public class LLMJudgeEvaluator extends BaseEvaluator {
          * Sets the expected score range for the LLM response.
          *
          * @param min the minimum score value
-         * @param max the maximum score value
+         * @param max the maximum score value (must be greater than {@code min})
          * @return this builder
+         * @throws IllegalArgumentException if {@code max} is not greater than {@code min}
          */
         public Builder scoreRange(double min, double max) {
+            if (max <= min) {
+                throw new IllegalArgumentException(
+                        "scoreRange max (" + max + ") must be greater than min (" + min + ")");
+            }
             this.minScore = min;
             this.maxScore = max;
             return this;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/RegexEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/RegexEvaluator.java
@@ -121,6 +121,9 @@ public class RegexEvaluator extends BaseEvaluator {
          * @return a new regex evaluator
          */
         public RegexEvaluator build() {
+            if (pattern == null || pattern.isBlank()) {
+                throw new IllegalStateException("A regex pattern is required; call .pattern(...) before build()");
+            }
             return new RegexEvaluator(this);
         }
     }

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/AgentEvalCase.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/AgentEvalCase.java
@@ -1,0 +1,135 @@
+package dev.dokimos.core.evaluators.agents;
+
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.agents.ToolDefinition;
+import java.util.List;
+
+/**
+ * Typed entry point for building an {@link EvalTestCase} for the agent evaluators.
+ * <p>
+ * The agent evaluators in this package read their inputs from fixed string keys:
+ * tool calls from {@code "toolCalls"} in actual outputs, available tools from
+ * {@code "tools"} in metadata, the task list from {@code "tasks"} in metadata, and
+ * expected tool calls from {@code "toolCalls"} in expected outputs. This builder lets
+ * callers populate those slots with typed values instead of hand-placing the keys.
+ * <p>
+ * Only the slots that are set are written, so the resulting test case carries exactly
+ * the keys the configured evaluators require.
+ *
+ * <pre>{@code
+ * EvalTestCase testCase = AgentEvalCase.builder()
+ *         .input("What's the weather in Paris?")
+ *         .toolCalls(actualCalls)
+ *         .tools(availableTools)
+ *         .build();
+ *
+ * EvalResult result = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+ * }</pre>
+ */
+public final class AgentEvalCase {
+
+    private AgentEvalCase() {}
+
+    /**
+     * Creates a new builder for constructing an agent {@link EvalTestCase}.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing an {@link EvalTestCase} that targets the agent evaluators.
+     */
+    public static final class Builder {
+        private String input;
+        private List<ToolCall> toolCalls;
+        private List<ToolDefinition> tools;
+        private List<ToolCall> expectedToolCalls;
+        private List<String> tasks;
+
+        private Builder() {}
+
+        /**
+         * Sets the primary input value (the {@code "input"} key).
+         *
+         * @param input the input value
+         * @return this builder
+         */
+        public Builder input(String input) {
+            this.input = input;
+            return this;
+        }
+
+        /**
+         * Sets the actual tool calls the agent made (the {@code "toolCalls"} key in actual outputs).
+         *
+         * @param toolCalls the tool calls
+         * @return this builder
+         */
+        public Builder toolCalls(List<ToolCall> toolCalls) {
+            this.toolCalls = List.copyOf(toolCalls);
+            return this;
+        }
+
+        /**
+         * Sets the tools available to the agent (the {@code "tools"} key in metadata).
+         *
+         * @param tools the tool definitions
+         * @return this builder
+         */
+        public Builder tools(List<ToolDefinition> tools) {
+            this.tools = List.copyOf(tools);
+            return this;
+        }
+
+        /**
+         * Sets the expected tool calls (the {@code "toolCalls"} key in expected outputs).
+         *
+         * @param expectedToolCalls the expected tool calls
+         * @return this builder
+         */
+        public Builder expectedToolCalls(List<ToolCall> expectedToolCalls) {
+            this.expectedToolCalls = List.copyOf(expectedToolCalls);
+            return this;
+        }
+
+        /**
+         * Sets the tasks the agent was asked to complete (the {@code "tasks"} key in metadata).
+         *
+         * @param tasks the task descriptions
+         * @return this builder
+         */
+        public Builder tasks(List<String> tasks) {
+            this.tasks = List.copyOf(tasks);
+            return this;
+        }
+
+        /**
+         * Builds the test case, writing only the slots that were set.
+         *
+         * @return a new test case populated with the keys the agent evaluators read
+         */
+        public EvalTestCase build() {
+            EvalTestCase.Builder builder = EvalTestCase.builder();
+            if (input != null) {
+                builder.input(input);
+            }
+            if (toolCalls != null) {
+                builder.actualOutput("toolCalls", toolCalls);
+            }
+            if (tools != null) {
+                builder.metadata("tools", tools);
+            }
+            if (expectedToolCalls != null) {
+                builder.expectedOutput("toolCalls", expectedToolCalls);
+            }
+            if (tasks != null) {
+                builder.metadata("tasks", tasks);
+            }
+            return builder.build();
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/TaskCompletionEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/TaskCompletionEvaluator.java
@@ -1,7 +1,6 @@
 package dev.dokimos.core.evaluators.agents;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.BaseEvaluator;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
@@ -20,8 +19,6 @@ import java.util.Map;
  * The score is the fraction of completed tasks (0.0–1.0).
  */
 public class TaskCompletionEvaluator extends BaseEvaluator {
-
-    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
 
     private final JudgeLM judge;
     private final String tasksKey;
@@ -75,7 +72,7 @@ public class TaskCompletionEvaluator extends BaseEvaluator {
                 : "";
 
         String prompt = buildPrompt(dialog, tasks, constraints);
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
+        String response = judge.generate(prompt);
 
         return parseResponse(response, tasks.size());
     }
@@ -113,8 +110,7 @@ public class TaskCompletionEvaluator extends BaseEvaluator {
 
     private EvalResult parseResponse(String response, int totalTasks) {
         try {
-            String json = extractJsonObject(response);
-            Map<String, Object> parsed = OBJECT_MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
+            Map<String, Object> parsed = LlmResponseUtils.parse(response, new TypeReference<Map<String, Object>>() {});
 
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> taskResults = (List<Map<String, Object>>) parsed.get("tasks");
@@ -150,15 +146,6 @@ public class TaskCompletionEvaluator extends BaseEvaluator {
                     .reason("Failed to parse judge response: " + e.getMessage())
                     .build();
         }
-    }
-
-    private static String extractJsonObject(String response) {
-        int start = response.indexOf('{');
-        int end = response.lastIndexOf('}');
-        if (start >= 0 && end > start) {
-            return response.substring(start, end + 1);
-        }
-        return response;
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluator.java
@@ -74,7 +74,7 @@ public class ToolArgumentHallucinationEvaluator extends BaseEvaluator {
         }
 
         String prompt = buildPrompt(userInput, toolCalls);
-        String response = LlmResponseUtils.stripMarkdown(judge.generate(prompt));
+        String response = judge.generate(prompt);
 
         return parseResponse(response, toolCalls.size());
     }
@@ -113,9 +113,8 @@ public class ToolArgumentHallucinationEvaluator extends BaseEvaluator {
 
     private EvalResult parseResponse(String response, int totalCalls) {
         try {
-            String json = extractJsonArray(response);
             List<Map<String, Object>> verdicts =
-                    OBJECT_MAPPER.readValue(json, new TypeReference<List<Map<String, Object>>>() {});
+                    LlmResponseUtils.parse(response, new TypeReference<List<Map<String, Object>>>() {});
 
             long grounded = verdicts.stream()
                     .filter(v -> Boolean.TRUE.equals(v.get("grounded")))
@@ -139,16 +138,6 @@ public class ToolArgumentHallucinationEvaluator extends BaseEvaluator {
                     .reason("Failed to parse judge response: " + e.getMessage())
                     .build();
         }
-    }
-
-    private static String extractJsonArray(String response) {
-        // Find the first '[' and last ']' to extract the JSON array
-        int start = response.indexOf('[');
-        int end = response.lastIndexOf(']');
-        if (start >= 0 && end > start) {
-            return response.substring(start, end + 1);
-        }
-        return response;
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolCallValidityEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolCallValidityEvaluator.java
@@ -161,7 +161,7 @@ public class ToolCallValidityEvaluator extends BaseEvaluator {
                 switch (type) {
                     case "string" -> value instanceof String;
                     case "number" -> value instanceof Number;
-                    case "integer" -> value instanceof Integer || value instanceof Long;
+                    case "integer" -> value instanceof Number n && isWholeNumber(n);
                     case "boolean" -> value instanceof Boolean;
                     case "array" -> value instanceof List;
                     case "object" -> value instanceof Map;
@@ -174,15 +174,59 @@ public class ToolCallValidityEvaluator extends BaseEvaluator {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void validateEnum(String paramName, Object value, Map<String, Object> schema, List<String> errors) {
         Object enumValues = schema.get("enum");
         if (enumValues instanceof List<?> allowed) {
-            if (!allowed.contains(value)) {
+            if (!enumContains(allowed, value)) {
                 errors.add(
                         "Parameter '%s' value '%s' is not in allowed values: %s".formatted(paramName, value, allowed));
             }
         }
+    }
+
+    /**
+     * Returns whether a {@link Number} represents a whole value. JSON tool arguments
+     * commonly deserialize integral values as {@link Double}, so a fractional-free
+     * Double/Float/BigDecimal is accepted as an integer while genuine non-integers
+     * (e.g. {@code 1.5}) are rejected.
+     */
+    private boolean isWholeNumber(Number n) {
+        if (n instanceof Integer || n instanceof Long || n instanceof Short || n instanceof Byte) {
+            return true;
+        }
+        double d = n.doubleValue();
+        return !Double.isNaN(d) && !Double.isInfinite(d) && d == Math.rint(d);
+    }
+
+    /**
+     * Returns whether {@code value} is in {@code allowed}, comparing numbers by numeric
+     * value so a {@code Double} {@code 1.0} matches an {@code Integer} enum entry {@code 1}.
+     * Non-numeric entries keep {@link Object#equals(Object)} semantics.
+     */
+    private boolean enumContains(List<?> allowed, Object value) {
+        if (allowed.contains(value)) {
+            return true;
+        }
+        if (value instanceof Number vn) {
+            for (Object entry : allowed) {
+                if (entry instanceof Number en && numbersEqual(vn, en)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean numbersEqual(Number a, Number b) {
+        if (isNonFinite(a) || isNonFinite(b)) {
+            // BigDecimal cannot parse "NaN" / "Infinity"; compare these directly.
+            return Double.compare(a.doubleValue(), b.doubleValue()) == 0;
+        }
+        return new java.math.BigDecimal(a.toString()).compareTo(new java.math.BigDecimal(b.toString())) == 0;
+    }
+
+    private boolean isNonFinite(Number n) {
+        return (n instanceof Double d && !Double.isFinite(d)) || (n instanceof Float f && !Float.isFinite(f));
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluator.java
@@ -21,7 +21,9 @@ import java.util.Map;
  * their names are equal and their arguments match under an {@link ArgumentMatcher}.
  * Argument matching is configurable per tool via
  * {@link Builder#argumentMatcher(String, ArgumentMatcher)}; the default matcher
- * compares names only ({@link ArgMatchMode#IGNORE}).
+ * compares arguments tolerantly ({@link ArgumentMatcher#tolerant()}). Use
+ * {@link Builder#argumentMatcher(ArgumentMatcher)} with
+ * {@code ArgumentMatcher.of(ArgMatchMode.IGNORE)} to compare names only.
  * <p>
  * Match modes:
  * <ul>
@@ -296,7 +298,7 @@ public class ToolTrajectoryEvaluator extends BaseEvaluator {
         private String toolCallsKey = "toolCalls";
         private String expectedToolCallsKey = "toolCalls";
         private MatchMode matchMode = MatchMode.IN_ORDER;
-        private ArgumentMatcher defaultMatcher = ArgumentMatcher.of(ArgMatchMode.IGNORE);
+        private ArgumentMatcher defaultMatcher = ArgumentMatcher.tolerant();
         private final Map<String, ArgumentMatcher> perToolMatchers = new HashMap<>();
 
         /**
@@ -368,8 +370,9 @@ public class ToolTrajectoryEvaluator extends BaseEvaluator {
         /**
          * Sets the default argument matcher applied to every tool unless overridden.
          * <p>
-         * Defaults to {@link ArgMatchMode#IGNORE}, so by default only tool names and
-         * order are compared. Supply a tolerant or exact matcher to also assert arguments.
+         * Defaults to {@link ArgumentMatcher#tolerant()}, so arguments are compared by
+         * default. Supply {@code ArgumentMatcher.of(ArgMatchMode.IGNORE)} to compare tool
+         * names and order only.
          *
          * @param matcher the default argument matcher
          * @return this builder

--- a/dokimos-core/src/test/java/dev/dokimos/core/ContextualRelevanceEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ContextualRelevanceEvaluatorTest.java
@@ -443,6 +443,26 @@ class ContextualRelevanceEvaluatorTest {
         assertThat(result.score()).isEqualTo(0.75);
     }
 
+    @Test
+    void shouldParseProseWrappedJson() {
+        JudgeLM judge = prompt -> "Relevance assessment: {\"score\": 0.9, \"reason\": \"Directly relevant\"} done";
+
+        var evaluator = ContextualRelevanceEvaluator.builder()
+                .judge(judge)
+                .includeReason(false)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("What are symptoms of dehydration?")
+                .actualOutput("retrievalContext", List.of("Dehydration symptoms include thirst."))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isCloseTo(0.9, within(1e-9));
+        assertThat(result.success()).isTrue();
+    }
+
     private static class MockJudge implements JudgeLM {
         private final Map<Integer, String> scoreResponses = new java.util.HashMap<>();
         private String summaryResponse = "Default summary.";

--- a/dokimos-core/src/test/java/dev/dokimos/core/DatasetResolverRegistryTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/DatasetResolverRegistryTest.java
@@ -6,6 +6,22 @@ import org.junit.jupiter.api.Test;
 
 class DatasetResolverRegistryTest {
 
+    private static final String MARKER = "classpath:__devex_isolation_marker__.json";
+
+    private static DatasetResolver markerResolver(String datasetName) {
+        return new DatasetResolver() {
+            @Override
+            public boolean supports(String uri) {
+                return MARKER.equals(uri);
+            }
+
+            @Override
+            public Dataset resolve(String uri) {
+                return Dataset.builder().name(datasetName).build();
+            }
+        };
+    }
+
     @Test
     void shouldResolveClasspathResource() {
         var registry = DatasetResolverRegistry.getInstance();
@@ -42,5 +58,42 @@ class DatasetResolverRegistryTest {
 
         Dataset dataset = registry.resolve("custom:anything");
         assertThat(dataset.name()).isEqualTo("custom-dataset");
+    }
+
+    @Test
+    void isolatedRegistryShouldResolveBuiltInResolvers() {
+        var registry = new DatasetResolverRegistry();
+
+        Dataset dataset = registry.resolve("classpath:datasets/sample.json");
+
+        assertThat(dataset).isNotNull();
+        assertThat(dataset.size()).isGreaterThan(0);
+    }
+
+    @Test
+    void registerOnIsolatedInstanceShouldNotAffectAnother() {
+        var a = new DatasetResolverRegistry();
+        var b = new DatasetResolverRegistry();
+
+        a.register(markerResolver("from-a"));
+        b.register(markerResolver("from-b"));
+
+        // Each isolated registry consults only its own registered resolver (added at highest priority).
+        assertThat(a.resolve(MARKER).name()).isEqualTo("from-a");
+        assertThat(b.resolve(MARKER).name()).isEqualTo("from-b");
+    }
+
+    @Test
+    void registerOnIsolatedInstanceShouldNotAffectSingleton() {
+        var isolated = new DatasetResolverRegistry();
+        isolated.register(markerResolver("isolated-only"));
+
+        assertThat(isolated.resolve(MARKER).name()).isEqualTo("isolated-only");
+
+        // The global singleton never saw the custom resolver, so it falls through to the built-in
+        // classpath resolver, which fails to find the (nonexistent) marker resource.
+        assertThatThrownBy(() -> DatasetResolverRegistry.getInstance().resolve(MARKER))
+                .isInstanceOf(DatasetResolutionException.class)
+                .hasMessageContaining("Classpath resource not found");
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/DatasetTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/DatasetTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 class DatasetTest {
 
+    private static final String BOM = "﻿";
+
     @Test
     void shouldBuildSimpleDataset() {
         var dataset = Dataset.builder()
@@ -300,5 +302,121 @@ class DatasetTest {
         assertThatThrownBy(() -> Dataset.fromJsonl(jsonl, "test"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("line 2");
+    }
+
+    @Test
+    void shouldCollapseDoubledQuotesToSingleLiteralQuote() {
+        String csv = "input,output\n\"He said \"\"hi\"\"\",greeting\n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "quotes");
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo("He said \"hi\"");
+        assertThat(dataset.get(0).expectedOutput()).isEqualTo("greeting");
+    }
+
+    @Test
+    void shouldKeepNewlineInsideQuotedFieldAsOneExample() {
+        String csv = "input,output\n\"line one\nline two\",multi\n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "newlines");
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo("line one\nline two");
+        assertThat(dataset.get(0).expectedOutput()).isEqualTo("multi");
+    }
+
+    @Test
+    void shouldKeepDelimiterInsideQuotedField() {
+        String csv = "input,output\n\"a,b,c\",joined\n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "delimiter");
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo("a,b,c");
+    }
+
+    @Test
+    void shouldPreserveLeadingAndTrailingSpacesInQuotedField() {
+        String csv = "input,output\n\"  padded  \",result\n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "padded");
+
+        assertThat(dataset.get(0).input()).isEqualTo("  padded  ");
+    }
+
+    @Test
+    void shouldTrimUnquotedFields() {
+        String csv = "input,output\n  spaced  ,  trimmed  \n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "unquoted");
+
+        assertThat(dataset.get(0).input()).isEqualTo("spaced");
+        assertThat(dataset.get(0).expectedOutput()).isEqualTo("trimmed");
+    }
+
+    @Test
+    void shouldResolveInputColumnWithBomPrefixedHeader() {
+        String csv = BOM + "input,output\n2+2,4\n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "bom");
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo("2+2");
+    }
+
+    @Test
+    void shouldStripBomFromJsonContent() {
+        String json = BOM + "{\"name\":\"d\",\"examples\":[{\"input\":\"q\",\"expectedOutput\":\"a\"}]}";
+
+        Dataset dataset = Dataset.fromJson(json);
+
+        assertThat(dataset.name()).isEqualTo("d");
+        assertThat(dataset.get(0).input()).isEqualTo("q");
+    }
+
+    @Test
+    void shouldIncludeFoundHeadersWhenInputColumnMissing() {
+        String csv = "question,answer\nq,a\n";
+
+        assertThatThrownBy(() -> Dataset.fromCsv(csv, "missing"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("question")
+                .hasMessageContaining("answer");
+    }
+
+    @Test
+    void shouldRoundTripEscapedCsvOutput() {
+        // Mirrors ExperimentResultExporter.escapeCsv: quote-wrap and double inner quotes.
+        String raw = "value with \"quotes\", a comma\nand a newline";
+        String escaped = "\"" + raw.replace("\"", "\"\"") + "\"";
+        String csv = "input,output\n" + escaped + ",ok\n";
+
+        Dataset dataset = Dataset.fromCsv(csv, "roundtrip");
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo(raw);
+    }
+
+    @Test
+    void shouldLoadCsvPath(@TempDir Path tempDir) throws IOException {
+        Path csvFile = tempDir.resolve("sample.csv");
+        Files.writeString(csvFile, "input,output\n2+2,4\n");
+
+        Dataset dataset = Dataset.load(csvFile.toString());
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo("2+2");
+    }
+
+    @Test
+    void shouldLoadJsonPath(@TempDir Path tempDir) throws IOException {
+        Path jsonFile = tempDir.resolve("sample.json");
+        Files.writeString(jsonFile, "{\"name\":\"d\",\"examples\":[{\"input\":\"q\",\"expectedOutput\":\"a\"}]}");
+
+        Dataset dataset = Dataset.load(jsonFile.toString());
+
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).input()).isEqualTo("q");
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/ExperimentTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ExperimentTest.java
@@ -5,11 +5,31 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dev.dokimos.core.evaluators.ExactMatchEvaluator;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ExperimentTest {
+
+    private static Evaluator passingEvaluator() {
+        return new Evaluator() {
+            @Override
+            public EvalResult evaluate(EvalTestCase testCase) {
+                return EvalResult.success("noop", 1.0, "ok");
+            }
+
+            @Override
+            public String name() {
+                return "noop";
+            }
+
+            @Override
+            public double threshold() {
+                return 0.5;
+            }
+        };
+    }
 
     @Test
     void shouldRunTaskOnEachExample() {
@@ -25,6 +45,7 @@ class ExperimentTest {
                 .name("math-experiment")
                 .dataset(dataset)
                 .task(task)
+                .evaluator(passingEvaluator())
                 .build()
                 .run();
 
@@ -134,6 +155,7 @@ class ExperimentTest {
                 .description("Testing greeting responses")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "Hi there"))
+                .evaluator(passingEvaluator())
                 .metadata("model", "gpt-5")
                 .metadata("promptVersion", "2.1")
                 .build()
@@ -178,6 +200,7 @@ class ExperimentTest {
                 .name("reporter-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", example.expectedOutput()))
+                .evaluator(passingEvaluator())
                 .reporter(tracker)
                 .build()
                 .run();
@@ -195,6 +218,7 @@ class ExperimentTest {
                 .name("my-experiment")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
                 .metadata("model", "gpt-5")
                 .metadata("version", "1.0")
                 .reporter(tracker)
@@ -241,6 +265,7 @@ class ExperimentTest {
                 .name("success-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
                 .reporter(tracker)
                 .build()
                 .run();
@@ -249,24 +274,27 @@ class ExperimentTest {
     }
 
     @Test
-    void shouldCompleteRunWithFailedOnException() {
+    void shouldIsolateTaskExceptionAndCompleteRun() {
         var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
 
         var tracker = new TrackingReporter();
 
-        assertThatThrownBy(() -> Experiment.builder()
-                        .name("failure-test")
-                        .dataset(dataset)
-                        .task(example -> {
-                            throw new RuntimeException("Task failed");
-                        })
-                        .reporter(tracker)
-                        .build()
-                        .run())
-                .isInstanceOf(RuntimeException.class);
+        var result = Experiment.builder()
+                .name("failure-test")
+                .dataset(dataset)
+                .task(example -> {
+                    throw new RuntimeException("Task failed");
+                })
+                .evaluator(passingEvaluator())
+                .reporter(tracker)
+                .build()
+                .run();
 
-        assertThat(tracker.completeRunStatus).isEqualTo(RunStatus.FAILED);
-        assertThat(tracker.calls).contains("completeRun", "flush");
+        // A failing item no longer aborts the run; it is recorded as unsuccessful.
+        assertThat(result.totalCount()).isEqualTo(1);
+        assertThat(result.itemResults().get(0).success()).isFalse();
+        assertThat(tracker.completeRunStatus).isEqualTo(RunStatus.SUCCESS);
+        assertThat(tracker.calls).contains("reportItem", "completeRun", "flush");
     }
 
     @Test
@@ -279,6 +307,7 @@ class ExperimentTest {
                 .name("handle-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
                 .reporter(tracker)
                 .build()
                 .run();
@@ -296,6 +325,7 @@ class ExperimentTest {
                 .name("noop-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
                 .build()
                 .run();
 
@@ -310,6 +340,7 @@ class ExperimentTest {
                 .name("null-reporter-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
                 .reporter(null)
                 .build()
                 .run();
@@ -329,6 +360,7 @@ class ExperimentTest {
                 .name("parallel-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", example.expectedOutput()))
+                .evaluator(passingEvaluator())
                 .parallelism(2)
                 .build()
                 .run();
@@ -345,6 +377,7 @@ class ExperimentTest {
                 .name("multi-run-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", example.expectedOutput()))
+                .evaluator(passingEvaluator())
                 .runs(3)
                 .build()
                 .run();
@@ -365,6 +398,7 @@ class ExperimentTest {
                 .name("parallel-multi-run-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", example.expectedOutput()))
+                .evaluator(passingEvaluator())
                 .parallelism(2)
                 .runs(2)
                 .build()
@@ -407,6 +441,7 @@ class ExperimentTest {
                 .name("multi-run-reporter-test")
                 .dataset(dataset)
                 .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
                 .reporter(tracker)
                 .runs(2)
                 .build()
@@ -423,6 +458,269 @@ class ExperimentTest {
                         "reportItem",
                         "completeRun",
                         "flush");
+    }
+
+    @Test
+    void shouldRunWhenTaskReturnsMapWithNullValue() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        Task task = example -> {
+            Map<String, Object> outputs = new HashMap<>();
+            outputs.put("output", null);
+            return outputs;
+        };
+
+        var result = Experiment.builder()
+                .name("null-value-test")
+                .dataset(dataset)
+                .task(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.totalCount()).isEqualTo(1);
+        assertThat(result.itemResults().get(0).actualOutputs()).containsKey("output");
+        assertThat(result.itemResults().get(0).actualOutputs().get("output")).isNull();
+    }
+
+    @Test
+    void shouldIsolateOneFailingExampleAndCompleteRunSequentially() {
+        var result = runWithOneFailingExample(1);
+
+        assertThat(result.itemResults()).hasSize(3);
+        assertThat(result.itemResults().stream().filter(r -> !r.success()).count())
+                .isEqualTo(1);
+        assertThat(result.itemResults().stream().filter(ItemResult::success).count())
+                .isEqualTo(2);
+    }
+
+    @Test
+    void shouldIsolateOneFailingExampleAndCompleteRunInParallel() {
+        var result = runWithOneFailingExample(2);
+
+        assertThat(result.itemResults()).hasSize(3);
+        assertThat(result.itemResults().stream().filter(r -> !r.success()).count())
+                .isEqualTo(1);
+        assertThat(result.itemResults().stream().filter(ItemResult::success).count())
+                .isEqualTo(2);
+    }
+
+    private ExperimentResult runWithOneFailingExample(int parallelism) {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("q1", "a1"))
+                .addExample(Example.of("boom", "a2"))
+                .addExample(Example.of("q3", "a3"))
+                .build();
+
+        Task task = example -> {
+            if (example.input().equals("boom")) {
+                throw new RuntimeException("task blew up");
+            }
+            return Map.of("output", example.expectedOutput());
+        };
+
+        return Experiment.builder()
+                .name("isolation-test")
+                .dataset(dataset)
+                .task(task)
+                .evaluator(passingEvaluator())
+                .parallelism(parallelism)
+                .build()
+                .run();
+    }
+
+    @Test
+    void shouldIsolateFailingEvaluator() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        Evaluator throwing = new Evaluator() {
+            @Override
+            public EvalResult evaluate(EvalTestCase testCase) {
+                throw new RuntimeException("evaluator blew up");
+            }
+
+            @Override
+            public String name() {
+                return "throwing";
+            }
+
+            @Override
+            public double threshold() {
+                return 0.5;
+            }
+        };
+
+        var result = Experiment.builder()
+                .name("evaluator-failure-test")
+                .dataset(dataset)
+                .task(example -> Map.of("output", "result"))
+                .evaluator(throwing)
+                .build()
+                .run();
+
+        assertThat(result.totalCount()).isEqualTo(1);
+        assertThat(result.itemResults().get(0).success()).isFalse();
+    }
+
+    @Test
+    void shouldCloseReporterWhenAutoCloseEnabled() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+        var reporter = new RecordingReporter();
+
+        Experiment.builder()
+                .name("auto-close-test")
+                .dataset(dataset)
+                .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
+                .reporter(reporter)
+                .autoCloseReporter(true)
+                .build()
+                .run();
+
+        assertThat(reporter.closed).isTrue();
+    }
+
+    @Test
+    void shouldNotCloseReporterByDefault() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+        var reporter = new RecordingReporter();
+
+        Experiment.builder()
+                .name("no-auto-close-test")
+                .dataset(dataset)
+                .task(example -> Map.of("output", "result"))
+                .evaluator(passingEvaluator())
+                .reporter(reporter)
+                .build()
+                .run();
+
+        assertThat(reporter.closed).isFalse();
+    }
+
+    @Test
+    void shouldThrowOnEmptyDataset() {
+        var dataset = Dataset.builder().name("empty").build();
+
+        assertThatThrownBy(() -> Experiment.builder()
+                        .name("empty-dataset-test")
+                        .dataset(dataset)
+                        .task(example -> Map.of())
+                        .evaluator(passingEvaluator())
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("at least one example");
+    }
+
+    @Test
+    void shouldThrowWhenNoEvaluators() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        assertThatThrownBy(() -> Experiment.builder()
+                        .name("no-evaluator-test")
+                        .dataset(dataset)
+                        .task(example -> Map.of())
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("evaluator");
+    }
+
+    @Test
+    void measuredTaskCarriesMetricsThroughToItemResult() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+        var metrics = new CallMetrics(10, 20, 0.5, 123L);
+
+        MeasuredTask task = example -> new TaskResult(Map.of("output", "a"), metrics);
+
+        var result = Experiment.builder()
+                .name("measured")
+                .dataset(dataset)
+                .measuredTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(1);
+        assertThat(result.itemResults().get(0).metrics()).isEqualTo(metrics);
+        assertThat(result.itemResults().get(0).actualOutputs()).containsEntry("output", "a");
+    }
+
+    @Test
+    void plainTaskStillWorksWithNullMetrics() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        Task task = example -> Map.of("output", "a");
+
+        var result = Experiment.builder()
+                .name("plain")
+                .dataset(dataset)
+                .task(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(1);
+        assertThat(result.itemResults().get(0).metrics()).isNull();
+    }
+
+    @Test
+    void measuredTaskThatThrowsIsIsolated() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("ok", "a"))
+                .addExample(Example.of("boom", "a"))
+                .build();
+
+        MeasuredTask task = example -> {
+            if ("boom".equals(example.input())) {
+                throw new RuntimeException("kaboom");
+            }
+            return new TaskResult(Map.of("output", "a"), new CallMetrics(1, 1, 0.0, 1L));
+        };
+
+        var result = Experiment.builder()
+                .name("isolated")
+                .dataset(dataset)
+                .measuredTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(2);
+        assertThat(result.itemResults().get(0).success()).isTrue();
+        assertThat(result.itemResults().get(0).metrics()).isNotNull();
+        assertThat(result.itemResults().get(1).success()).isFalse();
+        assertThat(result.itemResults().get(1).evalResults()).isEmpty();
+    }
+
+    private static class RecordingReporter implements Reporter {
+        final List<String> calls = new ArrayList<>();
+        boolean closed = false;
+
+        @Override
+        public RunHandle startRun(String experimentName, Map<String, Object> metadata) {
+            calls.add("startRun");
+            return new RunHandle("recording-run-id");
+        }
+
+        @Override
+        public void reportItem(RunHandle handle, ItemResult result) {
+            calls.add("reportItem");
+        }
+
+        @Override
+        public void completeRun(RunHandle handle, RunStatus status) {
+            calls.add("completeRun");
+        }
+
+        @Override
+        public void flush() {
+            calls.add("flush");
+        }
+
+        @Override
+        public void close() {
+            calls.add("close");
+            closed = true;
+        }
     }
 
     /**

--- a/dokimos-core/src/test/java/dev/dokimos/core/FaithfulnessEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/FaithfulnessEvaluatorTest.java
@@ -330,6 +330,42 @@ class FaithfulnessEvaluatorTest {
         assertThat(result.success()).isTrue();
     }
 
+    @Test
+    void shouldParseProseWrappedJson() {
+        JudgeLM judge = prompt -> {
+            if (prompt.contains("Extract the factual truths")) {
+                return "Sure, here they are: [\"Paris is the capital\"] Hope that helps.";
+            }
+            if (prompt.contains("break it down into individual claims")) {
+                return "The claims are: [\"Paris is the capital\"]";
+            }
+            if (prompt.contains("Compare each CLAIM")) {
+                return "My verdicts: [{\"verdict\": \"Yes\", \"reasoning\": \"Matches\"}]";
+            }
+            return "All claims supported.";
+        };
+
+        var evaluator = FaithfulnessEvaluator.builder().judge(judge).build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Tell me about Paris")
+                .actualOutput("context", "Paris is the capital")
+                .actualOutput("Paris is the capital")
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    void shouldRequireJudgeOnBuild() {
+        assertThatThrownBy(() -> FaithfulnessEvaluator.builder().build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("JudgeLM");
+    }
+
     private static class MockJudge implements JudgeLM {
         private String truthsResponse;
         private String claimsResponse;

--- a/dokimos-core/src/test/java/dev/dokimos/core/HallucinationEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/HallucinationEvaluatorTest.java
@@ -344,6 +344,36 @@ class HallucinationEvaluatorTest {
         assertThat(result.name()).isEqualTo("custom-hallucination");
     }
 
+    @Test
+    void shouldHandleVerdictMissingVerdictFieldWithoutNpe() {
+        JudgeLM judge = prompt -> {
+            if (prompt.contains("determine whether each statement")) {
+                return """
+                        [
+                            {"reason": "No verdict field at all"},
+                            {"verdict": "no", "reason": "Not supported"}
+                        ]
+                        """;
+            }
+            return "Summary of evaluation.";
+        };
+
+        var evaluator =
+                HallucinationEvaluator.builder().judge(judge).threshold(0.6).build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("context", "Some context")
+                .actualOutput("Some output")
+                .build();
+
+        // A verdict missing its verdict field must not throw and must not count as a hallucination.
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(0.5);
+        assertThat(result.success()).isTrue();
+    }
+
     private static class MockJudge implements JudgeLM {
         private String verdictsResponse;
         private String reasonResponse;

--- a/dokimos-core/src/test/java/dev/dokimos/core/ItemResultTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ItemResultTest.java
@@ -2,6 +2,7 @@ package dev.dokimos.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -64,5 +65,31 @@ class ItemResultTest {
         assertThat(item.metrics().costUsd()).isEqualTo(0.0023);
         assertThat(item.metrics().latencyMs()).isEqualTo(512L);
         assertThat(item.success()).isTrue();
+    }
+
+    @Test
+    void shouldTolerateNullValueInActualOutputs() {
+        Map<String, Object> outputs = new HashMap<>();
+        outputs.put("output", null);
+
+        var item = new ItemResult(Example.of("q", "a"), outputs, List.of(EvalResult.success("eval1", 1.0, "ok")));
+
+        assertThat(item.actualOutputs()).containsKey("output");
+        assertThat(item.actualOutputs().get("output")).isNull();
+        assertThat(item.success()).isTrue();
+    }
+
+    @Test
+    void shouldNotBeSuccessWhenEvalResultsEmpty() {
+        var item = new ItemResult(Example.of("q", "a"), Map.of("output", "a"), List.of());
+
+        assertThat(item.success()).isFalse();
+    }
+
+    @Test
+    void shouldNotBeSuccessWhenEvalResultsNull() {
+        var item = new ItemResult(Example.of("q", "a"), Map.of("output", "a"), null);
+
+        assertThat(item.success()).isFalse();
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/LLMJudgeEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/LLMJudgeEvaluatorTest.java
@@ -144,7 +144,7 @@ class LLMJudgeEvaluatorTest {
         var result = evaluator.evaluate(testCase);
 
         assertThat(capturedPrompt[0]).contains("between 1.0 and 5.0");
-        assertThat(result.score()).isEqualTo(4.2);
+        assertThat(result.score()).isCloseTo(0.8, within(1e-9));
         assertThat(result.success()).isTrue();
     }
 
@@ -170,7 +170,7 @@ class LLMJudgeEvaluatorTest {
 
         var result = evaluator.evaluate(testCase);
 
-        assertThat(result.score()).isEqualTo(1.5);
+        assertThat(result.score()).isCloseTo(0.125, within(1e-9));
         assertThat(result.success()).isFalse();
     }
 
@@ -208,5 +208,34 @@ class LLMJudgeEvaluatorTest {
                         .build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("at least one evaluation param");
+    }
+
+    @Test
+    void shouldRecoverScoreFromProsePreamble() {
+        JudgeLM judge = prompt -> "Here is my assessment:\n{\"score\": 0.9, \"reason\": \"Matches well\"}\nThanks!";
+
+        var evaluator = LLMJudgeEvaluator.builder()
+                .name("correctness")
+                .criteria("Check correctness")
+                .evaluationParams(List.of(EvalTestCaseParam.ACTUAL_OUTPUT))
+                .threshold(0.7)
+                .judge(judge)
+                .build();
+
+        var testCase = EvalTestCase.builder().input("q").actualOutput("a").build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(0.9);
+        assertThat(result.success()).isTrue();
+        assertThat(result.reason()).isEqualTo("Matches well");
+    }
+
+    @Test
+    void shouldRejectInvertedOrEmptyScoreRange() {
+        assertThatThrownBy(() -> LLMJudgeEvaluator.builder().scoreRange(5, 5))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LLMJudgeEvaluator.builder().scoreRange(5, 1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/RegexEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/RegexEvaluatorTest.java
@@ -166,4 +166,11 @@ class RegexEvaluatorTest {
         assertThat(result.score()).isEqualTo(1.0);
         assertThat(result.success()).isTrue();
     }
+
+    @Test
+    void shouldRequirePatternOnBuild() {
+        assertThatThrownBy(() -> RegexEvaluator.builder().name("no-pattern").build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(".pattern(");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/TaskResultTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TaskResultTest.java
@@ -1,0 +1,24 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TaskResultTest {
+
+    @Test
+    void taskResultOfDefensivelyCopiesAndDefaultsNullMetrics() {
+        var outputs = new HashMap<String, Object>();
+        outputs.put("k", "v");
+        var taskResult = TaskResult.of(outputs);
+        outputs.put("k2", "v2");
+
+        assertThat(taskResult.metrics()).isNull();
+        assertThat(taskResult.outputs()).containsExactlyEntriesOf(Map.of("k", "v"));
+
+        var nullOutputs = new TaskResult(null, null);
+        assertThat(nullOutputs.outputs()).isEmpty();
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/comparison/RunComparisonTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/comparison/RunComparisonTest.java
@@ -378,8 +378,9 @@ class RunComparisonTest {
         assertThat(result.evaluatorDeltas())
                 .allSatisfy(d -> assertThat(d.status()).isEqualTo(ComparisonStatus.UNCHANGED));
         assertThat(result.significantRegressedCount()).isZero();
-        // The pass rate alone drives the regression verdict.
-        assertThat(result.passRateSignificance().method()).isEqualTo("mcnemar");
+        // Scores are continuous, so the pass-rate test uses the permutation path; the pass rate alone
+        // still drives the regression verdict.
+        assertThat(result.passRateSignificance().method()).isEqualTo("permutation");
         assertThat(result.passRateRegressed()).isTrue();
         assertThat(result.hasRegressions()).isTrue();
         assertThat(result.regressedCount()).isEqualTo(12);
@@ -460,6 +461,86 @@ class RunComparisonTest {
                         () -> RunComparison.builder().bootstrapIterations(0).build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("bootstrapIterations");
+    }
+
+    @Test
+    void shouldNotUseMcNemarForSingleRunContinuousScores() {
+        // A single run per side but with continuous (non-binary) evaluator scores. The McNemar path
+        // would binarize on passProbability and discard the magnitude, so the continuous permutation
+        // path must be chosen instead.
+        List<RunResult> baseline = continuousRun(0.81, 0.79, 0.82, 0.78, 0.80, 0.83, 0.77, 0.80);
+        List<RunResult> candidate = continuousRun(0.80, 0.80, 0.81, 0.79, 0.79, 0.82, 0.78, 0.81);
+
+        RunComparisonResult result = RunComparison.create().compare(baseline, candidate);
+
+        assertThat(result.passRateSignificance().method()).isEqualTo("permutation");
+    }
+
+    @Test
+    void shouldStillUseMcNemarForGenuinelyBinarySingleRun() {
+        // Genuinely binary single run: behavior must be unchanged and still route through McNemar.
+        List<ItemResult> baseItems = new ArrayList<>();
+        List<ItemResult> candItems = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            baseItems.add(binaryItem(true));
+            candItems.add(binaryItem(false));
+        }
+        for (int i = 0; i < 2; i++) {
+            baseItems.add(binaryItem(false));
+            candItems.add(binaryItem(true));
+        }
+
+        RunComparisonResult result = RunComparison.create()
+                .compare(List.of(new RunResult(0, baseItems)), List.of(new RunResult(0, candItems)));
+
+        assertThat(result.passRateSignificance().method()).isEqualTo("mcnemar");
+        assertThat(result.passRateSignificance().significant()).isTrue();
+    }
+
+    @Test
+    void shouldPairOnlyOverlapWhenPositionPairedRunsDifferInLength() {
+        // No itemKey: items pair by position. Baseline has 3 items, candidate has 2. The overlapping
+        // two positions pair, and the single trailing baseline item surfaces as REMOVED rather than
+        // crashing or mis-aligning.
+        List<ItemResult> baseItems =
+                List.of(continuousItem("p0", 0.8), continuousItem("p1", 0.7), continuousItem("p2", 0.6));
+        List<ItemResult> candItems = List.of(continuousItem("c0", 0.8), continuousItem("c1", 0.7));
+
+        RunComparisonResult result = RunComparison.create()
+                .compare(List.of(new RunResult(0, baseItems)), List.of(new RunResult(0, candItems)));
+
+        // Two overlapping positions paired, one trailing baseline item unmatched (REMOVED).
+        assertThat(result.removedCount()).isEqualTo(1);
+        assertThat(result.addedCount()).isZero();
+        assertThat(result.items()).hasSize(3);
+        assertThat(result.items().stream()
+                        .filter(i -> i.status() == ComparisonStatus.REMOVED)
+                        .count())
+                .isEqualTo(1L);
+        // The trailing position is the one reported unmatched, not a mis-paired earlier index.
+        ItemComparison removed = result.items().stream()
+                .filter(i -> i.status() == ComparisonStatus.REMOVED)
+                .findFirst()
+                .orElseThrow();
+        assertThat(removed.key()).isEqualTo("item-2");
+    }
+
+    @Test
+    void shouldReportExtraCandidatePositionsAsAddedWhenCandidateLonger() {
+        List<ItemResult> baseItems = List.of(continuousItem("p0", 0.8), continuousItem("p1", 0.7));
+        List<ItemResult> candItems =
+                List.of(continuousItem("c0", 0.8), continuousItem("c1", 0.7), continuousItem("c2", 0.6));
+
+        RunComparisonResult result = RunComparison.create()
+                .compare(List.of(new RunResult(0, baseItems)), List.of(new RunResult(0, candItems)));
+
+        assertThat(result.addedCount()).isEqualTo(1);
+        assertThat(result.removedCount()).isZero();
+        ItemComparison added = result.items().stream()
+                .filter(i -> i.status() == ComparisonStatus.ADDED)
+                .findFirst()
+                .orElseThrow();
+        assertThat(added.key()).isEqualTo("item-2");
     }
 
     private static List<RunResult> continuousRun(double... scores) {

--- a/dokimos-core/src/test/java/dev/dokimos/core/conversation/ConversationSimulatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/conversation/ConversationSimulatorTest.java
@@ -177,4 +177,49 @@ class ConversationSimulatorTest {
         assertThat(trajectory.messages().get(0).content()).isEqualTo("First message");
         assertThat(trajectory.messages().get(2).content()).isEqualTo("Responding to: Reply #0");
     }
+
+    @Test
+    void shouldReturnPartialTrajectoryWhenSimulatedUserThrowsOnSecondTurn() {
+        SimulatedUser user = trajectory -> {
+            if (trajectory.userMessages().size() >= 1) {
+                throw new RuntimeException("simulated user blew up on turn 2");
+            }
+            return Message.user("First user message");
+        };
+
+        ConversationalApplication app = trajectory -> Message.assistant("Assistant reply");
+
+        ConversationSimulator simulator = ConversationSimulator.builder()
+                .simulatedUser(user)
+                .application(app)
+                .maxTurns(5)
+                .build();
+
+        ConversationTrajectory trajectory = simulator.simulate();
+
+        // First turn is preserved instead of losing the entire trajectory
+        assertThat(trajectory.turnCount()).isEqualTo(1);
+        assertThat(trajectory.userMessages()).hasSize(1);
+        assertThat(trajectory.userMessages().get(0).content()).isEqualTo("First user message");
+        assertThat(trajectory.metadata()).containsEntry("errorSource", "simulatedUser");
+        assertThat(trajectory.metadata().get("error").toString()).contains("turn 2");
+    }
+
+    @Test
+    void shouldSurfaceClearErrorWhenApplicationReturnsNull() {
+        SimulatedUser user = trajectory -> Message.user("User message");
+        ConversationalApplication app = trajectory -> null;
+
+        ConversationSimulator simulator = ConversationSimulator.builder()
+                .simulatedUser(user)
+                .application(app)
+                .maxTurns(3)
+                .build();
+
+        ConversationTrajectory trajectory = simulator.simulate();
+
+        assertThat(trajectory.userMessages()).hasSize(1);
+        assertThat(trajectory.metadata()).containsEntry("errorSource", "application");
+        assertThat(trajectory.metadata().get("error").toString()).contains("null");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/conversation/LLMSimulatedUserTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/conversation/LLMSimulatedUserTest.java
@@ -168,4 +168,21 @@ class LLMSimulatedUserTest {
 
         assertThat(message.content()).isEqualTo("Response with whitespace");
     }
+
+    @Test
+    void shouldSurfaceClearExceptionWhenJudgeReturnsNull() {
+        JudgeLM nullJudge = prompt -> null;
+
+        LLMSimulatedUser user = LLMSimulatedUser.builder().judge(nullJudge).build();
+
+        ConversationTrajectory trajectory = ConversationTrajectory.builder()
+                .userMessage("Previous user message")
+                .assistantMessage("Assistant reply")
+                .build();
+
+        assertThatThrownBy(() -> user.generateMessage(trajectory))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("JudgeLM")
+                .hasMessageContaining("null");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/conversation/TrajectoryEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/conversation/TrajectoryEvaluatorTest.java
@@ -354,4 +354,31 @@ class TrajectoryEvaluatorTest {
 
         assertThat(result.metadata()).containsEntry("turnCount", 2);
     }
+
+    @Test
+    void shouldTreatNonNumericScoreAsParseFailureNotSilentZero() {
+        JudgeLM mockJudge = prompt -> """
+                {"score": "high", "reason": "Great conversation"}
+                """;
+
+        TrajectoryEvaluator evaluator = TrajectoryEvaluator.builder()
+                .name("Test")
+                .judge(mockJudge)
+                .criterion(TrajectoryEvaluationCriteria.userSatisfaction())
+                .build();
+
+        ConversationTrajectory trajectory = ConversationTrajectory.builder()
+                .userMessage("Test")
+                .assistantMessage("Response")
+                .build();
+
+        EvalTestCase testCase =
+                EvalTestCase.builder().actualOutput("trajectory", trajectory).build();
+
+        EvalResult result = evaluator.evaluate(testCase);
+
+        // A non-numeric score must surface as a parse failure, not a silent 0.0 judgment
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("Failed to parse evaluation");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/AgentEvalCaseTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/AgentEvalCaseTest.java
@@ -1,0 +1,83 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.agents.ToolDefinition;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AgentEvalCaseTest {
+
+    private static final ToolDefinition SEARCH_TOOL = ToolDefinition.of(
+            "search_flights",
+            "Search for flights",
+            Map.of(
+                    "type",
+                    "object",
+                    "properties",
+                    Map.of(
+                            "origin", Map.of("type", "string"),
+                            "destination", Map.of("type", "string")),
+                    "required",
+                    List.of("origin", "destination")));
+
+    @Test
+    void shouldBuildValidTestCaseEvaluatedByToolCallValidityWithoutStringKeys() {
+        EvalTestCase testCase = AgentEvalCase.builder()
+                .input("Find me a flight from NYC to LAX")
+                .toolCalls(List.of(ToolCall.of("search_flights", Map.of("origin", "NYC", "destination", "LAX"))))
+                .tools(List.of(SEARCH_TOOL))
+                .build();
+
+        var result = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    void shouldReflectInvalidCallInScore() {
+        EvalTestCase testCase = AgentEvalCase.builder()
+                .toolCalls(List.of(
+                        ToolCall.of("search_flights", Map.of("origin", "NYC", "destination", "LAX")),
+                        ToolCall.of("search_flights", Map.of("origin", "NYC"))))
+                .tools(List.of(SEARCH_TOOL))
+                .build();
+
+        var result = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    void shouldPopulateExactlyTheKeysTheEvaluatorsRead() {
+        EvalTestCase testCase = AgentEvalCase.builder()
+                .input("hi")
+                .toolCalls(List.of(ToolCall.of("search_flights", Map.of("origin", "NYC", "destination", "LAX"))))
+                .tools(List.of(SEARCH_TOOL))
+                .expectedToolCalls(
+                        List.of(ToolCall.of("search_flights", Map.of("origin", "NYC", "destination", "LAX"))))
+                .tasks(List.of("Book a flight"))
+                .build();
+
+        assertThat(testCase.inputs()).containsKey("input");
+        assertThat(testCase.actualOutputs()).containsOnlyKeys("toolCalls");
+        assertThat(testCase.expectedOutputs()).containsOnlyKeys("toolCalls");
+        assertThat(testCase.metadata()).containsOnlyKeys("tools", "tasks");
+    }
+
+    @Test
+    void shouldOmitUnsetSlots() {
+        EvalTestCase testCase = AgentEvalCase.builder()
+                .toolCalls(List.of(ToolCall.of("search_flights", Map.of("origin", "NYC", "destination", "LAX"))))
+                .tools(List.of(SEARCH_TOOL))
+                .build();
+
+        assertThat(testCase.inputs()).isEmpty();
+        assertThat(testCase.expectedOutputs()).isEmpty();
+        assertThat(testCase.metadata()).containsOnlyKeys("tools");
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/TaskCompletionEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/TaskCompletionEvaluatorTest.java
@@ -200,4 +200,22 @@ class TaskCompletionEvaluatorTest {
 
         assertThat(result.score()).isEqualTo(1.0);
     }
+
+    @Test
+    void taskCompletionParsesProsePrefixedJudgeReply() {
+        JudgeLM mockJudge = prompt -> "Sure, here is my assessment:\n"
+                + "{\"tasks\": [{\"task\": \"Book hotel\", \"completed\": true, \"reason\": \"Done\"}]}";
+
+        var evaluator = TaskCompletionEvaluator.builder().judge(mockJudge).build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a hotel")
+                .metadata("tasks", List.of("Book hotel"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.reason()).contains("1/1");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolArgumentHallucinationEvaluatorTest.java
@@ -320,4 +320,22 @@ class ToolArgumentHallucinationEvaluatorTest {
 
         assertThat(result.score()).isEqualTo(1.0);
     }
+
+    @Test
+    void argumentHallucinationParsesProsePrefixedJudgeReply() {
+        JudgeLM mockJudge = prompt -> "Here are the verdicts:\n"
+                + "[{\"toolName\": \"search\", \"grounded\": true, \"reason\": \"From user input\"}]";
+
+        var evaluator =
+                ToolArgumentHallucinationEvaluator.builder().judge(mockJudge).build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Search for shoes")
+                .actualOutput("toolCalls", List.of(ToolCall.of("search", Map.of("q", "shoes"))))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolCallValidityEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolCallValidityEvaluatorTest.java
@@ -41,6 +41,28 @@ class ToolCallValidityEvaluatorTest {
                     "additionalProperties",
                     false));
 
+    private static final ToolDefinition INTEGER_TOOL = ToolDefinition.of(
+            "set_count",
+            "Set a count",
+            Map.of(
+                    "type",
+                    "object",
+                    "properties",
+                    Map.of("count", Map.of("type", "integer")),
+                    "required",
+                    List.of("count")));
+
+    private static final ToolDefinition NUMERIC_ENUM_TOOL = ToolDefinition.of(
+            "set_rating",
+            "Set a rating",
+            Map.of(
+                    "type",
+                    "object",
+                    "properties",
+                    Map.of("rating", Map.of("type", "integer", "enum", List.of(1, 2, 3))),
+                    "required",
+                    List.of("rating")));
+
     @Test
     void shouldReturnFullScoreWhenAllCallsValid() {
         var evaluator = ToolCallValidityEvaluator.builder().build();
@@ -301,6 +323,77 @@ class ToolCallValidityEvaluatorTest {
         var result = evaluator.evaluate(testCase);
 
         assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void integerParamAcceptsWholeNumberDouble() {
+        var evaluator = ToolCallValidityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("set_count", Map.of("count", 42.0))))
+                .metadata("tools", List.of(INTEGER_TOOL))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    void integerParamRejectsFractionalNumber() {
+        var evaluator = ToolCallValidityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("set_count", Map.of("count", 1.5))))
+                .metadata("tools", List.of(INTEGER_TOOL))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void numericEnumAcceptsEquivalentDouble() {
+        var evaluator = ToolCallValidityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("set_rating", Map.of("rating", 1.0))))
+                .metadata("tools", List.of(NUMERIC_ENUM_TOOL))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    void numericEnumRejectsOutOfSetWholeValue() {
+        var evaluator = ToolCallValidityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("toolCalls", List.of(ToolCall.of("set_rating", Map.of("rating", 5.0))))
+                .metadata("tools", List.of(NUMERIC_ENUM_TOOL))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void nonFiniteNumericArgScoresInvalidWithoutThrowing() {
+        var evaluator = ToolCallValidityEvaluator.builder().build();
+
+        for (Object value : List.of(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+            var testCase = EvalTestCase.builder()
+                    .actualOutput("toolCalls", List.of(ToolCall.of("set_rating", Map.of("rating", value))))
+                    .metadata("tools", List.of(NUMERIC_ENUM_TOOL))
+                    .build();
+
+            // Must not throw (a non-finite value previously made the enum check throw NumberFormatException).
+            assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+        }
     }
 
     @Test

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolTrajectoryEvaluatorTest.java
@@ -131,12 +131,25 @@ class ToolTrajectoryEvaluatorTest {
     @DisplayName("argument matching")
     class Arguments {
         @Test
-        @DisplayName("default ignores arguments")
-        void ignoresArgsByDefault() {
+        @DisplayName("default compares arguments")
+        void comparesArgsByDefault() {
             var actual = List.of(ToolCall.of("search", Map.of("q", "shoes")));
             var expected = List.of(ToolCall.of("search", Map.of("q", "boots")));
             var result = ToolTrajectoryEvaluator.builder()
                     .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .build()
+                    .evaluate(testCase(actual, expected));
+            assertThat(result.score()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("explicit IGNORE matcher compares names only")
+        void ignoreMatcherComparesNamesOnly() {
+            var actual = List.of(ToolCall.of("search", Map.of("q", "shoes")));
+            var expected = List.of(ToolCall.of("search", Map.of("q", "boots")));
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
                     .build()
                     .evaluate(testCase(actual, expected));
             assertThat(result.score()).isEqualTo(1.0);
@@ -154,6 +167,18 @@ class ToolTrajectoryEvaluatorTest {
                     .evaluate(testCase(actual, expected));
             // search args differ -> strict fails
             assertThat(result.score()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("default matcher passes under STRICT when arguments match")
+        void defaultMatcherPassesWhenArgumentsMatch() {
+            var actual = List.of(ToolCall.of("search", Map.of("q", "shoes")));
+            var expected = List.of(ToolCall.of("search", Map.of("q", "shoes")));
+            var result = ToolTrajectoryEvaluator.builder()
+                    .matchMode(ToolTrajectoryEvaluator.MatchMode.STRICT)
+                    .build()
+                    .evaluate(testCase(actual, expected));
+            assertThat(result.score()).isEqualTo(1.0);
         }
     }
 

--- a/dokimos-core/src/test/java/dev/dokimos/core/integration/AgentEvaluatorIT.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/integration/AgentEvaluatorIT.java
@@ -141,9 +141,11 @@ class AgentEvaluatorIT {
                         List.of(ToolCall.of("search_flights", Map.of()), ToolCall.of("book_hotel", Map.of())))
                 .build();
 
-        // ANY_ORDER tolerates whichever sequence the model picks for these two independent tools.
+        // ANY_ORDER tolerates whichever sequence the model picks for these two independent tools;
+        // IGNORE keeps this a name/order check since the expected calls carry no argument values.
         var trajectory = ToolTrajectoryEvaluator.builder()
                 .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
                 .build()
                 .evaluate(testCase);
         assertThat(trajectory.score()).isGreaterThanOrEqualTo(0.5);

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetArgumentsProvider.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetArgumentsProvider.java
@@ -3,6 +3,7 @@ package dev.dokimos.junit;
 import dev.dokimos.core.Dataset;
 import dev.dokimos.core.DatasetResolutionException;
 import dev.dokimos.core.DatasetResolverRegistry;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
@@ -45,18 +46,34 @@ public class DatasetArgumentsProvider implements ArgumentsProvider, AnnotationCo
 
     private Dataset loadDataset() {
         if (!inlineJson.isBlank()) {
-            return Dataset.fromJson(inlineJson);
+            return load("json()", "inline JSON", () -> Dataset.fromJson(inlineJson));
         }
 
         if (!inlineJsonl.isBlank()) {
-            return Dataset.fromJsonl(inlineJsonl);
+            return load("jsonl()", "inline JSONL", () -> Dataset.fromJsonl(inlineJsonl));
         }
 
         if (!uri.isBlank()) {
-            return DatasetResolverRegistry.getInstance().resolve(uri);
+            return load(
+                    "value()", uri, () -> DatasetResolverRegistry.getInstance().resolve(uri));
         }
 
         throw new DatasetResolutionException(
                 "Either `value()`, `json()`, or `jsonl()` must be specified in @DatasetSource");
+    }
+
+    /**
+     * Loads a dataset, wrapping any failure in a message that names {@code @DatasetSource}, the
+     * offending source, and the underlying cause so the JUnit user sees the real reason instead of an
+     * opaque arguments-provider error.
+     */
+    private Dataset load(String attribute, String source, Supplier<Dataset> loader) {
+        try {
+            return loader.get();
+        } catch (RuntimeException e) {
+            throw new DatasetResolutionException(
+                    "Failed to load dataset for @DatasetSource " + attribute + " '" + source + "': " + e.getMessage(),
+                    e);
+        }
     }
 }

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetRunExtension.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetRunExtension.java
@@ -1,6 +1,7 @@
 package dev.dokimos.junit;
 
 import dev.dokimos.core.Dataset;
+import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.Example;
 import dev.dokimos.core.ItemResult;
 import dev.dokimos.core.NoOpReporter;
@@ -9,16 +10,22 @@ import dev.dokimos.core.RunHandle;
 import dev.dokimos.core.RunStatus;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 
 /**
@@ -37,12 +44,20 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
  * {@link Reporter#flush() flushed} after completion. The extension never closes a reporter supplied
  * via {@link DatasetReporter}; that lifecycle belongs to the test class.
  */
-public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallback, TestExecutionExceptionHandler {
+public class DatasetRunExtension
+        implements BeforeEachCallback, AfterEachCallback, TestExecutionExceptionHandler, ParameterResolver {
 
     private static final Namespace NAMESPACE = Namespace.create(DatasetRunExtension.class);
 
     private static final String RUN_KEY = "run";
     private static final String EXAMPLE_KEY = "example";
+    private static final String RECORDER_KEY = "recorder";
+
+    /**
+     * Matches the JUnit platform unique-id segment for a parameterized invocation,
+     * {@code [test-template-invocation:#N]}, capturing the one-based invocation number.
+     */
+    private static final Pattern INVOCATION_SEGMENT = Pattern.compile("test-template-invocation:#(\\d+)");
 
     @Override
     public void beforeEach(ExtensionContext context) {
@@ -53,7 +68,7 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
 
         Dataset dataset = context.getStore(DatasetArgumentsProvider.NAMESPACE)
                 .get(DatasetArgumentsProvider.DATASET_KEY, Dataset.class);
-        Example example = exampleAt(dataset, run.nextIndex());
+        Example example = exampleAt(dataset, invocationIndex(context));
         context.getStore(NAMESPACE).put(EXAMPLE_KEY, example);
     }
 
@@ -78,8 +93,31 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
             return;
         }
 
-        ItemResult result = new ItemResult(example, Map.of(), List.of());
+        DatasetItemRecorder recorder = context.getStore(NAMESPACE).get(RECORDER_KEY, DatasetItemRecorder.class);
+        ItemResult result = recorder != null
+                ? new ItemResult(example, recorder.actualOutputs(), recorder.evalResults())
+                : new ItemResult(example, Map.of(), List.of());
         run.reporter().reportItem(run.handle(), result);
+    }
+
+    /**
+     * Supports an optional {@link DatasetItemRecorder} test-method parameter. When the test body
+     * declares it, {@link #afterEach} reports the outputs and eval results it captured; otherwise the
+     * reported item stays empty.
+     */
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == DatasetItemRecorder.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        DatasetItemRecorder recorder = new DatasetItemRecorder();
+        // The invocation-scoped store keeps one recorder per parameterized invocation.
+        extensionContext.getStore(NAMESPACE).put(RECORDER_KEY, recorder);
+        return recorder;
     }
 
     /**
@@ -129,6 +167,14 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
         if (source == null) {
             return Map.of();
         }
+        MetadataEntry[] entries = source.entries();
+        if (entries.length > 0) {
+            Map<String, Object> metadata = new LinkedHashMap<>();
+            for (MetadataEntry entry : entries) {
+                metadata.put(entry.key(), entry.value());
+            }
+            return metadata;
+        }
         String[] pairs = source.metadata();
         if (pairs.length == 0) {
             return Map.of();
@@ -142,6 +188,22 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
             metadata.put(pairs[i], pairs[i + 1]);
         }
         return metadata;
+    }
+
+    /**
+     * Returns the zero-based index of the example under test for the current invocation, derived from
+     * the parameterized invocation's unique id rather than a separate counter. This keeps the reported
+     * example tied to the actual argument even when invocations run out of order or in parallel.
+     * Returns {@code -1} when no invocation segment is present (the dataset is then not reported).
+     */
+    private int invocationIndex(ExtensionContext context) {
+        Matcher matcher = INVOCATION_SEGMENT.matcher(context.getUniqueId());
+        int oneBased = -1;
+        while (matcher.find()) {
+            oneBased = Integer.parseInt(matcher.group(1));
+        }
+        // JUnit numbers invocations as #1, #2, ...; the dataset index is one less.
+        return oneBased < 1 ? -1 : oneBased - 1;
     }
 
     private Example exampleAt(Dataset dataset, int index) {
@@ -182,6 +244,79 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
     }
 
     /**
+     * Collects the actual outputs and evaluation results a {@link DatasetSource} test body produced
+     * for one parameterized invocation. Declare it as a test-method parameter and populate it; the
+     * extension then reports an {@link ItemResult} carrying these values instead of an empty one.
+     *
+     * <p>
+     * A fresh recorder is supplied per invocation, so it need not be reset between examples.
+     */
+    public static final class DatasetItemRecorder {
+
+        private final Map<String, Object> actualOutputs = new LinkedHashMap<>();
+        private final List<EvalResult> evalResults = new ArrayList<>();
+
+        /**
+         * Records a single actual output under the given key.
+         *
+         * @param key the output key
+         * @param value the output value
+         * @return this recorder
+         */
+        public DatasetItemRecorder actualOutput(String key, Object value) {
+            actualOutputs.put(key, value);
+            return this;
+        }
+
+        /**
+         * Records multiple actual outputs, merging them with any already recorded.
+         *
+         * @param outputs the outputs to record
+         * @return this recorder
+         */
+        public DatasetItemRecorder actualOutputs(Map<String, Object> outputs) {
+            if (outputs != null) {
+                actualOutputs.putAll(outputs);
+            }
+            return this;
+        }
+
+        /**
+         * Records a single evaluation result.
+         *
+         * @param result the result to record
+         * @return this recorder
+         */
+        public DatasetItemRecorder evalResult(EvalResult result) {
+            if (result != null) {
+                evalResults.add(result);
+            }
+            return this;
+        }
+
+        /**
+         * Records multiple evaluation results.
+         *
+         * @param results the results to record
+         * @return this recorder
+         */
+        public DatasetItemRecorder evalResults(List<EvalResult> results) {
+            if (results != null) {
+                evalResults.addAll(results);
+            }
+            return this;
+        }
+
+        Map<String, Object> actualOutputs() {
+            return actualOutputs;
+        }
+
+        List<EvalResult> evalResults() {
+            return evalResults;
+        }
+    }
+
+    /**
      * Per-method run state held in the method-scoped store. When stored there it is closed once the
      * test method finishes all parameterized invocations, completing and flushing the run.
      *
@@ -195,7 +330,6 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
         private final Reporter reporter;
         private final RunHandle handle;
         private final boolean active;
-        private final AtomicInteger index = new AtomicInteger(0);
         private final AtomicInteger failures = new AtomicInteger(0);
 
         private RunState(Reporter reporter, RunHandle handle) {
@@ -224,10 +358,6 @@ public class DatasetRunExtension implements BeforeEachCallback, AfterEachCallbac
 
         RunHandle handle() {
             return handle;
-        }
-
-        int nextIndex() {
-            return index.getAndIncrement();
         }
 
         void recordFailure() {

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetRunExtension.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetRunExtension.java
@@ -200,7 +200,12 @@ public class DatasetRunExtension
         Matcher matcher = INVOCATION_SEGMENT.matcher(context.getUniqueId());
         int oneBased = -1;
         while (matcher.find()) {
-            oneBased = Integer.parseInt(matcher.group(1));
+            try {
+                oneBased = Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException e) {
+                // A pathologically large invocation number is not a usable index.
+                oneBased = -1;
+            }
         }
         // JUnit numbers invocations as #1, #2, ...; the dataset index is one less.
         return oneBased < 1 ? -1 : oneBased - 1;

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetSource.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/DatasetSource.java
@@ -69,4 +69,12 @@ public @interface DatasetSource {
      * {@link DatasetReporter} field is present. Defaults to no metadata.
      */
     String[] metadata() default {};
+
+    /**
+     * Run metadata as typed key-value entries (for example
+     * {@code {@MetadataEntry(key = "model", value = "gpt-4")}}). Forwarded to the reporter when a
+     * {@link DatasetReporter} field is present. When non-empty this takes precedence over
+     * {@link #metadata()}. Defaults to no metadata.
+     */
+    MetadataEntry[] entries() default {};
 }

--- a/dokimos-junit/src/main/java/dev/dokimos/junit/MetadataEntry.java
+++ b/dokimos-junit/src/main/java/dev/dokimos/junit/MetadataEntry.java
@@ -1,0 +1,28 @@
+package dev.dokimos.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A single typed run-metadata key-value pair for {@link DatasetSource#entries()}.
+ *
+ * <p>
+ * Prefer this over the alternating-string {@link DatasetSource#metadata()} form: the key and value
+ * are named explicitly, so a malformed pairing cannot slip past compilation.
+ */
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MetadataEntry {
+
+    /**
+     * The metadata key.
+     */
+    String key();
+
+    /**
+     * The metadata value.
+     */
+    String value();
+}

--- a/dokimos-junit/src/test/java/dev/dokimos/junit/DatasetRunExtensionTest.java
+++ b/dokimos-junit/src/test/java/dev/dokimos/junit/DatasetRunExtensionTest.java
@@ -12,14 +12,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.Example;
 import dev.dokimos.core.ItemResult;
 import dev.dokimos.core.Reporter;
 import dev.dokimos.core.RunHandle;
 import dev.dokimos.core.RunStatus;
+import dev.dokimos.junit.DatasetRunExtension.DatasetItemRecorder;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +34,8 @@ import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -78,15 +85,40 @@ class DatasetRunExtensionTest {
             }
             """;
 
+    private static final String TWO_EXAMPLES = """
+            {
+              "examples": [
+                {"input": "Capital of France?", "expectedOutput": "Paris"},
+                {"input": "Capital of Germany?", "expectedOutput": "Berlin"}
+              ]
+            }
+            """;
+
+    private static final String DISTINCT_EXAMPLES = """
+            {
+              "examples": [
+                {"input": "Capital of France?", "expectedOutput": "Paris"},
+                {"input": "Capital of Germany?", "expectedOutput": "Berlin"},
+                {"input": "Capital of Italy?", "expectedOutput": "Rome"},
+                {"input": "Capital of Spain?", "expectedOutput": "Madrid"}
+              ]
+            }
+            """;
+
+    /** Inputs actually passed to each invocation of the {@link DistinctFixture} test method, in order. */
+    private static final List<String> RECEIVED = new CopyOnWriteArrayList<>();
+
     @BeforeEach
     void setUp() {
         reporter = mock(Reporter.class);
         when(reporter.startRun(any(), anyMap())).thenReturn(new RunHandle("run-1"));
+        RECEIVED.clear();
     }
 
     @AfterEach
     void tearDown() {
         reporter = null;
+        RECEIVED.clear();
     }
 
     private static void run(Class<?> testClass) {
@@ -95,6 +127,28 @@ class DatasetRunExtensionTest {
                 .selectors(selectClass(testClass))
                 .build();
         launcher.execute(request);
+    }
+
+    private static TestExecutionSummary runWithSummary(Class<?> testClass) {
+        Launcher launcher = LauncherFactory.create();
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(testClass))
+                .build();
+        launcher.execute(request, listener);
+        return listener.getSummary();
+    }
+
+    private static String failureText(TestExecutionSummary summary) {
+        StringWriter writer = new StringWriter();
+        for (TestExecutionSummary.Failure failure : summary.getFailures()) {
+            for (Throwable t = failure.getException(); t != null; t = t.getCause()) {
+                writer.append(String.valueOf(t.getMessage())).append('\n');
+            }
+        }
+        // Include the full stack output as a fallback so wrapped causes are always covered.
+        summary.printFailuresTo(new PrintWriter(writer));
+        return writer.toString();
     }
 
     @Test
@@ -187,6 +241,69 @@ class DatasetRunExtensionTest {
         verify(reporter, never()).close();
     }
 
+    @Test
+    void reportedExampleMatchesTheExamplePassedToEachInvocation() {
+        run(DistinctFixture.class);
+
+        ArgumentCaptor<ItemResult> captor = ArgumentCaptor.forClass(ItemResult.class);
+        verify(reporter, times(4)).reportItem(any(), captor.capture());
+
+        List<String> reported = new ArrayList<>();
+        for (ItemResult result : captor.getAllValues()) {
+            reported.add(result.example().inputs().get("input").toString());
+        }
+
+        // The example reported for each invocation must be the one the test method actually received,
+        // regardless of how many invocations ran or in which order the store was written.
+        assertThat(reported).hasSize(4);
+        assertThat(reported).containsExactlyInAnyOrderElementsOf(RECEIVED);
+        assertThat(reported).containsExactlyElementsOf(RECEIVED);
+    }
+
+    @Test
+    void missingResourceProducesMessageNamingDatasetSourceAndResource() {
+        TestExecutionSummary summary = runWithSummary(MissingResourceFixture.class);
+
+        assertThat(summary.getTotalFailureCount()).isGreaterThan(0);
+
+        String text = failureText(summary);
+        assertThat(text).contains("@DatasetSource");
+        assertThat(text).contains("classpath:datasets/does-not-exist.json");
+    }
+
+    @Test
+    void recorderSuppliesActualOutputsAndEvalResults() {
+        run(RecordingFixture.class);
+
+        ArgumentCaptor<ItemResult> captor = ArgumentCaptor.forClass(ItemResult.class);
+        verify(reporter, times(2)).reportItem(any(), captor.capture());
+
+        for (ItemResult result : captor.getAllValues()) {
+            assertThat(result.actualOutputs())
+                    .containsEntry("output", "answer-for:" + result.example().input());
+            assertThat(result.evalResults()).hasSize(1);
+            assertThat(result.evalResults().get(0).name()).isEqualTo("exact");
+        }
+    }
+
+    @Test
+    void typedEntriesMetadataReachesStartedRun() {
+        run(TypedMetadataFixture.class);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(reporter).startRun(any(), captor.capture());
+        assertThat(captor.getValue()).containsEntry("model", "gpt-x").containsEntry("temperature", "0.2");
+    }
+
+    @Test
+    void legacyStringMetadataStillWorks() {
+        run(LegacyMetadataFixture.class);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(reporter).startRun(any(), captor.capture());
+        assertThat(captor.getValue()).containsEntry("model", "gpt-4").containsEntry("temperature", "0");
+    }
+
     static class PassingFixture {
 
         @DatasetReporter
@@ -245,6 +362,105 @@ class DatasetRunExtensionTest {
                 metadata = {"model", "gpt-4", "temperature", "0"})
         void withMetadata(Example example) {
             assertThat(example.input()).isNotBlank();
+        }
+    }
+
+    static class DistinctFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(json = DISTINCT_EXAMPLES)
+        void runs(Example example) {
+            RECEIVED.add(example.inputs().get("input").toString());
+        }
+    }
+
+    static class MissingResourceFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = NoOpForwarding.INSTANCE;
+
+        @ParameterizedTest
+        @DatasetSource("classpath:datasets/does-not-exist.json")
+        void runs(Example example) {
+            assertThat(example).isNotNull();
+        }
+    }
+
+    static class RecordingFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(json = TWO_EXAMPLES)
+        void records(Example example, DatasetItemRecorder recorder) {
+            recorder.actualOutput("output", "answer-for:" + example.input())
+                    .evalResult(EvalResult.success("exact", 1.0, "matched"));
+        }
+    }
+
+    static class TypedMetadataFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(
+                json = TWO_EXAMPLES,
+                entries = {
+                    @MetadataEntry(key = "model", value = "gpt-x"),
+                    @MetadataEntry(key = "temperature", value = "0.2")
+                })
+        void typed(Example example) {
+            assertThat(example.input()).isNotBlank();
+        }
+    }
+
+    static class LegacyMetadataFixture {
+
+        @DatasetReporter
+        static final Reporter reporter = FORWARDING;
+
+        @ParameterizedTest
+        @DatasetSource(
+                json = TWO_EXAMPLES,
+                metadata = {"model", "gpt-4", "temperature", "0"})
+        void legacy(Example example) {
+            assertThat(example.input()).isNotBlank();
+        }
+    }
+
+    /** No-op reporter for fixtures whose datasets fail to load before any invocation runs. */
+    private static final class NoOpForwarding implements Reporter {
+
+        static final NoOpForwarding INSTANCE = new NoOpForwarding();
+
+        @Override
+        public RunHandle startRun(String experimentName, Map<String, Object> metadata) {
+            return new RunHandle("noop");
+        }
+
+        @Override
+        public void reportItem(RunHandle handle, ItemResult result) {
+            // no-op
+        }
+
+        @Override
+        public void completeRun(RunHandle handle, RunStatus status) {
+            // no-op
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
         }
     }
 }

--- a/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogTraceCollectorTest.kt
+++ b/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogTraceCollectorTest.kt
@@ -3,6 +3,7 @@ package dev.dokimos.koog
 import dev.dokimos.core.EvalTestCase
 import dev.dokimos.core.agents.ToolCall
 import dev.dokimos.core.agents.ToolDefinition
+import dev.dokimos.core.evaluators.agents.ArgMatchMode
 import dev.dokimos.core.evaluators.agents.ArgumentMatcher
 import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator
 import dev.dokimos.core.evaluators.agents.ToolTrajectoryEvaluator
@@ -167,6 +168,7 @@ class KoogTraceCollectorTest {
         assertThat(
             ToolTrajectoryEvaluator.builder()
                 .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
                 .build()
                 .evaluate(testCase)
                 .score(),

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/Ext.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/Ext.kt
@@ -63,6 +63,20 @@ fun EvalTestCase(actualOutputs: Map<String, Any>): EvalTestCase =
     EvalTestCase.builder().actualOutputs(actualOutputs).build()
 
 /**
+ * Builds an [EvalTestCase] via the Java builder.
+ *
+ * An unambiguous 2-arg factory for the common case, avoiding the overload
+ * ambiguity of calling [EvalTestCase] with two positional [String] arguments.
+ */
+fun evalCase(input: String, actualOutput: String, expectedOutput: String? = null): EvalTestCase {
+    val builder = EvalTestCase.builder()
+        .input(input)
+        .actualOutput(actualOutput)
+    expectedOutput?.let { builder.expectedOutput(it) }
+    return builder.build()
+}
+
+/**
  * Builds an [EvalResult]
  */
 fun EvalResult(name: String, score: Double, threshold: Double, reason: String) =

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
@@ -198,6 +198,10 @@ class ExampleDsl {
         metadata.putAll(values)
     }
 
+    fun metadata(values: Map<String, Any>) {
+        metadata.putAll(values)
+    }
+
     fun build(): Example {
         val builder = Example.builder()
         inputs.forEach { (k, v) -> builder.input(k, v) }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/ExtTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/ExtTest.kt
@@ -103,4 +103,22 @@ class ExtTest {
         assertThat(testCase.actualOutputs()).containsEntry("output", "answer")
         assertThat(testCase.actualOutputs()).containsEntry("context", listOf("Doc1"))
     }
+
+    @Test
+    fun `evalCase builds with input and actualOutput`() {
+        val testCase = evalCase("q", "a")
+
+        assertThat(testCase.inputs()).containsEntry("input", "q")
+        assertThat(testCase.actualOutputs()).containsEntry("output", "a")
+        assertThat(testCase.expectedOutputs()).isEmpty()
+    }
+
+    @Test
+    fun `evalCase builds with expectedOutput`() {
+        val testCase = evalCase("q", "a", "exp")
+
+        assertThat(testCase.inputs()).containsEntry("input", "q")
+        assertThat(testCase.actualOutputs()).containsEntry("output", "a")
+        assertThat(testCase.expectedOutputs()).containsEntry("output", "exp")
+    }
 }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/CoreDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/CoreDslTest.kt
@@ -136,4 +136,15 @@ class CoreDslTest {
         assertThat(ex.expectedOutputs()["output"]).isEqualTo(nestedPayload)
         assertThat(ex.metadata()["trace"]).isEqualTo(mapOf("path" to listOf("root", "child")))
     }
+
+    @Test
+    fun `example DSL metadata(Map) populates metadata`() {
+        val example = example {
+            input("input", "q")
+            metadata(mapOf("traceId" to "abc123", "score" to 1))
+        }
+
+        assertThat(example.metadata()).containsEntry("traceId", "abc123")
+        assertThat(example.metadata()).containsEntry("score", 1)
+    }
 }

--- a/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
+++ b/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
@@ -100,7 +100,13 @@ public final class LangChain4jSupport {
      * @return a JudgeLM that delegates to the ChatModel
      */
     public static JudgeLM asJudge(ChatModel model) {
-        return model::chat;
+        return prompt -> {
+            String content = model.chat(prompt);
+            if (content == null) {
+                throw new IllegalStateException("Judge response content was null");
+            }
+            return content;
+        };
     }
 
     /**
@@ -121,7 +127,32 @@ public final class LangChain4jSupport {
      * @return a Task suitable for the Experiment
      */
     public static Task simpleTask(ChatModel model) {
-        return example -> Map.of(OUTPUT_KEY, model.chat(example.input()));
+        return simpleTask(model, OUTPUT_KEY);
+    }
+
+    /**
+     * Creates a simple {@link Task} for Q&amp;A evaluation that writes the response
+     * under a caller-chosen key.
+     *
+     * <p>Behaves like {@link #simpleTask(ChatModel)} but lets you override the
+     * {@link #OUTPUT_KEY default output key} when your evaluators or dataset expect
+     * a different name.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * ChatModel model = OpenAiChatModel.builder()...build();
+     * Task task = LangChain4jSupport.simpleTask(model, "answer");
+     * }</pre>
+     *
+     * @param model     the ChatModel to evaluate
+     * @param outputKey the key for the output in the result map
+     * @return a Task suitable for the Experiment
+     */
+    public static Task simpleTask(ChatModel model, String outputKey) {
+        return example -> {
+            String output = model.chat(example.input());
+            return Map.of(outputKey, output != null ? output : "");
+        };
     }
 
     /**
@@ -384,6 +415,18 @@ public final class LangChain4jSupport {
         String type = jsonType(element);
         if (type != null) {
             map.put("type", type);
+        }
+        if (element instanceof JsonArraySchema array && array.items() != null) {
+            map.put("items", elementToMap(array.items()));
+        } else if (element instanceof JsonObjectSchema object) {
+            Map<String, Object> properties = new LinkedHashMap<>();
+            if (object.properties() != null) {
+                object.properties().forEach((name, child) -> properties.put(name, elementToMap(child)));
+            }
+            map.put("properties", properties);
+            if (object.required() != null && !object.required().isEmpty()) {
+                map.put("required", List.copyOf(object.required()));
+            }
         }
         return map;
     }

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAgentTraceTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAgentTraceTest.java
@@ -9,6 +9,8 @@ import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.agents.AgentTrace;
 import dev.dokimos.core.agents.ToolCall;
 import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.agents.ArgMatchMode;
+import dev.dokimos.core.evaluators.agents.ArgumentMatcher;
 import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator;
 import dev.dokimos.core.evaluators.agents.ToolTrajectoryEvaluator;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -179,6 +181,7 @@ class LangChain4jAgentTraceTest {
                 .doesNotThrowAnyException();
         assertThat(ToolTrajectoryEvaluator.builder()
                         .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                        .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
                         .build()
                         .evaluate(tc)
                         .score())

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jSupportTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jSupportTest.java
@@ -3,10 +3,14 @@ package dev.dokimos.langchain4j;
 import static org.assertj.core.api.Assertions.*;
 
 import dev.dokimos.core.Example;
+import dev.dokimos.core.agents.ToolDefinition;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.service.Result;
@@ -179,5 +183,120 @@ class LangChain4jSupportTest {
         @SuppressWarnings("unchecked")
         List<String> context = (List<String>) outputs.get("context");
         assertThat(context).isEmpty();
+    }
+
+    @Test
+    void simpleTask_shouldProduceNonNullOutputWhenModelReturnsNull() {
+        var task = LangChain4jSupport.simpleTask(nullReturningModel());
+
+        var example = Example.of("What is the answer?", "42");
+        Map<String, Object> outputs = task.run(example);
+
+        assertThat(outputs).containsEntry("output", "");
+    }
+
+    @Test
+    void asJudge_shouldThrowWhenModelReturnsNull() {
+        var judge = LangChain4jSupport.asJudge(nullReturningModel());
+
+        assertThatThrownBy(() -> judge.generate("Test prompt"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Judge response content was null");
+    }
+
+    @Test
+    void toToolDefinition_shouldRecurseIntoArrayAndObjectParameters() {
+        JsonObjectSchema parameters = JsonObjectSchema.builder()
+                .addProperty(
+                        "tags",
+                        JsonArraySchema.builder()
+                                .items(JsonStringSchema.builder().build())
+                                .build())
+                .addProperty(
+                        "address",
+                        JsonObjectSchema.builder()
+                                .addProperty("city", JsonStringSchema.builder().build())
+                                .required("city")
+                                .build())
+                .build();
+
+        var specification = dev.langchain4j.agent.tool.ToolSpecification.builder()
+                .name("create_user")
+                .description("Creates a user")
+                .parameters(parameters)
+                .build();
+
+        ToolDefinition definition = LangChain4jSupport.toToolDefinition(specification);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties =
+                (Map<String, Object>) definition.inputSchema().get("properties");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> tags = (Map<String, Object>) properties.get("tags");
+        assertThat(tags).containsEntry("type", "array");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> items = (Map<String, Object>) tags.get("items");
+        assertThat(items).containsEntry("type", "string");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> address = (Map<String, Object>) properties.get("address");
+        assertThat(address).containsEntry("type", "object");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> addressProps = (Map<String, Object>) address.get("properties");
+        assertThat(addressProps).containsKey("city");
+        assertThat(address).containsEntry("required", List.of("city"));
+    }
+
+    @Test
+    void simpleTask_withOutputKey_shouldWriteUnderChosenKey() {
+        var task = LangChain4jSupport.simpleTask(respondingWith("The answer is 47"), "answer");
+
+        Map<String, Object> outputs = task.run(Example.of("What is 45+2?", "47"));
+
+        assertThat(outputs).containsEntry("answer", "The answer is 47").doesNotContainKey("output");
+    }
+
+    @Test
+    void simpleTask_noKeyOverload_shouldStillUseDefaultKey() {
+        var task = LangChain4jSupport.simpleTask(respondingWith("The answer is 47"));
+
+        Map<String, Object> outputs = task.run(Example.of("What is 45+2?", "47"));
+
+        assertThat(outputs).containsEntry(LangChain4jSupport.OUTPUT_KEY, "The answer is 47");
+    }
+
+    @Test
+    void simpleTask_withOutputKey_shouldGuardAgainstNullResponse() {
+        var task = LangChain4jSupport.simpleTask(nullReturningModel(), "answer");
+
+        Map<String, Object> outputs = task.run(Example.of("Question?", "Expected"));
+
+        assertThat(outputs.get("answer")).isNotNull().isEqualTo("");
+    }
+
+    private static ChatModel nullReturningModel() {
+        return new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                throw new UnsupportedOperationException("not used");
+            }
+
+            @Override
+            public String chat(String userMessage) {
+                return null;
+            }
+        };
+    }
+
+    private static ChatModel respondingWith(String response) {
+        return new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from(response))
+                        .build();
+            }
+        };
     }
 }

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/integration/LangChain4jToolTraceIT.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/integration/LangChain4jToolTraceIT.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.agents.AgentTrace;
+import dev.dokimos.core.evaluators.agents.ArgMatchMode;
+import dev.dokimos.core.evaluators.agents.ArgumentMatcher;
 import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator;
 import dev.dokimos.core.evaluators.agents.ToolTrajectoryEvaluator;
 import dev.dokimos.langchain4j.LangChain4jSupport;
@@ -72,6 +74,7 @@ class LangChain4jToolTraceIT {
 
         var trajectory = ToolTrajectoryEvaluator.builder()
                 .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
                 .build()
                 .evaluate(testCase);
         assertThat(trajectory.score()).isGreaterThanOrEqualTo(0.5);

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/DokimosMcpServer.java
@@ -97,13 +97,17 @@ public class DokimosMcpServer {
                                                 "description",
                                                 "Path to the dataset file (JSON, CSV, or JSONL)"),
                                 "model",
-                                        Map.of("type", "string", "description", "OpenAI model name (default: gpt-5.5)"),
+                                        Map.of(
+                                                "type",
+                                                "string",
+                                                "description",
+                                                "OpenAI model name (default: " + ToolHandlers.DEFAULT_MODEL + ")"),
                                 "temperature",
                                         Map.of(
                                                 "type",
                                                 "number",
                                                 "description",
-                                                "Sampling temperature, 0.0 to 2.0 (default: 0.0)"),
+                                                "Sampling temperature, 0.0 to 2.0 (omitted when unset, using the model default)"),
                                 "evaluator",
                                         Map.of(
                                                 "type",

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
@@ -45,6 +45,9 @@ public class ToolHandlers {
 
     private static final Logger log = LoggerFactory.getLogger(ToolHandlers.class);
 
+    /** Default OpenAI model used when a run_evaluation call does not specify one. */
+    public static final String DEFAULT_MODEL = "gpt-5.5";
+
     private final ResultStore store;
     private final ObjectMapper json;
 
@@ -59,46 +62,56 @@ public class ToolHandlers {
     public McpSchema.CallToolResult handleRunEvaluation(Map<String, Object> arguments) {
         try {
             String datasetPath = requireString(arguments, "dataset_path");
-            String model = stringOrDefault(arguments, "model", "gpt-5.5");
-            double temperature = doubleOrDefault(arguments, "temperature", 0.0);
+            String model = stringOrDefault(arguments, "model", DEFAULT_MODEL);
+            // Omit temperature entirely unless the caller specified one, so models that reject a
+            // non-default temperature do not reject the request.
+            Double temperature = nullableDouble(arguments, "temperature");
             String evaluatorType = stringOrDefault(arguments, "evaluator", "exact_match");
             String criteria = stringOrDefault(arguments, "criteria", null);
             double threshold = doubleOrDefault(arguments, "threshold", 0.7);
             String experimentName = stringOrDefault(arguments, "experiment_name", "mcp-evaluation");
 
             Dataset dataset = loadDataset(datasetPath);
+
+            // The OpenAI client owns a connection pool and dispatcher threads; close it once the run
+            // is done so those resources are always released. OpenAIClient exposes close() but does
+            // not implement AutoCloseable, so it cannot be a try-with-resources target.
             OpenAIClient openai = buildOpenAIClient();
-            Task task = buildTask(openai, model, temperature);
-            List<Evaluator> evaluators = buildEvaluators(evaluatorType, criteria, threshold, openai, model);
+            try {
+                Task task = buildTask(openai, model, temperature);
+                List<Evaluator> evaluators = buildEvaluators(evaluatorType, criteria, threshold, openai, model);
 
-            ExperimentResult result = Experiment.builder()
-                    .name(experimentName)
-                    .dataset(dataset)
-                    .task(task)
-                    .evaluators(evaluators)
-                    .build()
-                    .run();
+                ExperimentResult result = Experiment.builder()
+                        .name(experimentName)
+                        .dataset(dataset)
+                        .task(task)
+                        .evaluators(evaluators)
+                        .build()
+                        .run();
 
-            RunRecord record = toRunRecord(result, dataset, datasetPath, model, temperature);
-            store.save(record);
+                RunRecord record = toRunRecord(result, dataset, datasetPath, model, temperature);
+                store.save(record);
 
-            Map<String, Object> response = new LinkedHashMap<>();
-            response.put("run_id", record.id());
-            response.put("experiment_name", experimentName);
-            response.put("dataset", dataset.name());
-            response.put("model", model);
-            response.put("total_examples", result.totalCount());
-            response.put("pass_rate", result.passRate());
-            response.put("pass_count", (int) result.passCount());
-            response.put("fail_count", (int) result.failCount());
+                Map<String, Object> response = new LinkedHashMap<>();
+                response.put("run_id", record.id());
+                response.put("experiment_name", experimentName);
+                response.put("dataset", dataset.name());
+                response.put("model", model);
+                response.put("total_examples", result.totalCount());
+                response.put("pass_rate", result.passRate());
+                response.put("pass_count", (int) result.passCount());
+                response.put("fail_count", (int) result.failCount());
 
-            Map<String, Double> scores = new LinkedHashMap<>();
-            for (String name : result.evaluatorNames()) {
-                scores.put(name, result.averageScore(name));
+                Map<String, Double> scores = new LinkedHashMap<>();
+                for (String name : result.evaluatorNames()) {
+                    scores.put(name, result.averageScore(name));
+                }
+                response.put("average_scores", scores);
+
+                return textResult(response);
+            } finally {
+                openai.close();
             }
-            response.put("average_scores", scores);
-
-            return textResult(response);
         } catch (Exception e) {
             return errorResult("run_evaluation failed: " + e.getMessage());
         }
@@ -425,20 +438,21 @@ public class ToolHandlers {
         return OpenAIOkHttpClient.builder().apiKey(apiKey).build();
     }
 
-    private Task buildTask(OpenAIClient openai, String model, double temperature) {
+    private Task buildTask(OpenAIClient openai, String model, Double temperature) {
         return example -> {
             String input = example.input();
             if (input == null || input.isBlank()) {
                 return Map.of("output", "");
             }
 
-            ChatCompletion completion = openai.chat()
-                    .completions()
-                    .create(ChatCompletionCreateParams.builder()
-                            .model(ChatModel.of(model))
-                            .temperature(temperature)
-                            .addUserMessage(input)
-                            .build());
+            ChatCompletionCreateParams.Builder params = ChatCompletionCreateParams.builder()
+                    .model(ChatModel.of(model))
+                    .addUserMessage(input);
+            if (temperature != null) {
+                params.temperature(temperature);
+            }
+
+            ChatCompletion completion = openai.chat().completions().create(params.build());
 
             String output = completion.choices().get(0).message().content().orElse("");
             return Map.of("output", output);
@@ -482,7 +496,7 @@ public class ToolHandlers {
     }
 
     private RunRecord toRunRecord(
-            ExperimentResult result, Dataset dataset, String datasetPath, String model, double temperature) {
+            ExperimentResult result, Dataset dataset, String datasetPath, String model, Double temperature) {
         String runId = UUID.randomUUID().toString().substring(0, 8);
 
         Map<String, Double> averageScores = new LinkedHashMap<>();
@@ -570,6 +584,18 @@ public class ToolHandlers {
         Object value = args.get(key);
         if (value == null) {
             return defaultValue;
+        }
+        if (value instanceof Number n) {
+            return n.doubleValue();
+        }
+        return Double.parseDouble(value.toString());
+    }
+
+    // Returns the value as a double when the caller supplied it, or null when the key is absent.
+    private static Double nullableDouble(Map<String, Object> args, String key) {
+        Object value = args.get(key);
+        if (value == null) {
+            return null;
         }
         if (value instanceof Number n) {
             return n.doubleValue();

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/ToolHandlers.java
@@ -600,7 +600,11 @@ public class ToolHandlers {
         if (value instanceof Number n) {
             return n.doubleValue();
         }
-        return Double.parseDouble(value.toString());
+        try {
+            return Double.parseDouble(value.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("'" + key + "' must be a number, got: " + value);
+        }
     }
 
     private static int intOrDefault(Map<String, Object> args, String key, int defaultValue) {

--- a/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/JsonResultStore.java
+++ b/dokimos-mcp-server/src/main/java/dev/dokimos/mcp/store/JsonResultStore.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -106,8 +108,20 @@ public class JsonResultStore implements ResultStore {
     }
 
     private void writeAll(List<RunRecord> records) {
+        // Write to a temp file in the same directory and move it into place so a crash mid-write
+        // cannot truncate the live file (a partial file would make loadAll silently start fresh).
         try {
-            mapper.writeValue(filePath.toFile(), records);
+            Path tmp = Files.createTempFile(filePath.getParent(), ".mcp-results-", ".tmp");
+            try {
+                mapper.writeValue(tmp.toFile(), records);
+                try {
+                    Files.move(tmp, filePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                } catch (AtomicMoveNotSupportedException e) {
+                    Files.move(tmp, filePath, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } finally {
+                Files.deleteIfExists(tmp);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write results: " + filePath, e);
         }

--- a/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/ToolHandlersTest.java
+++ b/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/ToolHandlersTest.java
@@ -9,6 +9,7 @@ import dev.dokimos.mcp.store.JsonResultStore;
 import dev.dokimos.mcp.store.ResultStore;
 import dev.dokimos.mcp.store.RunRecord;
 import io.modelcontextprotocol.spec.McpSchema;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -376,6 +377,29 @@ class ToolHandlersTest {
         assertThat(result.isError()).isTrue();
         String text = ((McpSchema.TextContent) result.content().get(0)).text();
         assertThat(text).contains("Unsupported dataset format");
+    }
+
+    @Test
+    void defaultModelConstantIsTheSingleAdvertisedDefault() throws Exception {
+        // The run_evaluation tool schema advertises the model default. It must be derived from the
+        // same constant the handler falls back to, so the two cannot drift.
+        McpSchema.JsonSchema schema = runEvaluationSchema();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> modelProperty =
+                (Map<String, Object>) schema.properties().get("model");
+        String advertised = modelProperty.get("description").toString();
+
+        assertThat(ToolHandlers.DEFAULT_MODEL).isNotBlank();
+        assertThat(advertised).contains(ToolHandlers.DEFAULT_MODEL);
+        assertThat(advertised).isEqualTo("OpenAI model name (default: " + ToolHandlers.DEFAULT_MODEL + ")");
+    }
+
+    private static McpSchema.JsonSchema runEvaluationSchema() throws Exception {
+        Method method = DokimosMcpServer.class.getDeclaredMethod("runEvaluationTool");
+        method.setAccessible(true);
+        McpSchema.Tool tool = (McpSchema.Tool) method.invoke(null);
+        return tool.inputSchema();
     }
 
     private Map<String, Object> parseResponse(McpSchema.CallToolResult result) throws Exception {

--- a/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/store/JsonResultStoreTest.java
+++ b/dokimos-mcp-server/src/test/java/dev/dokimos/mcp/store/JsonResultStoreTest.java
@@ -2,6 +2,10 @@ package dev.dokimos.mcp.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
@@ -16,11 +20,13 @@ class JsonResultStoreTest {
     @TempDir
     Path tempDir;
 
+    private Path file;
     private JsonResultStore store;
 
     @BeforeEach
     void setUp() {
-        store = new JsonResultStore(tempDir.resolve("test-results.json"));
+        file = tempDir.resolve("test-results.json");
+        store = new JsonResultStore(file);
     }
 
     @Test
@@ -119,6 +125,44 @@ class JsonResultStoreTest {
         assertThat(loaded.items()).hasSize(1);
         assertThat(loaded.items().get(0).input()).isEqualTo("What is 2+2?");
         assertThat(loaded.items().get(0).evaluations().get(0).evaluator()).isEqualTo("Exact Match");
+    }
+
+    @Test
+    void saveThenLoadRoundTrips() {
+        store.save(sampleRecord("run-1", "exp-1", "ds-a"));
+
+        RunRecord loaded = store.get("run-1").orElseThrow();
+        assertThat(loaded.experimentName()).isEqualTo("exp-1");
+        assertThat(loaded.datasetName()).isEqualTo("ds-a");
+        assertThat(loaded.passRate()).isEqualTo(0.75);
+    }
+
+    @Test
+    void overwriteSaveKeepsValidJsonWithPriorRecordsSurviving() throws Exception {
+        store.save(sampleRecord("run-1", "exp-1", "ds-a"));
+        store.save(sampleRecord("run-2", "exp-2", "ds-b"));
+
+        // The live file must be readable as a well-formed JSON array after the second write.
+        byte[] bytes = Files.readAllBytes(file);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        List<RunRecord> parsed = mapper.readValue(bytes, new TypeReference<List<RunRecord>>() {});
+        assertThat(parsed).extracting(RunRecord::id).containsExactlyInAnyOrder("run-1", "run-2");
+
+        // And the prior record survives the overwrite when read back through the store.
+        assertThat(store.get("run-1")).isPresent();
+        assertThat(store.get("run-2")).isPresent();
+        assertThat(store.list(null, 0)).hasSize(2);
+    }
+
+    @Test
+    void overwriteLeavesNoStrayTempFilesBehind() throws Exception {
+        store.save(sampleRecord("run-1", "exp-1", "ds-a"));
+        store.save(sampleRecord("run-2", "exp-2", "ds-b"));
+
+        try (var entries = Files.list(tempDir)) {
+            assertThat(entries).containsExactly(file);
+        }
     }
 
     private static RunRecord sampleRecord(String id, String experiment, String dataset) {

--- a/dokimos-server-client/src/main/java/dev/dokimos/server/client/DokimosServerReporter.java
+++ b/dokimos-server-client/src/main/java/dev/dokimos/server/client/DokimosServerReporter.java
@@ -12,7 +12,14 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +30,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +48,9 @@ public class DokimosServerReporter implements Reporter {
     private static final long BATCH_TIMEOUT_MS = 500;
     private static final int MAX_RETRIES = 3;
     private static final long INITIAL_BACKOFF_MS = 100;
+    // Upper bound on an honored Retry-After so a large (or hostile) value cannot park the single
+    // worker thread for an unbounded time and stall delivery for every run.
+    private static final long MAX_RETRY_AFTER_MS = 60_000;
 
     /** Default API version when none is specified. */
     public static final String DEFAULT_API_VERSION = "v1";
@@ -55,8 +66,12 @@ public class DokimosServerReporter implements Reporter {
     private final AtomicBoolean running;
     private final AtomicInteger pendingItems;
     private final AtomicInteger inFlight;
+    private final AtomicInteger failedItems;
     private final ConcurrentHashMap<String, AtomicInteger> pendingByRun;
     private final Object flushLock;
+    private final Consumer<ItemDeliveryFailure> onItemDeliveryFailure;
+    private final Path spoolDirectory;
+    private final Object spoolLock;
 
     private DokimosServerReporter(Builder builder) {
         this.serverUrl = builder.serverUrl.endsWith("/")
@@ -74,8 +89,12 @@ public class DokimosServerReporter implements Reporter {
         this.running = new AtomicBoolean(true);
         this.pendingItems = new AtomicInteger(0);
         this.inFlight = new AtomicInteger(0);
+        this.failedItems = new AtomicInteger(0);
         this.pendingByRun = new ConcurrentHashMap<>();
         this.flushLock = new Object();
+        this.onItemDeliveryFailure = builder.onItemDeliveryFailure;
+        this.spoolDirectory = builder.spoolDirectory;
+        this.spoolLock = new Object();
 
         this.workerThread = new Thread(this::processQueue, "dokimos-reporter-worker");
         this.workerThread.setDaemon(true);
@@ -133,6 +152,15 @@ public class DokimosServerReporter implements Reporter {
     /** Package-private for tests. Item POSTs currently in flight. */
     int inFlightCount() {
         return inFlight.get();
+    }
+
+    /**
+     * Number of items permanently dropped after exhausting all delivery retries.
+     *
+     * @return the count of items that could not be delivered to the server
+     */
+    public int getFailedItemCount() {
+        return failedItems.get();
     }
 
     @Override
@@ -294,19 +322,16 @@ public class DokimosServerReporter implements Reporter {
             Map<String, String> headers =
                     Map.of("Idempotency-Key", UUID.randomUUID().toString());
 
-            // Counters are decremented in finally on every path so flush() cannot hang.
+            // Counters are decremented in finally on every path so flush() cannot hang. Permanent-failure
+            // accounting (count, spool, callback) runs before the finally so it is complete by the time
+            // flush() observes inFlight == 0; the callback contract forbids re-entrant flush()/close().
             inFlight.incrementAndGet();
             try {
                 String response = executeWithRetry("POST", url, body, headers);
                 if (response != null) {
                     LOGGER.debug("Sent batch of {} items to run {}", items.size(), runId);
                 } else {
-                    // Permanent failure: surface the loss; durable spooling is out of scope.
-                    LOGGER.error(
-                            "Failed to deliver {} items for run {} after {} retries; these items were NOT recorded",
-                            items.size(),
-                            runId,
-                            MAX_RETRIES);
+                    handlePermanentFailure(runId, items);
                 }
             } finally {
                 inFlight.decrementAndGet();
@@ -321,6 +346,48 @@ public class DokimosServerReporter implements Reporter {
                     flushLock.notifyAll();
                 }
             }
+        }
+    }
+
+    private void handlePermanentFailure(String runId, List<ItemResult> items) {
+        LOGGER.error(
+                "Failed to deliver {} items for run {} after {} retries; these items were NOT recorded",
+                items.size(),
+                runId,
+                MAX_RETRIES);
+        failedItems.addAndGet(items.size());
+
+        if (spoolDirectory != null) {
+            spoolFailedBatch(runId, items);
+        }
+
+        if (onItemDeliveryFailure != null) {
+            try {
+                onItemDeliveryFailure.accept(new ItemDeliveryFailure(runId, items.size(), List.copyOf(items)));
+            } catch (RuntimeException e) {
+                LOGGER.warn("onItemDeliveryFailure callback threw for run {}: {}", runId, e.getMessage());
+            }
+        }
+    }
+
+    private void spoolFailedBatch(String runId, List<ItemResult> items) {
+        // Append one JSON object per line ({"runId":..,"items":[..]}); a JSON-lines (NDJSON) file
+        // a future replay step can read back line by line. Automatic replay is out of scope here.
+        try {
+            Files.createDirectories(spoolDirectory);
+            Path spoolFile = spoolDirectory.resolve("failed-items.ndjson");
+
+            List<Map<String, Object>> itemsPayload =
+                    items.stream().map(this::itemResultToMap).toList();
+            Map<String, Object> line = Map.of("runId", runId, "items", itemsPayload);
+            String json = objectMapper.writeValueAsString(line) + System.lineSeparator();
+
+            synchronized (spoolLock) {
+                Files.writeString(
+                        spoolFile, json, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to spool {} undelivered items for run {}: {}", items.size(), runId, e.getMessage());
         }
     }
 
@@ -400,6 +467,8 @@ public class DokimosServerReporter implements Reporter {
     private String executeWithRetry(String method, String url, Map<String, Object> body, Map<String, String> headers) {
         int attempt = 0;
         long backoff = INITIAL_BACKOFF_MS;
+        // When set by a Retry-After header, overrides the exponential backoff for the next wait.
+        long retryAfterMs = -1;
 
         while (attempt < MAX_RETRIES) {
             attempt++;
@@ -438,12 +507,18 @@ public class DokimosServerReporter implements Reporter {
                     return response.body();
                 }
 
-                if (response.statusCode() >= 400 && response.statusCode() < 500) {
+                // 429 (Too Many Requests) is transient and retryable; prefer the Retry-After hint
+                // for the next wait when present. Other 4xx remain terminal.
+                if (response.statusCode() == 429) {
+                    retryAfterMs = parseRetryAfterMs(
+                            response.headers().firstValue("Retry-After").orElse(null));
+                    LOGGER.debug("Rate limited (429), attempt {} of {}", attempt, MAX_RETRIES);
+                } else if (response.statusCode() >= 400 && response.statusCode() < 500) {
                     LOGGER.warn("Client error {} for {} {}", response.statusCode(), method, url);
                     return null;
+                } else {
+                    LOGGER.debug("Server error {}, attempt {} of {}", response.statusCode(), attempt, MAX_RETRIES);
                 }
-
-                LOGGER.debug("Server error {}, attempt {} of {}", response.statusCode(), attempt, MAX_RETRIES);
 
             } catch (IOException | InterruptedException e) {
                 LOGGER.debug("Request failed, attempt {} of {}: {}", attempt, MAX_RETRIES, e.getMessage());
@@ -455,8 +530,9 @@ public class DokimosServerReporter implements Reporter {
 
             if (attempt < MAX_RETRIES) {
                 try {
-                    Thread.sleep(backoff);
+                    Thread.sleep(retryAfterMs >= 0 ? retryAfterMs : backoff);
                     backoff *= 2;
+                    retryAfterMs = -1;
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return null;
@@ -468,7 +544,51 @@ public class DokimosServerReporter implements Reporter {
         return null;
     }
 
+    /**
+     * Parses a Retry-After header (RFC 7231 delay-seconds or HTTP-date) into milliseconds, clamped to
+     * {@link #MAX_RETRY_AFTER_MS}. Returns -1 when the header is absent or unparseable.
+     */
+    private static long parseRetryAfterMs(String headerValue) {
+        if (headerValue == null || headerValue.isBlank()) {
+            return -1;
+        }
+        String trimmed = headerValue.trim();
+        long millis;
+        try {
+            long seconds = Long.parseLong(trimmed);
+            if (seconds <= 0) {
+                return 0;
+            }
+            // Overflow-safe: cap before multiplying so a huge value cannot wrap negative.
+            millis = seconds > MAX_RETRY_AFTER_MS / 1000 ? MAX_RETRY_AFTER_MS : seconds * 1000;
+        } catch (NumberFormatException notSeconds) {
+            try {
+                long until = ZonedDateTime.parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME)
+                                .toInstant()
+                                .toEpochMilli()
+                        - System.currentTimeMillis();
+                millis = Math.max(0, until);
+            } catch (DateTimeParseException notDate) {
+                return -1;
+            }
+        }
+        return Math.min(millis, MAX_RETRY_AFTER_MS);
+    }
+
     private record QueuedItem(RunHandle handle, ItemResult result) {}
+
+    /**
+     * Describes a batch of items permanently dropped after all delivery retries were exhausted.
+     *
+     * @param runId the run the items belonged to
+     * @param itemCount the number of items in the dropped batch
+     * @param items the dropped item results
+     */
+    public record ItemDeliveryFailure(String runId, int itemCount, List<ItemResult> items) {
+        public ItemDeliveryFailure {
+            items = List.copyOf(items);
+        }
+    }
 
     /** Builder for {@link DokimosServerReporter}. */
     public static class Builder {
@@ -477,6 +597,8 @@ public class DokimosServerReporter implements Reporter {
         private String apiVersion;
         private String apiKey;
         private HttpClient httpClient;
+        private Consumer<ItemDeliveryFailure> onItemDeliveryFailure;
+        private Path spoolDirectory;
 
         private Builder() {}
 
@@ -507,6 +629,28 @@ public class DokimosServerReporter implements Reporter {
         /** Package-private: inject a custom HTTP client for tests. */
         Builder httpClient(HttpClient httpClient) {
             this.httpClient = httpClient;
+            return this;
+        }
+
+        /**
+         * Callback invoked when a batch of items is permanently dropped after all delivery retries.
+         * The callback runs on the reporter's background worker thread, so keep it lightweight and do
+         * NOT call {@code flush()}, {@code close()}, or {@code reportItem(...)} on this reporter from it;
+         * doing so re-enters the worker and stalls delivery. Exceptions thrown by the callback are
+         * caught and logged.
+         */
+        public Builder onItemDeliveryFailure(Consumer<ItemDeliveryFailure> onItemDeliveryFailure) {
+            this.onItemDeliveryFailure = onItemDeliveryFailure;
+            return this;
+        }
+
+        /**
+         * Opt-in durable spool directory. When set, permanently-failed item batches are appended as
+         * JSON lines to {@code failed-items.ndjson} in this directory so a transient outage past all
+         * retries does not silently lose data. Defaults to {@code null} (disabled).
+         */
+        public Builder spoolDirectory(Path spoolDirectory) {
+            this.spoolDirectory = spoolDirectory;
             return this;
         }
 

--- a/dokimos-server-client/src/test/java/dev/dokimos/server/client/DokimosServerReporterTest.java
+++ b/dokimos-server-client/src/test/java/dev/dokimos/server/client/DokimosServerReporterTest.java
@@ -17,12 +17,16 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class DokimosServerReporterTest {
 
@@ -33,8 +37,11 @@ class DokimosServerReporterTest {
 
     // Item POST response control for the recording handler.
     private volatile boolean alwaysFailItems = false;
+    private volatile boolean alwaysRateLimitItems = false;
     private volatile boolean failFirstItemPost = false;
     private volatile long itemSendDelayMillis = 0;
+    // -1 means no Retry-After header on the 429 responses.
+    private volatile long retryAfterSeconds = -1;
     private final java.util.concurrent.atomic.AtomicInteger itemPostAttempts =
             new java.util.concurrent.atomic.AtomicInteger(0);
 
@@ -486,6 +493,107 @@ class DokimosServerReporterTest {
         }
     }
 
+    @Test
+    void shouldRetryItemPostOn429ThenCountAsFailedAfterRetriesExhausted() {
+        alwaysRateLimitItems = true;
+
+        try (var reporter = createReporter()) {
+            RunHandle handle = reporter.startRun("test", Map.of());
+            recordedRequests.clear();
+            itemPostAttempts.set(0);
+
+            reporter.reportItem(handle, createItemResult("q1", "a1"));
+            reporter.flush();
+
+            // 429 is retryable like a 5xx: the same logical POST is attempted MAX_RETRIES times.
+            assertThat(itemPostAttempts.get()).isEqualTo(3);
+            // After all retries are exhausted, the batch is permanently dropped and counted.
+            assertThat(reporter.getFailedItemCount()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void shouldPreferRetryAfterHeaderForBackoffOn429() {
+        alwaysRateLimitItems = true;
+        retryAfterSeconds = 1;
+
+        try (var reporter = createReporter()) {
+            RunHandle handle = reporter.startRun("test", Map.of());
+            recordedRequests.clear();
+            itemPostAttempts.set(0);
+
+            long start = System.currentTimeMillis();
+            reporter.reportItem(handle, createItemResult("q1", "a1"));
+            reporter.flush();
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertThat(itemPostAttempts.get()).isEqualTo(3);
+            // Two inter-attempt waits at a 1s Retry-After each dominate the default exponential
+            // backoff (100ms, 200ms), so the total must clearly exceed the exponential lower bound.
+            assertThat(elapsed).isGreaterThanOrEqualTo(1500);
+        }
+    }
+
+    @Test
+    void shouldFireFailureCallbackAndCountWhenBatchPermanentlyDropped() {
+        alwaysRateLimitItems = true;
+        AtomicReference<DokimosServerReporter.ItemDeliveryFailure> captured = new AtomicReference<>();
+
+        try (var reporter = DokimosServerReporter.builder()
+                .serverUrl(serverUrl)
+                .projectName("my-project")
+                .onItemDeliveryFailure(captured::set)
+                .build()) {
+            RunHandle handle = reporter.startRun("test", Map.of());
+            recordedRequests.clear();
+            itemPostAttempts.set(0);
+
+            reporter.reportItem(handle, createItemResult("q1", "a1"));
+            reporter.reportItem(handle, createItemResult("q2", "a2"));
+            reporter.flush();
+
+            assertThat(reporter.getFailedItemCount()).isEqualTo(2);
+
+            DokimosServerReporter.ItemDeliveryFailure failure = captured.get();
+            assertThat(failure).isNotNull();
+            assertThat(failure.runId()).isEqualTo("test-run-123");
+            assertThat(failure.itemCount()).isEqualTo(2);
+            assertThat(failure.items()).hasSize(2);
+        }
+    }
+
+    @Test
+    void shouldWriteFailedBatchToSpoolFileWhenSpoolDirectorySet(@TempDir Path spoolDir) throws Exception {
+        alwaysRateLimitItems = true;
+
+        try (var reporter = DokimosServerReporter.builder()
+                .serverUrl(serverUrl)
+                .projectName("my-project")
+                .spoolDirectory(spoolDir)
+                .build()) {
+            RunHandle handle = reporter.startRun("test", Map.of());
+            recordedRequests.clear();
+            itemPostAttempts.set(0);
+
+            reporter.reportItem(handle, createItemResult("q1", "a1"));
+            reporter.flush();
+
+            assertThat(reporter.getFailedItemCount()).isEqualTo(1);
+
+            Path spoolFile = spoolDir.resolve("failed-items.ndjson");
+            assertThat(spoolFile).exists();
+
+            List<String> lines = Files.readAllLines(spoolFile, StandardCharsets.UTF_8);
+            assertThat(lines).hasSize(1);
+
+            JsonNode line = objectMapper.readTree(lines.get(0));
+            assertThat(line.get("runId").asText()).isEqualTo("test-run-123");
+            assertThat(line.get("items")).hasSize(1);
+            assertThat(line.get("items").get(0).path("inputs").path("input").asText())
+                    .isEqualTo("q1");
+        }
+    }
+
     private DokimosServerReporter createReporter() {
         return DokimosServerReporter.builder()
                 .serverUrl(serverUrl)
@@ -518,6 +626,9 @@ class DokimosServerReporterTest {
                 statusCode = 201;
             } else if (path.contains("/items")) {
                 statusCode = itemStatusFor();
+                if (statusCode == 429 && retryAfterSeconds >= 0) {
+                    exchange.getResponseHeaders().add("Retry-After", String.valueOf(retryAfterSeconds));
+                }
                 response = statusCode >= 200 && statusCode < 300 ? "{\"status\": \"ok\"}" : "{\"error\": \"boom\"}";
             } else if (method.equals("PATCH")) {
                 response = "{\"status\": \"completed\"}";
@@ -539,10 +650,14 @@ class DokimosServerReporterTest {
                     Thread.currentThread().interrupt();
                 }
             }
+            int attempt = itemPostAttempts.getAndIncrement();
+            if (alwaysRateLimitItems) {
+                return 429;
+            }
             if (alwaysFailItems) {
                 return 500;
             }
-            if (failFirstItemPost && itemPostAttempts.getAndIncrement() == 0) {
+            if (failFirstItemPost && attempt == 0) {
                 return 500;
             }
             return 201;

--- a/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
+++ b/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
@@ -217,7 +217,7 @@ public final class SpringAiSupport {
         Map<String, Object> metadata = new HashMap<>(result.metadata());
         metadata.put("score", (float) result.score());
 
-        return new EvaluationResponse(result.success(), result.reason(), metadata);
+        return new EvaluationResponse(result.success(), (float) result.score(), result.reason(), metadata);
     }
 
     private static final ObjectMapper TOOL_ARG_MAPPER = new ObjectMapper();

--- a/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAgentTraceTest.java
+++ b/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAgentTraceTest.java
@@ -9,6 +9,8 @@ import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.agents.AgentTrace;
 import dev.dokimos.core.agents.ToolCall;
 import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.agents.ArgMatchMode;
+import dev.dokimos.core.evaluators.agents.ArgumentMatcher;
 import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator;
 import dev.dokimos.core.evaluators.agents.ToolTrajectoryEvaluator;
 import java.util.List;
@@ -181,6 +183,7 @@ class SpringAiAgentTraceTest {
                 .doesNotThrowAnyException();
         assertThat(ToolTrajectoryEvaluator.builder()
                         .matchMode(ToolTrajectoryEvaluator.MatchMode.ANY_ORDER)
+                        .argumentMatcher(ArgumentMatcher.of(ArgMatchMode.IGNORE))
                         .build()
                         .evaluate(testCase)
                         .score())

--- a/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiSupportTest.java
+++ b/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiSupportTest.java
@@ -156,6 +156,17 @@ class SpringAiSupportTest {
     }
 
     @Test
+    void toEvaluationResponse_shouldPopulateScoreField() {
+        EvalResult result = EvalResult.success("relevancy", 0.87, "Highly relevant");
+
+        EvaluationResponse response = SpringAiSupport.toEvaluationResponse(result);
+
+        assertThat(response.getScore()).isEqualTo(0.87f);
+        assertThat(response.getMetadata()).containsEntry("score", 0.87f);
+        assertThat(response.isPass()).isTrue();
+    }
+
+    @Test
     void toEvaluationResponse_shouldMapReason() {
         EvalResult result = EvalResult.success("coherence", 0.92, "The response is well-structured and coherent");
 


### PR DESCRIPTION
## Summary
Fixes bugs from a review of the JVM modules (`dokimos-core` and the adapters) and adds DX, behavior, and additive-API changes.

## Behavior changes
- Experiments isolate per-item failures: one throwing task/evaluator no longer aborts the whole run (the item is recorded failed). `Experiment.builder()` rejects an empty dataset or zero evaluators.
- CSV loading is RFC 4180 compliant (quoted commas/newlines, `""` escapes, preserved whitespace, BOM).
- LLM judge replies tolerate prose around the JSON; `LLMJudge` normalizes a custom `scoreRange` to 0..1; `ToolTrajectory` default now compares arguments; the server reporter retries HTTP 429.

## New (additive) APIs
`Dataset.load(pathOrUri)`, `MeasuredTask`/`TaskResult` + `Experiment.measuredTask`, `autoCloseReporter`, reporter `getFailedItemCount()`/`onItemDeliveryFailure`/`spoolDirectory`, JUnit `DatasetItemRecorder` + typed `@MetadataEntry`, Kotlin `evalCase` + `ExampleDsl.metadata(Map)`, `LangChain4j.simpleTask(model, outputKey)`, `AgentEvalCase`.