### PR TITLE
Fix mobile overflow and make docs search a Cmd+K modal

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -144,14 +144,13 @@ const config: Config = {
 
   themes: [
     [
-      // Offline search on "/"; the Velm chat widget keeps Cmd/Ctrl+K.
+      // Offline search index. src/theme/SearchBar owns the Cmd+K shortcut.
       require.resolve("@easyops-cn/docusaurus-search-local"),
       {
         hashed: true,
         indexBlog: false,
         docsRouteBasePath: "/",
-        searchBarShortcut: true,
-        searchBarShortcutKeymap: "/",
+        searchBarShortcut: false,
       },
     ],
   ],

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -92,6 +92,9 @@
   --dok-code-text: #d7dbe2;
   --dok-code-dot: #2a2f38;
   --dok-on-primary: #1a1205;
+
+  /* Light-stroked search icon; the default is dark and vanishes on the dark input. */
+  --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf8,<svg fill="%238a929e" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" height="16px" width="16px"><path d="M6.02945,10.20327a4.17382,4.17382,0,1,1,4.17382-4.17382A4.15609,4.15609,0,0,1,6.02945,10.20327Zm9.69195,4.2199L10.8989,9.59979A5.88021,5.88021,0,0,0,12.058,6.02856,6.00467,6.00467,0,1,0,9.59979,10.8989l4.82338,4.82338a.89729.89729,0,0,0,1.29912,0,.89749.89749,0,0,0-.00087-1.29909Z" /></svg>');
 }
 
 html {

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -213,6 +213,9 @@
   border-radius: 12px;
   padding: 1.4rem 1.5rem;
   background: var(--ifm-background-surface-color);
+  /* Allow the card to shrink below the code block's intrinsic width;
+     without this a grid item keeps min-width:auto and overflows on mobile. */
+  min-width: 0;
 }
 
 .infoTitle {

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Velm } from "@velmhq/embed-react";
 
 export default function Root({ children }: { children: React.ReactNode }) {
+  // Release Cmd/Ctrl+K from the Velm widget so docs search owns it.
+  useEffect(() => {
+    document.getElementById("velm-embed-launcher")?.setAttribute("data-hotkey", "off");
+  }, []);
+
   return (
     <>
       {children}

--- a/docs/src/theme/SearchBar/index.tsx
+++ b/docs/src/theme/SearchBar/index.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import OriginalSearchBar from "@theme-original/SearchBar";
+
+import styles from "./styles.module.css";
+
+// Opens the offline search in a centered modal on Cmd/Ctrl+K or "/".
+export default function SearchBarModal(): ReactNode {
+  const [open, setOpen] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const inField =
+        e.target instanceof HTMLElement &&
+        (e.target.tagName === "INPUT" ||
+          e.target.tagName === "TEXTAREA" ||
+          e.target.isContentEditable);
+      const cmdK = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
+      const slash = e.key === "/" && !inField;
+      if (cmdK || slash) {
+        e.preventDefault();
+        setOpen(true);
+      } else if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Focus the input when the modal opens.
+  useEffect(() => {
+    if (!open) return;
+    const input = overlayRef.current?.querySelector<HTMLInputElement>(".navbar__search-input");
+    input?.focus();
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.trigger}
+        aria-label="Search"
+        onClick={() => setOpen(true)}
+      >
+        <svg width="15" height="15" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+          <path
+            d="M14.4 14.4 18 18m-2-9a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+        </svg>
+        <span className={styles.triggerLabel}>Search</span>
+        <kbd className={styles.triggerKbd}>{isMac ? "⌘K" : "Ctrl K"}</kbd>
+      </button>
+
+      {open && (
+        <div
+          className={styles.backdrop}
+          ref={overlayRef}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) close();
+          }}
+        >
+          <div className={styles.modal} role="dialog" aria-modal="true" aria-label="Search">
+            <OriginalSearchBar />
+            <div className={styles.modalHint}>
+              <kbd>esc</kbd> to close
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/docs/src/theme/SearchBar/styles.module.css
+++ b/docs/src/theme/SearchBar/styles.module.css
@@ -1,0 +1,110 @@
+/* Navbar trigger button */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--dok-border);
+  border-radius: 8px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-color-content-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.trigger:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-content);
+}
+
+.triggerLabel {
+  margin-right: 4px;
+}
+
+.triggerKbd {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.7rem;
+  line-height: 1;
+  padding: 3px 5px;
+  border: 1px solid var(--dok-border);
+  border-radius: 4px;
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-content-secondary);
+}
+
+@media (max-width: 600px) {
+  .triggerLabel,
+  .triggerKbd {
+    display: none;
+  }
+  .trigger {
+    padding: 0 9px;
+  }
+}
+
+/* Modal */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 1rem 1rem;
+}
+
+.modal {
+  width: 100%;
+  max-width: 580px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--dok-border);
+  border-radius: 12px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
+  padding: 14px;
+}
+
+/* Make the wrapped search input fill the modal. autocomplete.js inserts an
+   inline-block span around the input, so force the whole chain full-width. */
+.modal :global(.navbar__search) {
+  display: block;
+  width: 100%;
+}
+
+.modal :global(.navbar__search) > span {
+  display: block !important;
+  width: 100% !important;
+}
+
+/* Override the base navbar pill styling so the input fills the modal. */
+.modal :global(.navbar__search-input) {
+  width: 100% !important;
+  max-width: none !important;
+  box-sizing: border-box;
+  height: 48px;
+  border-radius: 10px;
+  border: 1px solid var(--dok-border);
+  font-size: 1rem;
+  background-position: 14px center;
+  padding-left: 2.6rem;
+}
+
+.modalHint {
+  margin-top: 10px;
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--ifm-color-content-secondary);
+}
+
+.modalHint kbd {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.7rem;
+  padding: 2px 5px;
+  border: 1px solid var(--dok-border);
+  border-radius: 4px;
+}


### PR DESCRIPTION
Two follow-up fixes to the docs site.

The landing page scrolled sideways on mobile (about 150px of overflow at 390px wide). The Get started cards are grid items whose default min-width let the code panels force the track wider than the screen; setting min-width to 0 lets them shrink and the code scrolls within.

Docs search now opens in a centered modal on Cmd+K or /, with a navbar button showing the shortcut. It reuses the existing offline search index. The input fills the modal, the search icon stays visible in dark mode, and the chat widget releases Cmd+K so the two no longer both fire.