### PR TITLE
Add support for typed structured outputs

### DIFF
--- a/docs/docs/evaluation/agent-evaluation.md
+++ b/docs/docs/evaluation/agent-evaluation.md
@@ -339,8 +339,21 @@ ToolCall.builder()
     .build();
 ```
 
+Read a structured result back type-safely with `resultAs(Class<T>)` or `resultAs(OutputType<T>)` — the symmetric counterpart of `resultJson`. This is what makes a sequential agent's `output -> input -> output` chain assertable: capture each step's structured result, then read it back as a real object.
+
+```java
+ToolCall call = ToolCall.builder()
+    .name("book_hotel")
+    .resultJson(new Confirmation("ABC123", 540.0))
+    .build();
+
+Confirmation booked = call.resultAs(Confirmation.class);   // back to a typed object
+List<Confirmation> many =
+    call.resultAs(new OutputType<List<Confirmation>>() {}); // generics via OutputType
+```
+
 :::note
-Both methods set the same `result` field, so the downstream evaluators (`ToolErrorEvaluator`, the hallucination judge, and anything reading `ToolCall.result()`) see an identical string either way.
+Both writers set the same `result` field, so downstream evaluators (`ToolErrorEvaluator`, the hallucination judge, and anything reading `ToolCall.result()`) see an identical string either way. `resultAs` parses that string as JSON (the form `resultJson` produces): a `null` or blank result returns `null`, and a raw non-JSON string from `result(String)` is not parseable — use `result()` for that.
 :::
 
 ### ToolDefinition

--- a/docs/docs/evaluation/agent-evaluation.md
+++ b/docs/docs/evaluation/agent-evaluation.md
@@ -321,6 +321,28 @@ ToolCall call = ToolCall.builder()
     .build();
 ```
 
+The `result` is a single string. `result(String)` stores whatever you pass verbatim — use it for a result your tool already rendered as a string. When the tool produced a structured value (a record, POJO, map, or list), use `resultJson(Object)` instead: it serializes the value to a compact, single-line JSON string and stores it in the same `result` component, so you stop hand-escaping JSON. A `null` value serializes to the JSON literal `null`.
+
+```java
+record Confirmation(String confirmation, double total) {}
+
+// Before — hand-escaped JSON, easy to get wrong
+ToolCall.builder()
+    .name("book_hotel")
+    .result("{\"confirmation\": \"ABC123\", \"total\": 540.0}")
+    .build();
+
+// After — serialize the value, no escaping
+ToolCall.builder()
+    .name("book_hotel")
+    .resultJson(new Confirmation("ABC123", 540.0))
+    .build();
+```
+
+:::note
+Both methods set the same `result` field, so the downstream evaluators (`ToolErrorEvaluator`, the hallucination judge, and anything reading `ToolCall.result()`) see an identical string either way.
+:::
+
 ### ToolDefinition
 
 A tool's contract: name, description, and JSON schema for arguments.

--- a/docs/docs/evaluation/agent-evaluation.md
+++ b/docs/docs/evaluation/agent-evaluation.md
@@ -339,7 +339,7 @@ ToolCall.builder()
     .build();
 ```
 
-Read a structured result back type-safely with `resultAs(Class<T>)` or `resultAs(OutputType<T>)` — the symmetric counterpart of `resultJson`. This is what makes a sequential agent's `output -> input -> output` chain assertable: capture each step's structured result, then read it back as a real object.
+Read a structured result back type-safely with `resultAs(Class<T>)` or `resultAs(OutputType<T>)` — the symmetric counterpart of `resultJson`. This is what makes a sequential agent's `output -> input -> output` chain assertable: capture each step's structured result, then read it back as a real object. Tool-call arguments read back the same way with `argumentsAs(Class<T>)` / `argumentsAs(OutputType<T>)`. This is one stop on Dokimos's typed-data pipeline — see the [Structured & Typed Data](./structured-typed-data.md) hub for how it connects to typed task outputs, structural matching, and the typed accessors on `EvalTestCase`.
 
 ```java
 ToolCall call = ToolCall.builder()

--- a/docs/docs/evaluation/datamodel.md
+++ b/docs/docs/evaluation/datamodel.md
@@ -426,6 +426,10 @@ This is what gets passed to evaluators. Usually you don't create these directly;
 
 The output and expected-output maps hold `Object` values, so the common pattern is to stringify everything. But a task can just as well produce a structured object — a record, a list, a POJO — and read it back type-safely later. This keeps your task body honest (return the thing you actually built, not a hand-assembled map) and lets custom evaluators work with real domain objects instead of parsing strings.
 
+:::tip
+For the whole typed pipeline narrated in one place — authoring a typed output, comparing it, reading it back, judging it as JSON, and typing tool-call results — see the [Structured & Typed Data](./structured-typed-data.md) hub. The sections below are the per-method reference it links into.
+:::
+
 ### Returning a typed value from a task
 
 `Task.typed(fn)` wraps a function that returns a single value and stores it under the conventional `"output"` key. In Kotlin, the reified `typedTask<T> { ... }` DSL does the same thing.

--- a/docs/docs/evaluation/datamodel.md
+++ b/docs/docs/evaluation/datamodel.md
@@ -422,6 +422,185 @@ This is what gets passed to evaluators. Usually you don't create these directly;
 
 ---
 
+## Typed outputs
+
+The output and expected-output maps hold `Object` values, so the common pattern is to stringify everything. But a task can just as well produce a structured object — a record, a list, a POJO — and read it back type-safely later. This keeps your task body honest (return the thing you actually built, not a hand-assembled map) and lets custom evaluators work with real domain objects instead of parsing strings.
+
+### Returning a typed value from a task
+
+`Task.typed(fn)` wraps a function that returns a single value and stores it under the conventional `"output"` key. In Kotlin, the reified `typedTask<T> { ... }` DSL does the same thing.
+
+:::note
+`Task.typed` rejects a `null` return with `NullPointerException` — the output map cannot hold a null value. If you genuinely need an absent output, use a raw `Task`. As a convenience guard, if your function already returns a `Map`, that map is used directly as the output map rather than being nested under `"output"`, so a multi-key task can adopt `typed` without double-nesting.
+:::
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+record Whisky(String name, String region, int age) {}
+
+Task task = Task.typed(example -> {
+    String json = llm.chat(example.input());
+    return Json.parseWhisky(json); // returns a Whisky record
+});
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+data class Whisky(val name: String, val region: String, val age: Int)
+
+val task = typedTask<Whisky> { example ->
+    val json = llm.chat(example.input())
+    parseWhisky(json) // returns a Whisky
+}
+```
+
+Inside `experiment { ... }` you can also set it directly with the `typedTask` builder method:
+
+```kotlin
+val experiment = experiment {
+    name = "Whisky extraction"
+    dataset(whiskyDataset)
+    typedTask<Whisky> { example -> parseWhisky(llm.chat(example.input())) }
+    evaluator(StructuralMatchEvaluator())
+}
+```
+
+  </TabItem>
+</Tabs>
+
+### Reading typed values back
+
+Both `EvalTestCase` and `Example` expose typed accessors. For a non-generic target, pass a `Class<T>`. The accessors default to the `"output"` key; keyed overloads read any other key.
+
+| Method | Reads | Returns |
+|--------|-------|---------|
+| `actualOutputAs(Class<T>)` | actual `"output"` | converted value or `null` |
+| `actualOutputAs(OutputType<T>)` | actual `"output"` | converted value or `null` |
+| `actualOutputAs(String, Class<T>)` | actual under `key` | converted value or `null` |
+| `actualOutputAs(String, OutputType<T>)` | actual under `key` | converted value or `null` |
+| `expectedOutputAs(Class<T>)` | expected `"output"` | converted value or `null` |
+| `expectedOutputAs(OutputType<T>)` | expected `"output"` | converted value or `null` |
+| `expectedOutputAs(String, Class<T>)` | expected under `key` | converted value or `null` |
+| `expectedOutputAs(String, OutputType<T>)` | expected under `key` | converted value or `null` |
+
+`Example` carries the `expectedOutputAs(...)` twins only (it has no actual output yet). `EvalTestCase` carries both the actual and expected variants.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+public class WhiskyEvaluator implements Evaluator {
+    @Override
+    public EvalResult evaluate(EvalTestCase testCase) {
+        Whisky actual = testCase.actualOutputAs(Whisky.class);
+        Whisky expected = testCase.expectedOutputAs(Whisky.class);
+
+        boolean match = actual != null
+            && actual.region().equals(expected.region());
+
+        return EvalResult.builder()
+            .name("Whisky Region")
+            .score(match ? 1.0 : 0.0)
+            .success(match)
+            .reason(match ? "Region matches" : "Wrong region")
+            .build();
+    }
+
+    @Override
+    public String name() { return "Whisky Region"; }
+
+    @Override
+    public double threshold() { return 1.0; }
+}
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+class WhiskyEvaluator : Evaluator {
+    override fun evaluate(testCase: EvalTestCase): EvalResult {
+        val actual = testCase.actualOutputAs(Whisky::class.java)
+        val expected = testCase.expectedOutputAs(Whisky::class.java)
+
+        val match = actual != null && actual.region == expected?.region
+
+        return EvalResult(
+            name = "Whisky Region",
+            score = if (match) 1.0 else 0.0,
+            success = match,
+            reason = if (match) "Region matches" else "Wrong region",
+        )
+    }
+
+    override fun name(): String = "Whisky Region"
+
+    override fun threshold(): Double = 1.0
+}
+```
+
+  </TabItem>
+</Tabs>
+
+### Generic types with `OutputType<T>`
+
+A plain `Class<T>` cannot express a generic target such as `List<Whisky>` — type arguments are erased at runtime. `OutputType<T>` is a super-type token (the "Gafter gadget", like Jackson's `TypeReference` or Spring's `ParameterizedTypeReference`) that captures the full generic type. Always instantiate it as an **anonymous subclass** so the type argument is recorded:
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+// Task produces a List<Whisky>
+Task task = Task.typed(example -> parseWhiskies(llm.chat(example.input())));
+
+// Read it back, preserving the element type
+List<Whisky> whiskies =
+    testCase.actualOutputAs(new OutputType<List<Whisky>>() {});
+
+// A keyed, non-"output" variant works the same way
+List<Whisky> shortlist =
+    testCase.actualOutputAs("shortlist", new OutputType<List<Whisky>>() {});
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+// Task produces a List<Whisky>
+val task = typedTask<List<Whisky>> { example -> parseWhiskies(llm.chat(example.input())) }
+
+// Read it back, preserving the element type
+val whiskies: List<Whisky> =
+    testCase.actualOutputAs(object : OutputType<List<Whisky>>() {})
+
+// A keyed, non-"output" variant works the same way
+val shortlist: List<Whisky> =
+    testCase.actualOutputAs("shortlist", object : OutputType<List<Whisky>>() {})
+```
+
+  </TabItem>
+</Tabs>
+
+:::tip
+Constructing an `OutputType` raw (`new OutputType() {}`) throws `IllegalArgumentException` — there is no type argument to capture. Use the `Class<T>` accessors for non-generic targets; reach for `OutputType<T>` only when the target is generic.
+:::
+
+### Conversion contract
+
+The typed accessors share one conversion contract across `EvalTestCase` and `Example`:
+
+- **Absent key → `null`.** If the requested key is missing from the map, the accessor returns `null` (it does not throw).
+- **Already the right type → returned as-is.** For the `Class<T>` accessors, a stored value that is already an instance of the target type is cast directly without going through serialization.
+- **Otherwise → converted, or it throws.** Any other value is converted (via Jackson under the hood). If the value cannot be converted to the requested type, the accessor throws `DokimosTypeConversionException` (in `dev.dokimos.core.exceptions`).
+
+This is why a typed task pairs naturally with structural matching: `StructuralMatchEvaluator` compares the stored structured value against the expected structure, and your custom evaluators can read the same value back as a real object.
+
+---
+
 ### EvalResult
 
 The score and feedback from one evaluator.

--- a/docs/docs/evaluation/datamodel.md
+++ b/docs/docs/evaluation/datamodel.md
@@ -442,11 +442,11 @@ For the whole typed pipeline narrated in one place — authoring a typed output,
   <TabItem value="java" label="Java">
 
 ```java
-record Whisky(String name, String region, int age) {}
+record Movie(String title, String director, int year) {}
 
 Task task = Task.typed(example -> {
     String json = llm.chat(example.input());
-    return Json.parseWhisky(json); // returns a Whisky record
+    return Json.parseMovie(json); // returns a Movie record
 });
 ```
 
@@ -454,11 +454,11 @@ Task task = Task.typed(example -> {
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-data class Whisky(val name: String, val region: String, val age: Int)
+data class Movie(val title: String, val director: String, val year: Int)
 
-val task = typedTask<Whisky> { example ->
+val task = typedTask<Movie> { example ->
     val json = llm.chat(example.input())
-    parseWhisky(json) // returns a Whisky
+    parseMovie(json) // returns a Movie
 }
 ```
 
@@ -466,9 +466,9 @@ Inside `experiment { ... }` you can also set it directly with the `typedTask` bu
 
 ```kotlin
 val experiment = experiment {
-    name = "Whisky extraction"
-    dataset(whiskyDataset)
-    typedTask<Whisky> { example -> parseWhisky(llm.chat(example.input())) }
+    name = "Movie extraction"
+    dataset(movieDataset)
+    typedTask<Movie> { example -> parseMovie(llm.chat(example.input())) }
     evaluator(StructuralMatchEvaluator())
 }
 ```
@@ -497,25 +497,25 @@ Both `EvalTestCase` and `Example` expose typed accessors. For a non-generic targ
   <TabItem value="java" label="Java">
 
 ```java
-public class WhiskyEvaluator implements Evaluator {
+public class MovieEvaluator implements Evaluator {
     @Override
     public EvalResult evaluate(EvalTestCase testCase) {
-        Whisky actual = testCase.actualOutputAs(Whisky.class);
-        Whisky expected = testCase.expectedOutputAs(Whisky.class);
+        Movie actual = testCase.actualOutputAs(Movie.class);
+        Movie expected = testCase.expectedOutputAs(Movie.class);
 
         boolean match = actual != null
-            && actual.region().equals(expected.region());
+            && actual.director().equals(expected.director());
 
         return EvalResult.builder()
-            .name("Whisky Region")
+            .name("Movie Director")
             .score(match ? 1.0 : 0.0)
             .success(match)
-            .reason(match ? "Region matches" : "Wrong region")
+            .reason(match ? "Director matches" : "Wrong director")
             .build();
     }
 
     @Override
-    public String name() { return "Whisky Region"; }
+    public String name() { return "Movie Director"; }
 
     @Override
     public double threshold() { return 1.0; }
@@ -526,22 +526,22 @@ public class WhiskyEvaluator implements Evaluator {
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-class WhiskyEvaluator : Evaluator {
+class MovieEvaluator : Evaluator {
     override fun evaluate(testCase: EvalTestCase): EvalResult {
-        val actual = testCase.actualOutputAs(Whisky::class.java)
-        val expected = testCase.expectedOutputAs(Whisky::class.java)
+        val actual = testCase.actualOutputAs(Movie::class.java)
+        val expected = testCase.expectedOutputAs(Movie::class.java)
 
-        val match = actual != null && actual.region == expected?.region
+        val match = actual != null && actual.director == expected?.director
 
         return EvalResult(
-            name = "Whisky Region",
+            name = "Movie Director",
             score = if (match) 1.0 else 0.0,
             success = match,
-            reason = if (match) "Region matches" else "Wrong region",
+            reason = if (match) "Director matches" else "Wrong director",
         )
     }
 
-    override fun name(): String = "Whisky Region"
+    override fun name(): String = "Movie Director"
 
     override fun threshold(): Double = 1.0
 }
@@ -552,38 +552,38 @@ class WhiskyEvaluator : Evaluator {
 
 ### Generic types with `OutputType<T>`
 
-A plain `Class<T>` cannot express a generic target such as `List<Whisky>` — type arguments are erased at runtime. `OutputType<T>` is a super-type token (the "Gafter gadget", like Jackson's `TypeReference` or Spring's `ParameterizedTypeReference`) that captures the full generic type. Always instantiate it as an **anonymous subclass** so the type argument is recorded:
+A plain `Class<T>` cannot express a generic target such as `List<Movie>` — type arguments are erased at runtime. `OutputType<T>` is a super-type token (the "Gafter gadget", like Jackson's `TypeReference` or Spring's `ParameterizedTypeReference`) that captures the full generic type. Always instantiate it as an **anonymous subclass** so the type argument is recorded:
 
 <Tabs groupId="lang" defaultValue="java">
   <TabItem value="java" label="Java">
 
 ```java
-// Task produces a List<Whisky>
-Task task = Task.typed(example -> parseWhiskies(llm.chat(example.input())));
+// Task produces a List<Movie>
+Task task = Task.typed(example -> parseMovies(llm.chat(example.input())));
 
 // Read it back, preserving the element type
-List<Whisky> whiskies =
-    testCase.actualOutputAs(new OutputType<List<Whisky>>() {});
+List<Movie> movies =
+    testCase.actualOutputAs(new OutputType<List<Movie>>() {});
 
 // A keyed, non-"output" variant works the same way
-List<Whisky> shortlist =
-    testCase.actualOutputAs("shortlist", new OutputType<List<Whisky>>() {});
+List<Movie> shortlist =
+    testCase.actualOutputAs("shortlist", new OutputType<List<Movie>>() {});
 ```
 
   </TabItem>
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-// Task produces a List<Whisky>
-val task = typedTask<List<Whisky>> { example -> parseWhiskies(llm.chat(example.input())) }
+// Task produces a List<Movie>
+val task = typedTask<List<Movie>> { example -> parseMovies(llm.chat(example.input())) }
 
 // Read it back, preserving the element type
-val whiskies: List<Whisky> =
-    testCase.actualOutputAs(object : OutputType<List<Whisky>>() {})
+val movies: List<Movie> =
+    testCase.actualOutputAs(object : OutputType<List<Movie>>() {})
 
 // A keyed, non-"output" variant works the same way
-val shortlist: List<Whisky> =
-    testCase.actualOutputAs("shortlist", object : OutputType<List<Whisky>>() {})
+val shortlist: List<Movie> =
+    testCase.actualOutputAs("shortlist", object : OutputType<List<Movie>>() {})
 ```
 
   </TabItem>

--- a/docs/docs/evaluation/evaluators.md
+++ b/docs/docs/evaluation/evaluators.md
@@ -106,7 +106,11 @@ val evaluator = exactMatch {
 
 Returns score `1.0` if they match, `0.0` otherwise.
 
-**When to use:** Math calculations, code generation, structured data extraction, or any scenario where the output should be exactly as expected.
+**When to use:** Math calculations, code generation, or any scenario where the output is a string that should be exactly as expected.
+
+:::note
+`ExactMatchEvaluator` compares the **string forms** of the outputs (`toString()`). For a structured output — a record, `Map`, or list — use [`StructuralMatchEvaluator`](#structuralmatchevaluator) instead, which compares the values structurally and ignores formatting and numeric representation (`5` vs `5.0`).
+:::
 
 ### RegexEvaluator
 
@@ -193,6 +197,8 @@ val helpfulness: Evaluator = llmJudge(judge) {
 </Tabs>
 
 The evaluator sends your criteria along with the test case to the judge model, which returns a score between 0 and 1. The reply is parsed leniently: a one-sentence preamble or trailing prose around the JSON is dropped, so a recoverable judgment is not lost to a formatting quirk.
+
+A structured output (a record, `Map`, or list) is rendered to the judge as pretty-printed JSON, so you can judge a structured value directly; String and primitive output is passed through verbatim.
 
 By default the judge scores on a 0..1 scale. To let the judge work on a different range, set `scoreRange(min, max)`. The reported score is then normalized back to 0..1, so your `threshold` always stays on the 0..1 scale:
 

--- a/docs/docs/evaluation/evaluators.md
+++ b/docs/docs/evaluation/evaluators.md
@@ -228,6 +228,126 @@ val helpfulness: Evaluator = llmJudge(judge) {
 
 **When to use:** Checking semantic correctness, helpfulness, tone, clarity, or any quality dimension that's easier to describe in words than code.
 
+### StructuralMatchEvaluator
+
+Compares the actual output against the expected output as **JSON structures** rather than as opaque strings. Both operands are normalized to a JSON tree before comparison, so a record, a `Map`, or a JSON string all compare object-against-object. This makes it the right tool for structured output (extraction results, function-call arguments, typed POJOs) where reformatting, key ordering, or numeric representation should not count as a difference.
+
+Crucially, numbers compare **by value, not representation**: `5` equals `5.0`, and `1.0` equals `1.00`, in both modes. String equality of the serialized form would flag those as mismatches; structural comparison does not.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+record Invoice(String id, double total, List<String> items) {}
+
+Evaluator structural = StructuralMatchEvaluator.builder()
+    .name("Invoice Match")
+    .threshold(1.0)
+    .build();  // STRICT mode, outputKey "output", partial scoring
+
+var testCase = EvalTestCase.builder()
+    .expectedOutput("output", new Invoice("INV-1", 42.0, List.of("a", "b")))
+    .actualOutput("output", new Invoice("INV-1", 42.00, List.of("a", "b")))
+    .build();
+
+EvalResult result = structural.evaluate(testCase);
+// result.score() == 1.0 — 42.0 and 42.00 are value-equal
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+data class Invoice(val id: String, val total: Double, val items: List<String>)
+
+val structural: Evaluator = StructuralMatchEvaluator.builder()
+    .name("Invoice Match")
+    .threshold(1.0)
+    .build()  // STRICT mode, outputKey "output", partial scoring
+
+val testCase = EvalTestCase(
+    expectedOutputs = mapOf("output" to Invoice("INV-1", 42.0, listOf("a", "b"))),
+    actualOutputs = mapOf("output" to Invoice("INV-1", 42.00, listOf("a", "b"))),
+)
+
+val result = structural.evaluate(testCase)
+// result.score() == 1.0 — 42.0 and 42.00 are value-equal
+```
+
+  </TabItem>
+</Tabs>
+
+#### Comparison modes
+
+The comparison mode is set with `.mode(...)` using `StructuralMatchMode`:
+
+- **`STRICT`** (the default) requires the **exact field set** and **exact array order**. An extra field in the actual output is a mismatch and penalizes the score, and a `null` value is distinct from a missing field.
+- **`LENIENT`** allows **extra actual fields** (the actual object may be a superset of the expected one) and ignores array order, comparing arrays as **multisets** — `[1, 1, 2]` does not match `[1, 2]`, but order is irrelevant. A `null` value and a missing field are treated as equal.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+Evaluator lenient = StructuralMatchEvaluator.builder()
+    .name("Extraction Match")
+    .mode(StructuralMatchMode.LENIENT)  // tolerate extra fields, ignore array order
+    .threshold(0.9)
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val lenient: Evaluator = StructuralMatchEvaluator.builder()
+    .name("Extraction Match")
+    .mode(StructuralMatchMode.LENIENT)  // tolerate extra fields, ignore array order
+    .threshold(0.9)
+    .build()
+```
+
+  </TabItem>
+</Tabs>
+
+#### Scoring
+
+By default the score is the **fraction of matching leaf paths** in `[0.0, 1.0]`, so a single wrong field on a large object is a partial miss, not a total failure. In `STRICT` the denominator is the union of expected and actual leaf paths (extra fields lower the score); in `LENIENT` the denominator is the expected leaf paths only.
+
+Call `.binary()` for an **exact-contract gate**: the score collapses to `1.0` when the structures match completely and `0.0` when anything differs. Pair it with `threshold(1.0)` when the output contract must be satisfied exactly.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+Evaluator contract = StructuralMatchEvaluator.builder()
+    .name("Schema Contract")
+    .binary()          // 1.0 if everything matches, 0.0 otherwise
+    .threshold(1.0)
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val contract: Evaluator = StructuralMatchEvaluator.builder()
+    .name("Schema Contract")
+    .binary()          // 1.0 if everything matches, 0.0 otherwise
+    .threshold(1.0)
+    .build()
+```
+
+  </TabItem>
+</Tabs>
+
+By default the evaluator reads both operands from the `"output"` key of the expected and actual output maps. Use `.outputKey(...)` to read from a different key. The expected value is required — if it is absent the evaluator throws.
+
+:::tip
+This evaluator pairs naturally with the typed output accessors on `EvalTestCase` (`actualOutputAs(...)` / `expectedOutputAs(...)`): store your structured result under a map key as a record or `Map`, compare it structurally here, and read it back as a typed object elsewhere.
+:::
+
+**When to use:** Structured or JSON output — extraction results, tool-call arguments, typed response objects — where you care about the data, not its textual formatting, and where numeric representation differences (`5` vs `5.0`) should never count as a regression.
+
 ### FaithfulnessEvaluator
 
 Checks if the output is grounded in the provided context. This is essential for RAG systems where you need to ensure the LLM isn't making things up.
@@ -797,6 +917,7 @@ An output only passes if it meets **all** the thresholds. This lets you enforce 
 
 - Use **ExactMatch** when there's only one correct answer (like math or data extraction)
 - Use **Regex** for format validation (dates, emails, IDs)
+- Use **StructuralMatch** for structured/JSON output where formatting and numeric representation shouldn't count as differences
 - Use **LLMJudge** for semantic quality (helpfulness, clarity, tone)
 - Use **Faithfulness** for RAG systems to measure how grounded the output is
 - Use **Hallucination** to specifically measure and limit fabricated content

--- a/docs/docs/evaluation/evaluators.md
+++ b/docs/docs/evaluation/evaluators.md
@@ -349,7 +349,7 @@ val contract: Evaluator = StructuralMatchEvaluator.builder()
 By default the evaluator reads both operands from the `"output"` key of the expected and actual output maps. Use `.outputKey(...)` to read from a different key. The expected value is required — if it is absent the evaluator throws.
 
 :::tip
-This evaluator pairs naturally with the typed output accessors on `EvalTestCase` (`actualOutputAs(...)` / `expectedOutputAs(...)`): store your structured result under a map key as a record or `Map`, compare it structurally here, and read it back as a typed object elsewhere.
+This evaluator pairs naturally with the typed output accessors on `EvalTestCase` (`actualOutputAs(...)` / `expectedOutputAs(...)`): store your structured result under a map key as a record or `Map`, compare it structurally here, and read it back as a typed object elsewhere. See the [Structured & Typed Data](./structured-typed-data.md) hub for the whole pipeline end to end.
 :::
 
 **When to use:** Structured or JSON output — extraction results, tool-call arguments, typed response objects — where you care about the data, not its textual formatting, and where numeric representation differences (`5` vs `5.0`) should never count as a regression.
@@ -923,7 +923,7 @@ An output only passes if it meets **all** the thresholds. This lets you enforce 
 
 - Use **ExactMatch** when there's only one correct answer (like math or data extraction)
 - Use **Regex** for format validation (dates, emails, IDs)
-- Use **StructuralMatch** for structured/JSON output where formatting and numeric representation shouldn't count as differences
+- Use **StructuralMatch** for structured/JSON output where formatting and numeric representation shouldn't count as differences (see the [Structured & Typed Data](./structured-typed-data.md) hub)
 - Use **LLMJudge** for semantic quality (helpfulness, clarity, tone)
 - Use **Faithfulness** for RAG systems to measure how grounded the output is
 - Use **Hallucination** to specifically measure and limit fabricated content

--- a/docs/docs/evaluation/experiments.md
+++ b/docs/docs/evaluation/experiments.md
@@ -537,6 +537,105 @@ result.runs()                           // Individual run results
 
 High standard deviation suggests instability in your task or evaluator outputs.
 
+## Asynchronous Tasks
+
+The `task`/`measuredTask` paths block one thread per in-flight example. That's fine for blocking SDK calls, but it's a poor fit when your task is already non-blocking — a Kotlin `suspend` function, a Reactor or `CompletableFuture` pipeline, or an agent runtime that hands you a future. For those callers, set an `AsyncTask` instead. It returns a `CompletableFuture<TaskResult>`, so the experiment can drive many examples without parking a thread on each one.
+
+```java
+@FunctionalInterface
+public interface AsyncTask {
+    CompletableFuture<TaskResult> run(Example example);
+}
+```
+
+The completed future carries the same `TaskResult` (outputs plus optional `CallMetrics`) used by `measuredTask`, so call metrics flow through to each `ItemResult.metrics()` exactly as they do on the synchronous paths.
+
+Set it with `asyncTask(...)`. An async task satisfies the task requirement on its own — you don't also need to call `task(...)` or `measuredTask(...)`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+AsyncTask task = example ->
+    myAsyncLlmService
+        .generateAsync(example.input())                 // returns CompletableFuture<String>
+        .thenApply(answer -> TaskResult.of(Map.of("output", answer)));
+
+ExperimentResult result = Experiment.builder()
+    .name("QA Evaluation")
+    .dataset(dataset)
+    .asyncTask(task)
+    .evaluators(evaluators)
+    .parallelism(8)  // caps in-flight invocations at 8
+    .build()
+    .run();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.TaskResult
+import dev.dokimos.kotlin.dsl.experiment
+
+val result = experiment {
+    name = "QA Evaluation"
+    dataset(dataset)
+    parallelism = 8  // caps in-flight invocations at 8
+    suspendTask { example ->
+        val answer = myAsyncLlmService.generate(example.input())  // a suspend call
+        TaskResult.of(mapOf("output" to answer))
+    }
+    evaluators(evaluators)
+}.run()
+```
+
+  </TabItem>
+</Tabs>
+
+### Bounded execution
+
+When an async task is configured the experiment runs through a dedicated non-blocking execution path. This path takes precedence over the sequential and parallel paths — `parallelism` no longer sizes a thread pool; instead it caps the number of **in-flight** invocations using a semaphore. The experiment acquires a permit before calling `asyncTask.run(...)` and releases it when that example's future settles, so at most `parallelism` invocations are ever outstanding. This keeps a non-blocking task from launching the entire dataset at once and overwhelming a downstream service or rate limit. Dataset order is preserved in the returned results.
+
+:::note
+For tasks that bridge a **blocking** call onto a future (for example via `CompletableFuture.supplyAsync(..., executor)`), the effective concurrency is bounded by whichever is smaller: the experiment's `parallelism` cap or the executor backing those calls. The semaphore caps how many futures are outstanding; the executor caps how many run at once. The Kotlin `suspendTask {}` DSL dispatches on `Dispatchers.IO` by default. The framework integrations build async tasks on top of `asyncTask(...)` — see the [Koog](../integrations/koog.md), [LangChain4j](../integrations/langchain4j.md), and [Spring AI](../integrations/spring-ai.md) pages.
+:::
+
+### Per-item failure isolation
+
+Async tasks use the same isolation as the synchronous paths. A future that completes exceptionally becomes a failed `ItemResult` (its `success()` is `false`, with no eval results) and the run continues with the remaining examples. A task that throws synchronously from `run(...)`, or returns a `null` future, is isolated the same way rather than aborting the run. Filter for `!item.success()` to inspect what failed, exactly as on the [sequential and parallel paths](#per-item-failure-isolation).
+
+### The Kotlin `suspendTask {}` DSL
+
+In Kotlin you rarely build an `AsyncTask` by hand. The `suspendTask {}` block in the `experiment {}` DSL takes a `suspend` body returning a `TaskResult` and bridges it to a `CompletableFuture` for you. There is also a top-level `suspendTask(...)` function (and a `suspendMapTask(...)` convenience overload that returns an output `Map` and wraps it in a `TaskResult` with no metrics) when you want to construct the task outside the DSL.
+
+```kotlin
+import dev.dokimos.core.TaskResult
+import dev.dokimos.kotlin.dsl.suspendTask
+
+val task = suspendTask { example ->
+    val answer = myAsyncLlmService.generate(example.input())
+    TaskResult.of(mapOf("output" to answer))
+}
+
+val result = experiment {
+    name = "QA Evaluation"
+    dataset(dataset)
+    asyncTask(task)
+    parallelism = 8
+    evaluators(evaluators)
+}.run()
+```
+
+Each invocation launches the suspend body on the given `CoroutineScope` (the IO dispatcher by default); pass your own `scope` to either form to control where the work runs. A suspend exception surfaces as an exceptionally completed future, which the experiment isolates as a failed item.
+
+:::tip
+Reach for an async task only when your caller is genuinely non-blocking. If your task is a plain blocking SDK call, the synchronous `task(...)`/`measuredTask(...)` path with `parallelism(n)` is simpler and gives you the same concurrency through its thread pool.
+:::
+
 ## Configuring Experiments
 
 You can customize experiments with names, descriptions, evaluators, and metadata.

--- a/docs/docs/evaluation/structured-typed-data.md
+++ b/docs/docs/evaluation/structured-typed-data.md
@@ -28,11 +28,11 @@ Each step is self-contained, but they're designed to fit together: a task return
   <TabItem value="java" label="Java">
 
 ```java
-record Whisky(String name, String region, int age) {}
+record Movie(String title, String director, int year) {}
 
 Task task = Task.typed(example -> {
     String json = llm.chat(example.input());
-    return Json.parseWhisky(json); // returns a Whisky record
+    return Json.parseMovie(json); // returns a Movie record
 });
 ```
 
@@ -40,11 +40,11 @@ Task task = Task.typed(example -> {
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-data class Whisky(val name: String, val region: String, val age: Int)
+data class Movie(val title: String, val director: String, val year: Int)
 
-val task = typedTask<Whisky> { example ->
+val task = typedTask<Movie> { example ->
     val json = llm.chat(example.input())
-    parseWhisky(json) // returns a Whisky
+    parseMovie(json) // returns a Movie
 }
 ```
 
@@ -52,9 +52,9 @@ Inside `experiment { ... }` you can set it directly with the `typedTask` builder
 
 ```kotlin
 val experiment = experiment {
-    name = "Whisky extraction"
-    dataset(whiskyDataset)
-    typedTask<Whisky> { example -> parseWhisky(llm.chat(example.input())) }
+    name = "Movie extraction"
+    dataset(movieDataset)
+    typedTask<Movie> { example -> parseMovie(llm.chat(example.input())) }
     evaluator(StructuralMatchEvaluator())
 }
 ```
@@ -77,7 +77,7 @@ See the full reference for the typed-output accessors and the conversion contrac
 
 ```java
 Evaluator structural = StructuralMatchEvaluator.builder()
-    .name("Whisky Match")
+    .name("Movie Match")
     .threshold(1.0)
     .build();  // STRICT mode, outputKey "output", partial scoring
 ```
@@ -87,7 +87,7 @@ Evaluator structural = StructuralMatchEvaluator.builder()
 
 ```kotlin
 val structural: Evaluator = StructuralMatchEvaluator.builder()
-    .name("Whisky Match")
+    .name("Movie Match")
     .threshold(1.0)
     .build()  // STRICT mode, outputKey "output", partial scoring
 ```
@@ -99,7 +99,7 @@ For comparison modes (`STRICT` vs `LENIENT`), partial-vs-`binary()` scoring, and
 
 ## 3. Read typed values back
 
-A custom evaluator (or any code holding an `EvalTestCase`) can read the structured value back as a real object instead of parsing a string. Both `EvalTestCase` and `Example` expose typed accessors. For a non-generic target, pass a `Class<T>`; for a generic target like `List<Whisky>`, pass an `OutputType<T>` super-type token instantiated as an **anonymous subclass** so the element type is recorded.
+A custom evaluator (or any code holding an `EvalTestCase`) can read the structured value back as a real object instead of parsing a string. Both `EvalTestCase` and `Example` expose typed accessors. For a non-generic target, pass a `Class<T>`; for a generic target like `List<Movie>`, pass an `OutputType<T>` super-type token instantiated as an **anonymous subclass** so the element type is recorded.
 
 | Method | Reads | Default key |
 |--------|-------|-------------|
@@ -114,33 +114,33 @@ Each accessor has a keyed overload (`actualOutputAs(String, Class<T>)`, `inputAs
   <TabItem value="java" label="Java">
 
 ```java
-public class WhiskyEvaluator implements Evaluator {
+public class MovieEvaluator implements Evaluator {
     @Override
     public EvalResult evaluate(EvalTestCase testCase) {
         // Non-generic targets: pass a Class<T>
-        Whisky actual = testCase.actualOutputAs(Whisky.class);
-        Whisky expected = testCase.expectedOutputAs(Whisky.class);
+        Movie actual = testCase.actualOutputAs(Movie.class);
+        Movie expected = testCase.expectedOutputAs(Movie.class);
 
         // The input was itself a typed request object
-        WhiskyQuery query = testCase.inputAs(WhiskyQuery.class);
+        MovieQuery query = testCase.inputAs(MovieQuery.class);
 
         // Generic targets: pass an OutputType<T> anonymous subclass
-        List<Whisky> shortlist =
-            testCase.actualOutputAs("shortlist", new OutputType<List<Whisky>>() {});
+        List<Movie> shortlist =
+            testCase.actualOutputAs("shortlist", new OutputType<List<Movie>>() {});
 
         boolean match = actual != null
-            && actual.region().equals(expected.region());
+            && actual.director().equals(expected.director());
 
         return EvalResult.builder()
-            .name("Whisky Region")
+            .name("Movie Director")
             .score(match ? 1.0 : 0.0)
             .success(match)
-            .reason(match ? "Region matches" : "Wrong region")
+            .reason(match ? "Director matches" : "Wrong director")
             .build();
     }
 
     @Override
-    public String name() { return "Whisky Region"; }
+    public String name() { return "Movie Director"; }
 
     @Override
     public double threshold() { return 1.0; }
@@ -151,33 +151,33 @@ public class WhiskyEvaluator implements Evaluator {
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-class WhiskyEvaluator : Evaluator {
+class MovieEvaluator : Evaluator {
     override fun evaluate(testCase: EvalTestCase): EvalResult {
         // Java-style: pass a Class<T> or an OutputType<T> anonymous subclass
-        val actual = testCase.actualOutputAs(Whisky::class.java)
-        val expected = testCase.expectedOutputAs(Whisky::class.java)
+        val actual = testCase.actualOutputAs(Movie::class.java)
+        val expected = testCase.expectedOutputAs(Movie::class.java)
 
         // Kotlin reified accessors infer the type — no Class or token needed
-        val query = testCase.inputAs<WhiskyQuery>()
-        val shortlist = testCase.actualOutputAs<List<Whisky>>("shortlist")
+        val query = testCase.inputAs<MovieQuery>()
+        val shortlist = testCase.actualOutputAs<List<Movie>>("shortlist")
 
-        val match = actual != null && actual.region == expected?.region
+        val match = actual != null && actual.director == expected?.director
 
         return EvalResult(
-            name = "Whisky Region",
+            name = "Movie Director",
             score = if (match) 1.0 else 0.0,
             success = match,
-            reason = if (match) "Region matches" else "Wrong region",
+            reason = if (match) "Director matches" else "Wrong director",
         )
     }
 
-    override fun name(): String = "Whisky Region"
+    override fun name(): String = "Movie Director"
 
     override fun threshold(): Double = 1.0
 }
 ```
 
-The Kotlin reified `*As<T>()` extensions (`actualOutputAs<T>()`, `expectedOutputAs<T>()`, `inputAs<T>()`, `metadataAs<T>(key)`, and their keyed overloads) infer the target type from the call site, so you skip both `Class<T>` and `OutputType<T>` — including for generic types like `List<Whisky>`. They convert through a Kotlin-aware Jackson mapper, so a plain Kotlin data class reads back with no Jackson annotations (`@JsonCreator` / `@JsonProperty`) — its constructor parameter names, nullable fields, and defaults are all honored.
+The Kotlin reified `*As<T>()` extensions (`actualOutputAs<T>()`, `expectedOutputAs<T>()`, `inputAs<T>()`, `metadataAs<T>(key)`, and their keyed overloads) infer the target type from the call site, so you skip both `Class<T>` and `OutputType<T>` — including for generic types like `List<Movie>`. They convert through a Kotlin-aware Jackson mapper, so a plain Kotlin data class reads back with no Jackson annotations (`@JsonCreator` / `@JsonProperty`) — its constructor parameter names, nullable fields, and defaults are all honored.
 
   </TabItem>
 </Tabs>
@@ -198,7 +198,7 @@ The conversion contract is shared across every accessor: an absent key returns `
 ```java
 Evaluator wellFormed = LLMJudgeEvaluator.builder()
     .name("Extraction Quality")
-    .criteria("Is the extracted whisky record complete and plausible for the source text?")
+    .criteria("Is the extracted movie record complete and plausible for the source text?")
     .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
     .judge(judge)
     .threshold(0.8)
@@ -211,7 +211,7 @@ Evaluator wellFormed = LLMJudgeEvaluator.builder()
 ```kotlin
 val wellFormed: Evaluator = llmJudge(judge) {
     name = "Extraction Quality"
-    criteria = "Is the extracted whisky record complete and plausible for the source text?"
+    criteria = "Is the extracted movie record complete and plausible for the source text?"
     params(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT)
     threshold = 0.8
 }

--- a/docs/docs/evaluation/structured-typed-data.md
+++ b/docs/docs/evaluation/structured-typed-data.md
@@ -177,7 +177,7 @@ class WhiskyEvaluator : Evaluator {
 }
 ```
 
-The Kotlin reified `*As<T>()` extensions (`actualOutputAs<T>()`, `expectedOutputAs<T>()`, `inputAs<T>()`, `metadataAs<T>(key)`, and their keyed overloads) infer the target type from the call site, so you skip both `Class<T>` and `OutputType<T>` — including for generic types like `List<Whisky>`.
+The Kotlin reified `*As<T>()` extensions (`actualOutputAs<T>()`, `expectedOutputAs<T>()`, `inputAs<T>()`, `metadataAs<T>(key)`, and their keyed overloads) infer the target type from the call site, so you skip both `Class<T>` and `OutputType<T>` — including for generic types like `List<Whisky>`. They convert through a Kotlin-aware Jackson mapper, so a plain Kotlin data class reads back with no Jackson annotations (`@JsonCreator` / `@JsonProperty`) — its constructor parameter names, nullable fields, and defaults are all honored.
 
   </TabItem>
 </Tabs>

--- a/docs/docs/evaluation/structured-typed-data.md
+++ b/docs/docs/evaluation/structured-typed-data.md
@@ -1,0 +1,306 @@
+---
+sidebar_position: 6
+---
+
+# Structured & Typed Data
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Dokimos supports typed, structured data end to end.
+
+The input, output, expected, and metadata maps hold `Object` values, so it's easy to assume Dokimos is a string-in, string-out framework. It isn't. A task can produce a real domain object — a record, a POJO, a list — Dokimos can compare it structurally, and you can read it back type-safely wherever you need it. The same holds for tool-call results in agent evaluation. This page narrates that whole pipeline in one place:
+
+1. **Author** a typed output from your task (`Task.typed` / `typedTask`).
+2. **Compare** structured values (`StructuralMatchEvaluator`).
+3. **Read back** typed values in a custom evaluator (`actualOutputAs` / `expectedOutputAs` / `inputAs`, with `OutputType<T>` for generics, and Kotlin reified `*As<T>()`).
+4. **Judge** a structured value with an LLM judge that renders it as JSON.
+5. **Type your tool calls** in agent evaluation (`resultJson` / `resultAs`, `argumentsAs`).
+6. **Read typed metadata** (`metadataAs`).
+
+Each step is self-contained, but they're designed to fit together: a task returns a record, the same record is compared and read back as a real object, and a sequential agent's `output -> input -> output` chain stays assertable because each tool result is typed.
+
+## 1. Author a typed output
+
+`Task.typed(fn)` wraps a function that returns a single value and stores it under the conventional `"output"` key. There is no `Map.of("output", ...)` boilerplate, and the value you store is the value you built. In Kotlin, the reified `typedTask<T> { ... }` DSL does the same thing.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+record Whisky(String name, String region, int age) {}
+
+Task task = Task.typed(example -> {
+    String json = llm.chat(example.input());
+    return Json.parseWhisky(json); // returns a Whisky record
+});
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+data class Whisky(val name: String, val region: String, val age: Int)
+
+val task = typedTask<Whisky> { example ->
+    val json = llm.chat(example.input())
+    parseWhisky(json) // returns a Whisky
+}
+```
+
+Inside `experiment { ... }` you can set it directly with the `typedTask` builder method:
+
+```kotlin
+val experiment = experiment {
+    name = "Whisky extraction"
+    dataset(whiskyDataset)
+    typedTask<Whisky> { example -> parseWhisky(llm.chat(example.input())) }
+    evaluator(StructuralMatchEvaluator())
+}
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+`Task.typed` rejects a `null` return with `NullPointerException` — the output map cannot hold a null value. If your function already returns a `Map`, that map is used directly as the output map rather than being nested under `"output"`, so a multi-key task can adopt `typed` without double-nesting.
+:::
+
+See the full reference for the typed-output accessors and the conversion contract in [Data Model → Typed outputs](./datamodel.md#typed-outputs).
+
+## 2. Compare structured values
+
+`StructuralMatchEvaluator` compares the actual output against the expected output as **JSON structures** rather than as opaque strings. A record, a `Map`, or a JSON string all compare object-against-object, so reformatting, key ordering, and numeric representation (`5` vs `5.0`) never count as a difference. This is the natural partner for a typed task: store a record under `"output"`, compare it here.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+Evaluator structural = StructuralMatchEvaluator.builder()
+    .name("Whisky Match")
+    .threshold(1.0)
+    .build();  // STRICT mode, outputKey "output", partial scoring
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val structural: Evaluator = StructuralMatchEvaluator.builder()
+    .name("Whisky Match")
+    .threshold(1.0)
+    .build()  // STRICT mode, outputKey "output", partial scoring
+```
+
+  </TabItem>
+</Tabs>
+
+For comparison modes (`STRICT` vs `LENIENT`), partial-vs-`binary()` scoring, and the `outputKey(...)` option, see [Evaluators → StructuralMatchEvaluator](./evaluators.md#structuralmatchevaluator).
+
+## 3. Read typed values back
+
+A custom evaluator (or any code holding an `EvalTestCase`) can read the structured value back as a real object instead of parsing a string. Both `EvalTestCase` and `Example` expose typed accessors. For a non-generic target, pass a `Class<T>`; for a generic target like `List<Whisky>`, pass an `OutputType<T>` super-type token instantiated as an **anonymous subclass** so the element type is recorded.
+
+| Method | Reads | Default key |
+|--------|-------|-------------|
+| `actualOutputAs(Class<T>)` / `actualOutputAs(OutputType<T>)` | actual output | `"output"` |
+| `expectedOutputAs(Class<T>)` / `expectedOutputAs(OutputType<T>)` | expected output | `"output"` |
+| `inputAs(Class<T>)` / `inputAs(OutputType<T>)` | input | `"input"` |
+| `metadataAs(String, Class<T>)` / `metadataAs(String, OutputType<T>)` | metadata under `key` | (key required) |
+
+Each accessor has a keyed overload (`actualOutputAs(String, Class<T>)`, `inputAs(String, OutputType<T>)`, and so on) for reading any other key. `Example` carries the `expectedOutputAs(...)` and `inputAs(...)` twins (it has no actual output yet); `EvalTestCase` carries all of them.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+public class WhiskyEvaluator implements Evaluator {
+    @Override
+    public EvalResult evaluate(EvalTestCase testCase) {
+        // Non-generic targets: pass a Class<T>
+        Whisky actual = testCase.actualOutputAs(Whisky.class);
+        Whisky expected = testCase.expectedOutputAs(Whisky.class);
+
+        // The input was itself a typed request object
+        WhiskyQuery query = testCase.inputAs(WhiskyQuery.class);
+
+        // Generic targets: pass an OutputType<T> anonymous subclass
+        List<Whisky> shortlist =
+            testCase.actualOutputAs("shortlist", new OutputType<List<Whisky>>() {});
+
+        boolean match = actual != null
+            && actual.region().equals(expected.region());
+
+        return EvalResult.builder()
+            .name("Whisky Region")
+            .score(match ? 1.0 : 0.0)
+            .success(match)
+            .reason(match ? "Region matches" : "Wrong region")
+            .build();
+    }
+
+    @Override
+    public String name() { return "Whisky Region"; }
+
+    @Override
+    public double threshold() { return 1.0; }
+}
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+class WhiskyEvaluator : Evaluator {
+    override fun evaluate(testCase: EvalTestCase): EvalResult {
+        // Java-style: pass a Class<T> or an OutputType<T> anonymous subclass
+        val actual = testCase.actualOutputAs(Whisky::class.java)
+        val expected = testCase.expectedOutputAs(Whisky::class.java)
+
+        // Kotlin reified accessors infer the type — no Class or token needed
+        val query = testCase.inputAs<WhiskyQuery>()
+        val shortlist = testCase.actualOutputAs<List<Whisky>>("shortlist")
+
+        val match = actual != null && actual.region == expected?.region
+
+        return EvalResult(
+            name = "Whisky Region",
+            score = if (match) 1.0 else 0.0,
+            success = match,
+            reason = if (match) "Region matches" else "Wrong region",
+        )
+    }
+
+    override fun name(): String = "Whisky Region"
+
+    override fun threshold(): Double = 1.0
+}
+```
+
+The Kotlin reified `*As<T>()` extensions (`actualOutputAs<T>()`, `expectedOutputAs<T>()`, `inputAs<T>()`, `metadataAs<T>(key)`, and their keyed overloads) infer the target type from the call site, so you skip both `Class<T>` and `OutputType<T>` — including for generic types like `List<Whisky>`.
+
+  </TabItem>
+</Tabs>
+
+:::tip
+Constructing an `OutputType` raw (`new OutputType() {}`) throws `IllegalArgumentException` — there is no type argument to capture. Use the `Class<T>` accessors for non-generic targets and reach for `OutputType<T>` only when the target is generic. In Kotlin the reified `*As<T>()` form handles both.
+:::
+
+The conversion contract is shared across every accessor: an absent key returns `null`; a value already of the target type is returned as-is; anything else is converted via Jackson, and a value that cannot be converted throws `DokimosTypeConversionException` (in `dev.dokimos.core.exceptions`). The full contract is documented in [Data Model → Conversion contract](./datamodel.md#conversion-contract).
+
+## 4. Judge a structured value as JSON
+
+`LLMJudgeEvaluator` can judge a structured value directly. When the output is a record, `Map`, or list, the judge renders it as pretty-printed JSON before sending it to the model; String and primitive output is passed through verbatim. So you don't have to flatten a structured result into prose just to judge it — return the object and let the judge read the JSON.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+Evaluator wellFormed = LLMJudgeEvaluator.builder()
+    .name("Extraction Quality")
+    .criteria("Is the extracted whisky record complete and plausible for the source text?")
+    .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
+    .judge(judge)
+    .threshold(0.8)
+    .build();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val wellFormed: Evaluator = llmJudge(judge) {
+    name = "Extraction Quality"
+    criteria = "Is the extracted whisky record complete and plausible for the source text?"
+    params(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT)
+    threshold = 0.8
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## 5. Typed tool calls
+
+In agent evaluation, a `ToolCall` carries a single string `result`. When a tool produced a structured value, `resultJson(Object)` serializes it to a compact JSON string and stores it in the same `result` component, so you stop hand-escaping JSON. Read it back type-safely with `resultAs(Class<T>)` or `resultAs(OutputType<T>)` — the symmetric counterpart. This is what makes a sequential agent's `output -> input -> output` chain assertable: capture each step's structured result, then read it back as a real object. Tool-call arguments read back the same way with `argumentsAs(Class<T>)` / `argumentsAs(OutputType<T>)`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+record Confirmation(String confirmation, double total) {}
+
+// Write — serialize the value, no escaping
+ToolCall call = ToolCall.builder()
+    .name("book_hotel")
+    .argument("city", "Paris")
+    .argument("nights", 3)
+    .resultJson(new Confirmation("ABC123", 540.0))
+    .build();
+
+// Read back — typed
+Confirmation booked = call.resultAs(Confirmation.class);   // structured result
+HotelArgs args = call.argumentsAs(HotelArgs.class);        // typed arguments
+List<Confirmation> many =
+    call.resultAs(new OutputType<List<Confirmation>>() {}); // generics via OutputType
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+data class Confirmation(val confirmation: String, val total: Double)
+
+// Write — serialize the value, no escaping
+val call = ToolCall.builder()
+    .name("book_hotel")
+    .argument("city", "Paris")
+    .argument("nights", 3)
+    .resultJson(Confirmation("ABC123", 540.0))
+    .build()
+
+// Read back — typed
+val booked = call.resultAs(Confirmation::class.java)   // structured result
+val args = call.argumentsAs(HotelArgs::class.java)     // typed arguments
+val many = call.resultAs(object : OutputType<List<Confirmation>>() {}) // generics
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+`resultJson` and `resultAs` operate on the same `result` field, so downstream evaluators (`ToolErrorEvaluator`, the hallucination judge, and anything reading `ToolCall.result()`) see an identical string either way. `resultAs` parses that string as JSON: a `null` or blank result returns `null`, and a raw non-JSON string from `result(String)` is not parseable — use `result()` for that.
+:::
+
+For the full agent data model and where these read back into evaluators, see [Agent Evaluation → ToolCall](./agent-evaluation.md#toolcall).
+
+## 6. Typed metadata
+
+Metadata is just as typed as the rest. `metadataAs(key, Class<T>)` and `metadataAs(key, OutputType<T>)` read a metadata value back as a real object — useful when you stash a structured rubric, a list of expected entities, or any configuration object alongside an example. Because metadata has no conventional key, the key is always required.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+Rubric rubric = testCase.metadataAs("rubric", Rubric.class);
+List<String> tags = testCase.metadataAs("tags", new OutputType<List<String>>() {});
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+val rubric = testCase.metadataAs<Rubric>("rubric")     // reified
+val tags = testCase.metadataAs<List<String>>("tags")   // reified, generic
+```
+
+  </TabItem>
+</Tabs>
+
+The same conversion contract applies: absent key returns `null`, an already-typed value is returned as-is, and an unconvertible value throws `DokimosTypeConversionException`.
+
+## Where to go next
+
+- [Data Model → Typed outputs](./datamodel.md#typed-outputs) — the full accessor reference and conversion contract.
+- [Evaluators → StructuralMatchEvaluator](./evaluators.md#structuralmatchevaluator) — comparison modes and scoring.
+- [Agent Evaluation → ToolCall](./agent-evaluation.md#toolcall) — typed tool-call results in the agent data model.

--- a/docs/docs/integrations/junit.md
+++ b/docs/docs/integrations/junit.md
@@ -180,6 +180,7 @@ class CustomerSupportTest {
             LLMJudgeEvaluator.builder()
                 .name("Answer Quality")
                 .criteria("Is the answer helpful and addresses the user's question?")
+                .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
                 .threshold(0.80)
                 .judge(judge)
                 .build(),
@@ -285,6 +286,7 @@ void shouldAnswerFromDocumentation(Example example) {
         LLMJudgeEvaluator.builder()
             .name("Answer Quality")
             .criteria("Is the answer helpful?")
+            .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
             .threshold(0.8)
             .judge(judge)
             .build(),

--- a/docs/docs/integrations/junit.md
+++ b/docs/docs/integrations/junit.md
@@ -46,6 +46,10 @@ Add the JUnit integration dependency:
 
 > **Note:** Supports JUnit 5.x and 6.x.
 
+:::tip
+Your task can return a typed record (not just a string), and a JUnit test can read it back with `actualOutputAs(...)` or compare it with `StructuralMatchEvaluator`. See the [Structured & Typed Data](../evaluation/structured-typed-data.md) hub.
+:::
+
 ## Basic Usage
 
 ### Using @DatasetSource

--- a/docs/docs/integrations/koog.md
+++ b/docs/docs/integrations/koog.md
@@ -103,6 +103,69 @@ fun main() {
 }
 ```
 
+## Async Tasks
+
+The Basic Usage example calls the agent with `runBlocking`, which holds a thread per example. To let the experiment keep many agent calls in flight instead, adapt your `suspend` call into a Dokimos `AsyncTask` with `asTask` or `asTextTask`, wire it with `asyncTask(...)`, and bound concurrency with `parallelism`.
+
+Each invocation launches the suspend body on `Dispatchers.IO` and bridges the coroutine to a `CompletableFuture` via the kotlinx-coroutines `future` builder. A suspend exception surfaces as an exceptionally completed future, which the experiment isolates as a failed item while the run continues.
+
+`asTextTask` is the convenience overload: the suspend body receives the example `input()` and returns the model response, which is stored under the `"output"` key. A blank response throws `IllegalArgumentException`.
+
+```kotlin
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+import dev.dokimos.koog.asTextTask
+import dev.dokimos.kotlin.dsl.experiment
+
+fun agent() = AIAgent(
+    promptExecutor = simpleOpenAIExecutor(apiKey),
+    llmModel = OpenAIModels.Chat.GPT5Nano,
+    maxIterations = 10
+)
+
+val task = asTextTask { input -> agent().run("Answer briefly: $input") }
+
+val result = experiment {
+    name = "Koog Async"
+    dataset(dataset)
+    asyncTask(task)
+    parallelism = 8
+    evaluators {
+        llmJudge(judge) {
+            name = "Answer Quality"
+            criteria = "Is the answer helpful and accurate?"
+            threshold = 0.7
+        }
+    }
+}.run()
+```
+
+When you need the full output map (for example to emit RAG context alongside the answer), use `asTask`, whose suspend body receives the full `Example` and returns a `TaskResult`:
+
+```kotlin
+import dev.dokimos.core.TaskResult
+import dev.dokimos.koog.asTask
+
+val ragTask = asTask { example ->
+    val query = example.input()
+    val contextDocs = storage.mostRelevantDocuments(query, count = 2).toList()
+    val answer = agent().run(buildPrompt(query, contextDocs))
+    TaskResult.of(
+        mapOf(
+            "output" to answer,
+            "context" to contextDocs
+        )
+    )
+}
+```
+
+:::note
+
+Both `asTask` and `asTextTask` default the coroutine scope to `GlobalScope` — the launched coroutine has no parent lifecycle to inherit. To opt into structured concurrency, pass your own scope as the first argument: `asTextTask(scope = myScope) { input -> ... }`.
+
+:::
+
 ## RAG Evaluation with Koog
 
 For RAG pipelines, emit both the generated answer and retrieved context. You can build it manually (as below) or wrap your call with `ragTask` if you already have a function returning `RagResult`.

--- a/docs/docs/integrations/koog.md
+++ b/docs/docs/integrations/koog.md
@@ -12,6 +12,10 @@ Dokimos works with [Koog](https://github.com/koog-ai/koog) so you can evaluate K
 
 **Kotlin-first experiments**: Build datasets, tasks, and evaluators with the Dokimos Kotlin DSL. No Java are builders needed.
 
+:::tip
+A `typedTask<T> { ... }` can return a Kotlin data class, which you compare with `StructuralMatchEvaluator` and read back with the reified `actualOutputAs<T>()`. See the [Structured & Typed Data](../evaluation/structured-typed-data.md) hub.
+:::
+
 ## Setup
 
 Add the Koog integration dependency:

--- a/docs/docs/integrations/langchain4j.md
+++ b/docs/docs/integrations/langchain4j.md
@@ -321,6 +321,116 @@ The `ragTask()` method extracts the input, calls your AI Service, and automatica
 
 This lets the `FaithfulnessEvaluator` check if the answer is grounded in what was actually retrieved.
 
+## Async Tasks
+
+When each example is an independent, blocking model or assistant call, the async tasks let the experiment keep many calls in flight instead of blocking one thread per example. Wire them with `Experiment.builder().asyncTask(...)` and bound concurrency with `parallelism(...)`.
+
+`asyncTask(model)` is the async counterpart of `simpleTask(model)`, and `asyncRagTask(assistantCall)` is the async counterpart of `ragTask(...)` — it still extracts the retrieved context from `Result.sources()` into the `"context"` key. Both dispatch the blocking call on the common `ForkJoinPool` via `CompletableFuture.supplyAsync(...)`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.*;
+import dev.dokimos.langchain4j.LangChain4jSupport;
+
+// Simple Q&A
+AsyncTask task = LangChain4jSupport.asyncTask(model);
+
+// RAG (extracts context from Result.sources())
+AsyncTask ragTask = LangChain4jSupport.asyncRagTask(assistant::chat);
+
+ExperimentResult result = Experiment.builder()
+    .name("LangChain4j Async RAG")
+    .dataset(dataset)
+    .asyncTask(ragTask)
+    .parallelism(8)
+    .evaluators(List.of(faithfulness, contextRelevancy))
+    .build()
+    .run();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.AsyncTask
+import dev.dokimos.kotlin.dsl.experiment
+import dev.dokimos.langchain4j.LangChain4jSupport
+
+// Simple Q&A
+val task: AsyncTask = LangChain4jSupport.asyncTask(model)
+
+// RAG (extracts context from Result.sources())
+val ragTask: AsyncTask = LangChain4jSupport.asyncRagTask(assistant::chat)
+
+val result = experiment {
+    name = "LangChain4j Async RAG"
+    dataset(dataset)
+    asyncTask(ragTask)
+    parallelism = 8
+    evaluators {
+        faithfulness(judge) { threshold = 0.7 }
+    }
+}.run()
+```
+
+  </TabItem>
+</Tabs>
+
+To write under a different output key, use `asyncTask(model, outputKey)`. `asyncRagTask` has a four-arg overload `asyncRagTask(assistantCall, inputKey, outputKey, contextKey)` for custom dataset keys.
+
+:::note
+
+The common pool is shared process-wide and its effective parallelism is roughly one less than the CPU count, so it caps how many blocking calls actually run at once even when `parallelism` is higher. For controlled, isolated concurrency, pass an `Executor` sized to your target throughput — `asyncTask(model, executor)` or `asyncRagTask(assistantCall, executor)`.
+
+:::
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+// A pool sized to match your desired concurrency
+Executor executor = Executors.newFixedThreadPool(16);
+
+AsyncTask ragTask = LangChain4jSupport.asyncRagTask(assistant::chat, executor);
+
+Experiment.builder()
+    .dataset(dataset)
+    .asyncTask(ragTask)
+    .parallelism(16)
+    .evaluators(List.of(faithfulness))
+    .build()
+    .run();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import java.util.concurrent.Executors
+
+// A pool sized to match your desired concurrency
+val executor = Executors.newFixedThreadPool(16)
+
+val ragTask = LangChain4jSupport.asyncRagTask(assistant::chat, executor)
+
+experiment {
+    dataset(dataset)
+    asyncTask(ragTask)
+    parallelism = 16
+    evaluators {
+        faithfulness(judge) { threshold = 0.7 }
+    }
+}.run()
+```
+
+  </TabItem>
+</Tabs>
+
 ## Advanced Usage
 
 ### Custom Dataset Keys

--- a/docs/docs/integrations/langchain4j.md
+++ b/docs/docs/integrations/langchain4j.md
@@ -888,6 +888,59 @@ object RAGEvaluation {
   </TabItem>
 </Tabs>
 
+## Structured / typed output
+
+When your AI Service returns structured data — for example a record from a typed AI Service method — return that object under `"output"` instead of a string. Compare it with `StructuralMatchEvaluator` (numbers compare by value, formatting and key order don't count), and read it back type-safely with `actualOutputAs(Record.class)`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+record Invoice(String id, double total, List<String> items) {}
+
+// A LangChain4j AI Service can return a typed value directly
+interface Extractor {
+    Invoice extract(String text);
+}
+
+Task task = Task.typed(example -> extractor.extract(example.input()));
+
+Evaluator structural = StructuralMatchEvaluator.builder()
+    .name("Invoice Match")
+    .threshold(1.0)
+    .build();
+
+// In a custom evaluator, read the structured value back
+Invoice actual = testCase.actualOutputAs(Invoice.class);
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+data class Invoice(val id: String, val total: Double, val items: List<String>)
+
+// A LangChain4j AI Service can return a typed value directly
+interface Extractor {
+    fun extract(text: String): Invoice
+}
+
+val task = typedTask<Invoice> { example -> extractor.extract(example.input()) }
+
+val structural: Evaluator = StructuralMatchEvaluator.builder()
+    .name("Invoice Match")
+    .threshold(1.0)
+    .build()
+
+// In a custom evaluator, read the structured value back
+val actual = testCase.actualOutputAs(Invoice::class.java)
+```
+
+  </TabItem>
+</Tabs>
+
+See the [Structured & Typed Data](../evaluation/structured-typed-data.md) hub for the full pipeline.
+
 ## JUnit Integration
 
 Combine with [JUnit](./junit) for testing:

--- a/docs/docs/integrations/spring-ai.md
+++ b/docs/docs/integrations/spring-ai.md
@@ -379,6 +379,239 @@ Also see the [Datasets](../evaluation/datasets.md) and [Evaluators](../evaluatio
 
 :::
 
+## Async Tasks
+
+For datasets where each example is an independent, blocking `ChatClient` call, `asyncTask` lets the experiment keep many calls in flight instead of blocking one thread per example. Wire it with `Experiment.builder().asyncTask(...)` and bound concurrency with `parallelism(...)`.
+
+`SpringAiSupport.asyncTask(client)` reads the example input as the user message and writes the response under the default `"output"` key. The blocking `ChatClient` call is dispatched on the common `ForkJoinPool` via `CompletableFuture.supplyAsync(...)`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.*;
+import dev.dokimos.springai.SpringAiSupport;
+import org.springframework.ai.chat.client.ChatClient;
+
+ChatClient client = ChatClient.builder(chatModel).build();
+AsyncTask task = SpringAiSupport.asyncTask(client);
+
+ExperimentResult result = Experiment.builder()
+    .name("Spring AI Async")
+    .dataset(dataset)
+    .asyncTask(task)
+    .parallelism(8)
+    .evaluators(evaluators)
+    .build()
+    .run();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.AsyncTask
+import dev.dokimos.kotlin.dsl.experiment
+import dev.dokimos.springai.SpringAiSupport
+import org.springframework.ai.chat.client.ChatClient
+
+val client = ChatClient.builder(chatModel).build()
+val task: AsyncTask = SpringAiSupport.asyncTask(client)
+
+val result = experiment {
+    name = "Spring AI Async"
+    dataset(dataset)
+    asyncTask(task)
+    parallelism = 8
+    evaluators { evaluators.forEach { evaluator(it) } }
+}.run()
+```
+
+  </TabItem>
+</Tabs>
+
+To read and write different keys, use `asyncTask(client, inputKey, outputKey)`.
+
+:::note
+
+The common pool is shared process-wide and its effective parallelism is roughly one less than the CPU count, so it caps how many blocking calls actually run at once even when `parallelism` is higher. For controlled, isolated concurrency, pass an `Executor` sized to your target throughput — `asyncTask(client, executor)` or the four-arg `asyncTask(client, inputKey, outputKey, executor)`.
+
+:::
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+// A pool sized to match your desired concurrency
+Executor executor = Executors.newFixedThreadPool(16);
+
+AsyncTask task = SpringAiSupport.asyncTask(client, executor);
+
+Experiment.builder()
+    .dataset(dataset)
+    .asyncTask(task)
+    .parallelism(16)
+    .evaluators(evaluators)
+    .build()
+    .run();
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import java.util.concurrent.Executors
+
+// A pool sized to match your desired concurrency
+val executor = Executors.newFixedThreadPool(16)
+
+val task = SpringAiSupport.asyncTask(client, executor)
+
+experiment {
+    dataset(dataset)
+    asyncTask(task)
+    parallelism = 16
+    evaluators { evaluators.forEach { evaluator(it) } }
+}.run()
+```
+
+  </TabItem>
+</Tabs>
+
+### Reactive Tasks
+
+If your pipeline is already reactive (`Mono`), bridge it directly instead of blocking on a pool. `reactiveStringTask` wraps a `Mono<String>` response under the default `"output"` key; `reactiveTask` adapts a `Mono<TaskResult>` when you want full control over the output map. Each `Mono` is converted to a `CompletableFuture` via `Mono.toFuture()`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.*;
+import dev.dokimos.springai.SpringAiSupport;
+
+// Mono<String> -> output
+AsyncTask stringTask = SpringAiSupport.reactiveStringTask(example ->
+    reactiveChatClient.prompt()
+        .user(example.input())
+        .stream()
+        .content()
+        .collectList()
+        .map(parts -> String.join("", parts)));
+
+// Mono<TaskResult> -> full control over the output map
+AsyncTask resultTask = SpringAiSupport.reactiveTask(example ->
+    reactiveChatClient.prompt()
+        .user(example.input())
+        .stream()
+        .content()
+        .collectList()
+        .map(parts -> TaskResult.of(Map.of("output", String.join("", parts)))));
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.AsyncTask
+import dev.dokimos.core.TaskResult
+import dev.dokimos.springai.SpringAiSupport
+
+// Mono<String> -> output
+val stringTask: AsyncTask = SpringAiSupport.reactiveStringTask { example ->
+    reactiveChatClient.prompt()
+        .user(example.input())
+        .stream()
+        .content()
+        .collectList()
+        .map { parts -> parts.joinToString("") }
+}
+
+// Mono<TaskResult> -> full control over the output map
+val resultTask: AsyncTask = SpringAiSupport.reactiveTask { example ->
+    reactiveChatClient.prompt()
+        .user(example.input())
+        .stream()
+        .content()
+        .collectList()
+        .map { parts -> TaskResult.of(mapOf("output" to parts.joinToString(""))) }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## Evaluating Tool-Calling Agents
+
+When your Spring AI agent calls tools, `toAgentTrace` turns an `AssistantMessage` (and its `ToolResponseMessage`s) into an `AgentTrace` you can feed straight into the [agent evaluators](../evaluation/agent-evaluation). Tool calls are matched to their results by tool-call id, and `toToolDefinitions` converts the Spring AI tool definitions the agent was given so calls can be checked against them.
+
+`AgentTrace.toTestCase(userMessage, tools)` produces the `EvalTestCase` the agent evaluators expect.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.*;
+import dev.dokimos.core.agents.AgentTrace;
+import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator;
+import dev.dokimos.springai.SpringAiSupport;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+
+// From your agent run: the assistant message and the tool responses produced for it
+AssistantMessage assistantMessage = /* ... */;
+List<ToolResponseMessage> toolResponses = /* ... */;
+
+// Convert the tools the agent was given
+List<ToolDefinition> tools = SpringAiSupport.toToolDefinitions(springAiToolDefinitions);
+
+// Build a trace (tool calls matched to results by id) and a test case
+AgentTrace trace = SpringAiSupport.toAgentTrace(assistantMessage, toolResponses);
+EvalTestCase testCase = trace.toTestCase("What's the weather in Paris?", tools);
+
+// Evaluate with an agent evaluator
+EvalResult result = new ToolCorrectnessEvaluator().evaluate(testCase);
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.EvalResult
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.core.agents.AgentTrace
+import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator
+import dev.dokimos.springai.SpringAiSupport
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.ToolResponseMessage
+
+// From your agent run
+val assistantMessage: AssistantMessage = /* ... */
+val toolResponses: List<ToolResponseMessage> = /* ... */
+
+// Convert the tools the agent was given
+val tools = SpringAiSupport.toToolDefinitions(springAiToolDefinitions)
+
+// Build a trace (tool calls matched to results by id) and a test case
+val trace: AgentTrace = SpringAiSupport.toAgentTrace(assistantMessage, toolResponses)
+val testCase: EvalTestCase = trace.toTestCase("What's the weather in Paris?", tools)
+
+// Evaluate with an agent evaluator
+val result: EvalResult = ToolCorrectnessEvaluator().evaluate(testCase)
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+
+`toAgentTrace(message)` (without tool responses) builds a trace from the tool calls alone — use it when you only need to evaluate which tools the agent chose, not their results.
+
+:::
+
 ## Bridging Spring AI Evaluators
 
 If you're using Spring AI's built-in evaluators and want to integrate with Dokimos:

--- a/docs/docs/integrations/spring-ai.md
+++ b/docs/docs/integrations/spring-ai.md
@@ -832,6 +832,57 @@ val result = experiment {
   </TabItem>
 </Tabs>
 
+## Structured / typed output
+
+When your Spring AI call returns structured data — for example a record mapped from the model's JSON output — return that object under `"output"` instead of a string. Compare it with `StructuralMatchEvaluator` (numbers compare by value, formatting and key order don't count), and read it back type-safely with `actualOutputAs(Record.class)`.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+record Invoice(String id, double total, List<String> items) {}
+
+Task task = Task.typed(example -> chatClient.prompt()
+    .user(example.input())
+    .call()
+    .entity(Invoice.class));   // Spring AI maps the response to a record
+
+Evaluator structural = StructuralMatchEvaluator.builder()
+    .name("Invoice Match")
+    .threshold(1.0)
+    .build();
+
+// In a custom evaluator, read the structured value back
+Invoice actual = testCase.actualOutputAs(Invoice.class);
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+data class Invoice(val id: String, val total: Double, val items: List<String>)
+
+val task = typedTask<Invoice> { example ->
+    chatClient.prompt()
+        .user(example.input())
+        .call()
+        .entity(Invoice::class.java)   // Spring AI maps the response to a record
+}
+
+val structural: Evaluator = StructuralMatchEvaluator.builder()
+    .name("Invoice Match")
+    .threshold(1.0)
+    .build()
+
+// In a custom evaluator, read the structured value back
+val actual = testCase.actualOutputAs(Invoice::class.java)
+```
+
+  </TabItem>
+</Tabs>
+
+See the [Structured & Typed Data](../evaluation/structured-typed-data.md) hub for the full pipeline.
+
 ## Field Mappings
 
 ### EvaluationRequest -> EvalTestCase

--- a/docs/docs/integrations/spring-ai.md
+++ b/docs/docs/integrations/spring-ai.md
@@ -61,6 +61,7 @@ JudgeLM judge = SpringAiSupport.asJudge(clientBuilder);
 Evaluator correctness = LLMJudgeEvaluator.builder()
     .name("Answer Correctness")
     .criteria("Is the answer factually correct?")
+    .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
     .judge(judge)
     .threshold(0.8)
     .build();
@@ -278,6 +279,7 @@ public class SpringAiEvaluation {
             LLMJudgeEvaluator.builder()
                 .name("Answer Quality")
                 .criteria("Is the answer helpful and accurate?")
+                .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
                 .judge(judge)
                 .threshold(0.8)
                 .build(),
@@ -1021,6 +1023,7 @@ void experimentMeetsQualityThresholds() {
         LLMJudgeEvaluator.builder()
             .name("Answer Quality")
             .criteria("Is the answer helpful, clear, and accurate?")
+            .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
             .judge(judge)
             .build()
     );

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -11,8 +11,9 @@ Dokimos is an open-source Evaluation Framework for LLM applications in Java and 
 1. Build and manage datasets programatically, from files, or with custom sources
 2. Run experiments with built-in evaluators, or your own custom evaluators
 3. Evaluate AI agents, including their tool calls and execution traces
-4. Run evals in a test-driven way with JUnit parameterized tests
-5. Track experiment results over time with an optional server and web UI
+4. Work with typed, structured data end to end, from task output to evaluator
+5. Run evals in a test-driven way with JUnit parameterized tests
+6. Track experiment results over time with an optional server and web UI
 
 Dokimos aims to bring the evaluation tooling that Python developers have to the Java ecosystem.
 
@@ -23,6 +24,10 @@ Using a coding agent? Paste this to get a first eval written against your own co
 Read the **[Getting started Guide](./getting-started/installation)**.
 
 Lean more about what you can build with `dokimos` by exploring the [examples module](https://github.com/dokimos-dev/dokimos/tree/master/dokimos-examples).
+
+## Structured & typed data
+
+Dokimos supports typed, structured data end to end. A task can return a real domain object — a record, a POJO, a list — Dokimos compares it structurally (numbers compare by value, formatting and key order don't count), and you read it back type-safely in custom evaluators, LLM judges, tool-call results, and metadata. See the **[Structured & Typed Data](./evaluation/structured-typed-data.md)** guide for the whole pipeline in one place.
 
 ## The production eval loop
 

--- a/docs/docs/tutorials/evaluate-llm-output-in-junit.md
+++ b/docs/docs/tutorials/evaluate-llm-output-in-junit.md
@@ -1,0 +1,504 @@
+---
+sidebar_position: 2
+title: "Test your LLM in JUnit: evaluate and gate model output in Java"
+description: "Evaluate LLM output in JUnit with Dokimos. Add one dependency, assert model responses in Java or Kotlin, add an LLM judge, and gate quality in CI."
+keywords:
+  - evaluate LLM output
+  - LLM testing Java
+  - JUnit LLM evaluation
+  - test LLM in CI
+  - Dokimos
+---
+
+# Test your LLM in JUnit: evaluate and gate model output in Java
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Most LLM evaluation tooling is Python-first. If you ship on the JVM, that means a second language, a second toolchain, and a separate pipeline just to check whether your model output is any good.
+
+Dokimos runs where your code already runs. This tutorial takes you from zero to a passing-or-failing LLM evaluation **inside your existing JUnit test suite** - the same `mvn test` your team already runs, the same CI that already gates your merges. No new service, no Python.
+
+By the end you will have:
+
+- A JUnit test that calls a model and asserts its output, failing the build when quality drops
+- A deterministic check (exact match), a semantic check (an LLM judge), and a structured-output check
+- A dataset-driven test that runs many cases from one method
+
+## Prerequisites
+
+- Java 17 or later
+- Maven or Gradle
+- An OpenAI API key exported as `OPENAI_API_KEY`
+
+This tutorial calls OpenAI directly through the [OpenAI Java SDK](https://github.com/openai/openai-java) so there is no framework prerequisite. If you already use Spring AI or LangChain4j, see the [Spring AI agent evaluation tutorial](/tutorials/spring-ai-agent-evaluation) instead.
+
+## Step 1: Add the dependency
+
+Dokimos ships a JUnit integration. Add it in test scope alongside the core library.
+
+#### Maven
+
+```xml
+<dependencies>
+    <!-- Dokimos core: evaluators and test cases -->
+    <dependency>
+        <groupId>dev.dokimos</groupId>
+        <artifactId>dokimos-core</artifactId>
+        <version>${dokimos.version}</version>
+        <scope>test</scope>
+    </dependency>
+
+    <!-- Dokimos JUnit integration: @DatasetSource -->
+    <dependency>
+        <groupId>dev.dokimos</groupId>
+        <artifactId>dokimos-junit</artifactId>
+        <version>${dokimos.version}</version>
+        <scope>test</scope>
+    </dependency>
+
+    <!-- The model client used in this tutorial -->
+    <dependency>
+        <groupId>com.openai</groupId>
+        <artifactId>openai-java</artifactId>
+        <version>4.11.0</version>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+#### Gradle
+
+```groovy
+dependencies {
+    testImplementation 'dev.dokimos:dokimos-core:${dokimosVersion}'
+    testImplementation 'dev.dokimos:dokimos-junit:${dokimosVersion}'
+    testImplementation 'com.openai:openai-java:4.11.0'
+}
+```
+
+See [Installation](/getting-started/installation) for the current version and other build setups.
+
+## Step 2: Call the model and get text out
+
+Dokimos does not call the model for you - you bring your own call and hand the result to an evaluator. Here is a small helper that calls a `gpt-5.x` model through the OpenAI Responses API and returns the output text.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.ChatModel;
+import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCreateParams;
+
+static final OpenAIClient CLIENT = OpenAIOkHttpClient.fromEnv(); // reads OPENAI_API_KEY
+
+static String ask(String prompt) {
+    Response response = CLIENT
+            .responses()
+            .create(ResponseCreateParams.builder()
+                    .model(ChatModel.GPT_5_2)
+                    .input(prompt)
+                    .build());
+    return response.output().stream()
+            .filter(item -> item.isMessage())
+            .flatMap(item -> item.asMessage().content().stream())
+            .filter(content -> content.isOutputText())
+            .map(content -> content.asOutputText().text())
+            .reduce("", String::concat)
+            .trim();
+}
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import com.openai.client.okhttp.OpenAIOkHttpClient
+import com.openai.models.ChatModel
+import com.openai.models.responses.ResponseCreateParams
+
+val CLIENT = OpenAIOkHttpClient.fromEnv() // reads OPENAI_API_KEY
+
+fun ask(prompt: String): String {
+    val response = CLIENT.responses().create(
+        ResponseCreateParams.builder()
+            .model(ChatModel.GPT_5_2)
+            .input(prompt)
+            .build()
+    )
+    return response.output()
+        .filter { it.isMessage }
+        .flatMap { it.asMessage().content() }
+        .filter { it.isOutputText }
+        .joinToString("") { it.asOutputText().text() }
+        .trim()
+}
+```
+
+  </TabItem>
+</Tabs>
+
+`OpenAIOkHttpClient.fromEnv()` reads `OPENAI_API_KEY` from the environment, so there are no secrets in your code.
+
+## Step 3: Write a deterministic eval
+
+For questions with one correct answer - math, extraction, a known fact - `ExactMatchEvaluator` is all you need. It compares the actual output to the expected output and the test fails when they differ.
+
+Rather than hardcoding cases, drive them from a dataset resource so adding a case is a one-line edit. Create `src/test/resources/datasets/junit-tutorial-qa.json`:
+
+```json
+{
+  "name": "JUnit Tutorial QA",
+  "examples": [
+    {
+      "input": "What is the capital of France? Reply with only the city name.",
+      "expectedOutput": "Paris",
+      "metadata": { "category": "geography" }
+    },
+    {
+      "input": "What is the capital of Japan? Reply with only the city name.",
+      "expectedOutput": "Tokyo",
+      "metadata": { "category": "geography" }
+    },
+    {
+      "input": "What is the capital of Italy? Reply with only the city name.",
+      "expectedOutput": "Rome",
+      "metadata": { "category": "geography" }
+    }
+  ]
+}
+```
+
+Now `@DatasetSource` turns each example into one run of a parameterized test. `example.toTestCase(answer)` builds the `EvalTestCase`, and `Assertions.assertEval(...)` fails the test if any evaluator does not pass.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.Assertions;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.Evaluator;
+import dev.dokimos.core.Example;
+import dev.dokimos.core.evaluators.ExactMatchEvaluator;
+import dev.dokimos.junit.DatasetSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+@ParameterizedTest(name = "[{index}] {0}")
+@DatasetSource("classpath:datasets/junit-tutorial-qa.json")
+void factualAnswerMatchesExactly(Example example) {
+    String answer = ask(example.input());
+
+    EvalTestCase testCase = example.toTestCase(answer);
+    Evaluator exactMatch = ExactMatchEvaluator.builder()
+            .name("Exact Match")
+            .threshold(1.0)
+            .build();
+
+    Assertions.assertEval(testCase, exactMatch);
+}
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.Assertions
+import dev.dokimos.core.Example
+import dev.dokimos.core.evaluators.ExactMatchEvaluator
+import dev.dokimos.junit.DatasetSource
+import org.junit.jupiter.params.ParameterizedTest
+
+@ParameterizedTest(name = "[{index}] {0}")
+@DatasetSource("classpath:datasets/junit-tutorial-qa.json")
+fun factualAnswerMatchesExactly(example: Example) {
+    val answer = ask(example.input())
+
+    val testCase = example.toTestCase(answer)
+    val exactMatch = ExactMatchEvaluator.builder()
+        .name("Exact Match")
+        .threshold(1.0)
+        .build()
+
+    Assertions.assertEval(testCase, exactMatch)
+}
+```
+
+  </TabItem>
+</Tabs>
+
+Run it with `mvn test`. Each dataset row is a separate test case in your IDE and your CI report.
+
+## Step 4: Add an LLM judge for open-ended answers
+
+Exact match breaks down the moment there is more than one correct phrasing. For open-ended output, use `LLMJudgeEvaluator`: it scores the answer against criteria you write in plain English, using an LLM as the grader. Use a cheaper model as the judge.
+
+The judge is just a [`JudgeLM`](/evaluation/evaluators#llmjudgeevaluator) - a one-method functional interface that takes a prompt and returns text - so you wrap the same OpenAI client.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.Assertions;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.Evaluator;
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.evaluators.LLMJudgeEvaluator;
+import com.openai.models.ChatModel;
+import com.openai.models.responses.ResponseCreateParams;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+JudgeLM judge() {
+    return prompt -> CLIENT
+            .responses()
+            .create(ResponseCreateParams.builder()
+                    .model(ChatModel.GPT_5_MINI)
+                    .input(prompt)
+                    .build())
+            .output()
+            .stream()
+            .filter(item -> item.isMessage())
+            .flatMap(item -> item.asMessage().content().stream())
+            .filter(content -> content.isOutputText())
+            .map(content -> content.asOutputText().text())
+            .reduce("", String::concat);
+}
+
+@Test
+void openEndedAnswerIsHelpful() {
+    String answer = ask("In one sentence, what does an LLM evaluation framework do?");
+
+    EvalTestCase testCase = EvalTestCase.builder()
+            .input("What does an LLM evaluation framework do?")
+            .actualOutput(answer)
+            .build();
+    Evaluator helpfulness = LLMJudgeEvaluator.builder()
+            .name("Helpfulness")
+            .criteria("Is the answer accurate, clear, and genuinely helpful?")
+            .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
+            .threshold(0.7)
+            .judge(judge())
+            .build();
+
+    Assertions.assertEval(testCase, helpfulness);
+}
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.Assertions
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.core.EvalTestCaseParam
+import dev.dokimos.core.JudgeLM
+import dev.dokimos.core.evaluators.LLMJudgeEvaluator
+import com.openai.models.ChatModel
+import com.openai.models.responses.ResponseCreateParams
+import org.junit.jupiter.api.Test
+
+fun judge(): JudgeLM = JudgeLM { prompt ->
+    CLIENT.responses().create(
+        ResponseCreateParams.builder()
+            .model(ChatModel.GPT_5_MINI)
+            .input(prompt)
+            .build()
+    )
+        .output()
+        .filter { it.isMessage }
+        .flatMap { it.asMessage().content() }
+        .filter { it.isOutputText }
+        .joinToString("") { it.asOutputText().text() }
+}
+
+@Test
+fun openEndedAnswerIsHelpful() {
+    val answer = ask("In one sentence, what does an LLM evaluation framework do?")
+
+    val testCase = EvalTestCase.builder()
+        .input("What does an LLM evaluation framework do?")
+        .actualOutput(answer)
+        .build()
+    val helpfulness = LLMJudgeEvaluator.builder()
+        .name("Helpfulness")
+        .criteria("Is the answer accurate, clear, and genuinely helpful?")
+        .evaluationParams(listOf(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
+        .threshold(0.7)
+        .judge(judge())
+        .build()
+
+    Assertions.assertEval(testCase, helpfulness)
+}
+```
+
+  </TabItem>
+</Tabs>
+
+The judge returns a score in `[0, 1]`; the test passes when it meets the `threshold`. See [LLMJudgeEvaluator](/evaluation/evaluators#llmjudgeevaluator) for scoring details.
+
+## Step 5 (bonus): Assert on structured output
+
+Models increasingly return JSON. Comparing JSON as a string is brittle - `21` versus `21.0`, reordered keys, or extra whitespace all trip up `equals`. `StructuralMatchEvaluator` compares the two payloads as JSON structures, so numbers match by value and you choose how strict to be about field sets and array order.
+
+Ask the model for JSON, parse it into a `Map`, store it under the `output` key, and compare it against the expected contract. Then read the same output back through the **typed accessor** `actualOutputAs(...)` - no manual map juggling.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.Assertions;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.Evaluator;
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator;
+import dev.dokimos.core.evaluators.StructuralMatchMode;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+static final ObjectMapper JSON = new ObjectMapper();
+
+record WeatherReport(String city, int temperatureCelsius, String condition) {}
+
+@Test
+void structuredOutputMatchesContract() throws Exception {
+    String raw = ask("Return ONLY compact JSON with keys city (string), temperatureCelsius "
+            + "(integer), and condition (string) for this report: it is 21 degrees Celsius and "
+            + "sunny in Paris. Do not wrap it in markdown.");
+
+    Map<String, Object> actual = JSON.readValue(raw, new TypeReference<>() {});
+
+    EvalTestCase testCase = EvalTestCase.builder()
+            .input("weather report for Paris")
+            .actualOutput("output", actual)
+            .expectedOutput("output", Map.of(
+                    "city", "Paris", "temperatureCelsius", 21, "condition", "sunny"))
+            .build();
+
+    Evaluator structuralMatch = StructuralMatchEvaluator.builder()
+            .name("Structural Match")
+            .mode(StructuralMatchMode.LENIENT)  // tolerate extra fields, ignore array order
+            .threshold(1.0)
+            .build();
+
+    Assertions.assertEval(testCase, structuralMatch);
+
+    // Typed accessor: read the same output back as a record.
+    WeatherReport report = testCase.actualOutputAs(WeatherReport.class);
+    assertEquals("Paris", report.city());
+    assertEquals(21, report.temperatureCelsius());
+}
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import dev.dokimos.core.Assertions
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator
+import dev.dokimos.core.evaluators.StructuralMatchMode
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+val JSON = ObjectMapper()
+
+data class WeatherReport(val city: String, val temperatureCelsius: Int, val condition: String)
+
+@Test
+fun structuredOutputMatchesContract() {
+    val raw = ask(
+        "Return ONLY compact JSON with keys city (string), temperatureCelsius " +
+            "(integer), and condition (string) for this report: it is 21 degrees Celsius and " +
+            "sunny in Paris. Do not wrap it in markdown."
+    )
+
+    val actual: Map<String, Any> = JSON.readValue(raw, object : TypeReference<Map<String, Any>>() {})
+
+    val testCase = EvalTestCase.builder()
+        .input("weather report for Paris")
+        .actualOutput("output", actual)
+        .expectedOutput("output", mapOf(
+            "city" to "Paris", "temperatureCelsius" to 21, "condition" to "sunny"))
+        .build()
+
+    val structuralMatch = StructuralMatchEvaluator.builder()
+        .name("Structural Match")
+        .mode(StructuralMatchMode.LENIENT) // tolerate extra fields, ignore array order
+        .threshold(1.0)
+        .build()
+
+    Assertions.assertEval(testCase, structuralMatch)
+
+    // Typed accessor: read the same output back as a typed object.
+    val report = testCase.actualOutputAs(WeatherReport::class.java)
+    assertEquals("Paris", report.city)
+    assertEquals(21, report.temperatureCelsius)
+}
+```
+
+  </TabItem>
+</Tabs>
+
+`LENIENT` mode lets the model add fields you do not care about (and ignores array order); switch to `StructuralMatchMode.STRICT` when the contract must be exact. See [StructuralMatchEvaluator](/evaluation/evaluators#structuralmatchevaluator) for the full scoring and mode rules.
+
+## Step 6: Gate your build in CI
+
+The payoff: because these are ordinary JUnit tests, any CI that runs your tests already gates on them. When the model regresses below your thresholds, the build goes red.
+
+The only setup is making the API key available. In GitHub Actions:
+
+```yaml
+name: LLM Evaluation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run LLM evaluations
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: mvn test
+```
+
+:::tip Keep model calls off the critical path
+Tests that hit a live model cost money and add latency. A common pattern is to tag them and run the full set on a schedule or on demand, while keeping every commit fast. Annotate model-calling tests with JUnit's `@Tag("integration")` and gate them on the key with `@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")`, then run them with `mvn verify -Dgroups=integration`.
+:::
+
+## Next steps
+
+- Browse every built-in evaluator in the [Evaluators reference](/evaluation/evaluators)
+- Read the [JUnit integration guide](/integrations/junit) for more `@DatasetSource` options
+- Evaluating tool-using agents? See [Agent evaluation](/evaluation/agent-evaluation)
+- Track scores over time and compare runs with the [Dokimos Server](/server/overview)
+
+## Resources
+
+- [Tutorial example code](https://github.com/dokimos-dev/dokimos/tree/master/dokimos-examples/src/test/java/dev/dokimos/examples/junit5) - the complete, compiling test from this tutorial
+- [OpenAI Java SDK](https://github.com/openai/openai-java)
+- [Dokimos GitHub repository](https://github.com/dokimos-dev/dokimos)
+
+---
+
+If this saved you from standing up a Python pipeline just to test your model, consider giving the repository a star on GitHub ⭐.

--- a/docs/docs/tutorials/spring-ai-agent-evaluation.md
+++ b/docs/docs/tutorials/spring-ai-agent-evaluation.md
@@ -1760,6 +1760,55 @@ MatchingStrategy.allOf(strategy1, strategy2)  // AND
   </TabItem>
 </Tabs>
 
+### Typed Tool-Call Results
+
+When you extend the assistant into a tool-using agent, a tool often returns structured data, not a string. Capture that result with `resultJson(...)` — it serializes the value to JSON so you stop hand-escaping — and read it back type-safely with `resultAs(Class<T>)`. This keeps a sequential agent's `output -> input -> output` chain assertable.
+
+<Tabs groupId="lang" defaultValue="java">
+  <TabItem value="java" label="Java">
+
+```java
+import dev.dokimos.core.agents.ToolCall;
+
+record Booking(String confirmation, double total) {}
+
+// Build a tool call whose result is a structured value
+ToolCall call = ToolCall.builder()
+    .name("book_hotel")
+    .argument("city", "Paris")
+    .argument("nights", 5)
+    .resultJson(new Booking("ABC123", 540.0))  // serialized to JSON, no escaping
+    .build();
+
+// Read the structured result back as a real object
+Booking booked = call.resultAs(Booking.class);
+```
+
+  </TabItem>
+  <TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+import dev.dokimos.core.agents.ToolCall
+
+data class Booking(val confirmation: String, val total: Double)
+
+// Build a tool call whose result is a structured value
+val call = ToolCall.builder()
+    .name("book_hotel")
+    .argument("city", "Paris")
+    .argument("nights", 5)
+    .resultJson(Booking("ABC123", 540.0))  // serialized to JSON, no escaping
+    .build()
+
+// Read the structured result back as a real object
+val booked = call.resultAs(Booking::class.java)
+```
+
+  </TabItem>
+</Tabs>
+
+For the whole typed-data pipeline, see the [Structured & Typed Data](/evaluation/structured-typed-data) hub; for the full agent data model, see [Agent Evaluation](/evaluation/agent-evaluation).
+
 ### Async Evaluation
 
 For large datasets, you can run evaluations asynchronously:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -34,12 +34,15 @@ knowledge disagree, the page is correct.
    faithfulness, contextual relevance, hallucination, correctness. A tool-using agent:
    capture the run as an AgentTrace and use the agent evaluators (tool-call validity, tool
    correctness, trajectory, tool error, tool efficiency, task completion, argument
-   hallucination, tool name and description reliability). Plain text: exact match, regex,
-   or an LLM judge.
+   hallucination, tool name and description reliability). Structured/JSON output: return a
+   record from Task.typed, compare with StructuralMatchEvaluator, read back with
+   actualOutputAs(...). Plain text: exact match, regex, or an LLM judge.
 4. Read the matching page below (full text in llms-full.txt) before writing code: getting
    started and installation; the evaluators reference; agent and tool-call evaluation,
    which also covers the Spring AI, LangChain4j, Koog, and OpenAI trace extractors;
-   datasets; experiments; the JUnit integration (@DatasetSource, Assertions.assertEval).
+   structured and typed data (Task.typed, StructuralMatchEvaluator, actualOutputAs,
+   resultJson/resultAs); datasets; experiments; the JUnit integration (@DatasetSource,
+   Assertions.assertEval).
 5. Write ONE eval first and make it run in the existing test suite. For CI, assert a
    threshold (for example assertThat(result.passRate()).isGreaterThan(0.9) or
    Assertions.assertEval(testCase, evaluator)) so the build fails when quality drops. Tell
@@ -54,6 +57,10 @@ knowledge disagree, the page is correct.
   AgentTrace.toTestCase(...) or a framework extractor rather than wiring keys by hand.
 - Do not invent evaluator names or builder methods. If unsure, fetch the evaluators or
   agent-evaluation page and use the exact signature shown.
+- For structured/JSON output, return a record from Task.typed (or typedTask in Kotlin) and
+  compare with StructuralMatchEvaluator; read it back with actualOutputAs/expectedOutputAs/
+  inputAs (use OutputType<T> for generics). For typed tool calls, store results with
+  resultJson(...) and read them back with resultAs(...); read arguments with argumentsAs(...).
 
 Skill registry for agents: /.well-known/skills/index.json`;
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -72,7 +72,7 @@ const config: Config = {
 
   // Latest released version, surfaced in the landing page install snippet.
   customFields: {
-    dokimosVersion: "0.19.0",
+    dokimosVersion: "0.20.0",
   },
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future

--- a/docs/src/components/ReleaseTimeline/index.tsx
+++ b/docs/src/components/ReleaseTimeline/index.tsx
@@ -6,6 +6,103 @@ type Release = { version: string; date: string; latest?: boolean; lead?: string;
 
 const RELEASES: Release[] = [
   {
+    version: "0.20.0",
+    date: "June 2026",
+    lead: "Typed, structured outputs end to end and non-blocking async task execution: return a POJO from a task, match it structurally, and drive an experiment from suspend or reactive code without a thread per example.",
+    groups: [
+      {
+        label: "Added",
+        items: [
+          {
+            title: "Typed structured output",
+            body: (
+              <>
+                <code>Task.typed(fn)</code> lets a task return a record, list, or other POJO under the{" "}
+                <code>"output"</code> key, and <code>EvalTestCase.actualOutputAs(...)</code> /{" "}
+                <code>expectedOutputAs(...)</code> read it back type-safely via a{" "}
+                <code>Class&lt;T&gt;</code> or an <code>OutputType&lt;T&gt;</code> super-type token for
+                generics like <code>List&lt;Whisky&gt;</code>. A failed conversion throws{" "}
+                <code>DokimosTypeConversionException</code>.
+              </>
+            ),
+          },
+          {
+            title: "StructuralMatchEvaluator",
+            body: (
+              <>
+                Compares an expected structure against the actual one. <code>STRICT</code> requires the
+                exact field set and array order; <code>LENIENT</code> allows extra fields and ignores
+                array order. Both compare numbers by value. Scores the fraction of matching leaf paths
+                by default, or call <code>binary()</code> for a 1.0/0.0 all-or-nothing score.
+              </>
+            ),
+          },
+          {
+            title: "Async task execution",
+            body: (
+              <>
+                <code>AsyncTask</code> returns a <code>CompletableFuture&lt;TaskResult&gt;</code>, and{" "}
+                <code>Experiment.builder().asyncTask(...)</code> runs it through a bounded async path
+                that caps in-flight invocations with <code>parallelism(int)</code> — no thread parked
+                per example.
+              </>
+            ),
+          },
+          {
+            title: "Async and reactive adapters",
+            body: (
+              <>
+                Spring AI adds <code>asyncTask(...)</code> and <code>reactiveTask(...)</code>,
+                LangChain4j adds <code>asyncTask(...)</code> and <code>asyncRagTask(...)</code>, and
+                Koog adds <code>asTask(...)</code> / <code>asTextTask(...)</code>. Each has an overload
+                that takes an <code>Executor</code> so calls run on a pool you control.
+              </>
+            ),
+          },
+          {
+            title: "Kotlin task DSL and ToolCall.resultJson",
+            body: (
+              <>
+                Kotlin adds <code>typedTask&lt;T&gt; {"{ ... }"}</code> for returning a POJO directly
+                and <code>suspendTask {"{ ... }"}</code> for a suspend body, and{" "}
+                <code>ToolCall.Builder.resultJson(Object)</code> serializes a structured tool result to
+                compact JSON.
+              </>
+            ),
+          },
+          {
+            title: "Spring AI tool-eval example",
+            body: "A runnable Spring AI whisky-agent example that exercises the agent tool evaluators end to end.",
+          },
+        ],
+      },
+      {
+        label: "Changed",
+        items: [
+          {
+            title: "Judge renders structured output as JSON",
+            body: (
+              <>
+                <code>LLMJudgeEvaluator</code> renders a non-String output as pretty-printed JSON so the
+                judge sees a parseable structured value; String and primitive output is rendered
+                verbatim as before.
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        label: "Fixed",
+        items: [
+          {
+            title: "Parallel executor shutdown",
+            body: "The parallel experiment executor shuts down forcibly when a run fails, so worker threads no longer leak.",
+          },
+        ],
+      },
+    ],
+  },
+  {
     version: "0.19.0",
     date: "June 2, 2026",
     latest: true,

--- a/docs/src/components/ReleaseTimeline/index.tsx
+++ b/docs/src/components/ReleaseTimeline/index.tsx
@@ -89,6 +89,26 @@ const RELEASES: Release[] = [
               </>
             ),
           },
+          {
+            title: "task and asyncTask are mutually exclusive",
+            body: (
+              <>
+                <code>Experiment.builder().build()</code> now rejects configuring both a synchronous{" "}
+                <code>task</code>/<code>measuredTask</code> and an <code>asyncTask</code>, instead of
+                silently running the async path and ignoring the sync one.
+              </>
+            ),
+          },
+          {
+            title: "Consistent null handling in LangChain4j RAG tasks",
+            body: (
+              <>
+                <code>ragTask</code> and <code>asyncRagTask</code> coerce a null model response to an
+                empty string under the output key, matching <code>simpleTask</code> and{" "}
+                <code>asyncTask</code>.
+              </>
+            ),
+          },
         ],
       },
       {

--- a/dokimos-core/src/main/java/dev/dokimos/core/AsyncTask.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/AsyncTask.java
@@ -1,0 +1,30 @@
+package dev.dokimos.core;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A non-blocking task that produces a {@link TaskResult} asynchronously.
+ * <p>
+ * {@code AsyncTask} is the asynchronous counterpart to {@link MeasuredTask}: it returns a
+ * {@link CompletableFuture} so suspend-based or reactive callers (for example Koog agents or
+ * Reactor pipelines) can drive an experiment without blocking a thread per example. The completed
+ * future carries the same {@link TaskResult} carrier used by the synchronous paths, so call
+ * metrics flow through to each {@link ItemResult} exactly as they do for {@link MeasuredTask}.
+ * <p>
+ * Set an async task on an experiment via {@link Experiment.Builder#asyncTask(AsyncTask)}. When an
+ * async task is configured the experiment runs through a dedicated bounded async execution path
+ * (see {@link Experiment.Builder#parallelism(int)} for the in-flight cap); otherwise the
+ * synchronous sequential or parallel paths are used.
+ */
+@FunctionalInterface
+public interface AsyncTask {
+
+    /**
+     * Runs the task on the given {@link Example} and returns a future of its result.
+     *
+     * @param example the example containing inputs and expected outputs
+     * @return a future that completes with the task result, or completes exceptionally if the task
+     *     fails (a failed future is isolated as a failed {@link ItemResult}, the run continues)
+     */
+    CompletableFuture<TaskResult> run(Example example);
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/AsyncTask.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/AsyncTask.java
@@ -5,11 +5,10 @@ import java.util.concurrent.CompletableFuture;
 /**
  * A non-blocking task that produces a {@link TaskResult} asynchronously.
  * <p>
- * {@code AsyncTask} is the asynchronous counterpart to {@link MeasuredTask}: it returns a
- * {@link CompletableFuture} so suspend-based or reactive callers (for example Koog agents or
- * Reactor pipelines) can drive an experiment without blocking a thread per example. The completed
- * future carries the same {@link TaskResult} carrier used by the synchronous paths, so call
- * metrics flow through to each {@link ItemResult} exactly as they do for {@link MeasuredTask}.
+ * It returns a {@link CompletableFuture} so suspend-based or reactive callers (for example Koog
+ * agents or Reactor pipelines) can drive an experiment without blocking a thread per example. The
+ * completed future carries a {@link TaskResult}, so call metrics flow through to each
+ * {@link ItemResult} as they do for {@link MeasuredTask}.
  * <p>
  * Set an async task on an experiment via {@link Experiment.Builder#asyncTask(AsyncTask)}. When an
  * async task is configured the experiment runs through a dedicated bounded async execution path

--- a/dokimos-core/src/main/java/dev/dokimos/core/DatasetParser.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/DatasetParser.java
@@ -1,7 +1,7 @@
 package dev.dokimos.core;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.internal.Json;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
@@ -15,7 +15,6 @@ import java.util.Map;
 
 public final class DatasetParser {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final char BOM = '﻿';
 
     private DatasetParser() {}
@@ -23,7 +22,11 @@ public final class DatasetParser {
     public static Dataset parseJson(String json) {
         json = stripBom(json);
         try {
-            Map<String, Object> root = MAPPER.readValue(json, new TypeReference<>() {});
+            // Hardened load path: the comparison reader rejects duplicate keys, NaN/Infinity tokens,
+            // and trailing garbage so malformed datasets fail here instead of confusingly later.
+            Map<String, Object> root = Json.comparisonReader()
+                    .forType(new TypeReference<Map<String, Object>>() {})
+                    .readValue(json);
 
             String name = (String) root.getOrDefault("name", "unnamed");
             String description = (String) root.getOrDefault("description", "");
@@ -108,7 +111,9 @@ public final class DatasetParser {
             if (line.isBlank()) continue;
 
             try {
-                Map<String, Object> raw = MAPPER.readValue(line, new TypeReference<>() {});
+                Map<String, Object> raw = Json.comparisonReader()
+                        .forType(new TypeReference<Map<String, Object>>() {})
+                        .readValue(line);
                 examples.add(parseExample(raw));
             } catch (IOException e) {
                 throw new IllegalArgumentException(

--- a/dokimos-core/src/main/java/dev/dokimos/core/EvalTestCase.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/EvalTestCase.java
@@ -126,7 +126,7 @@ public record EvalTestCase(
      * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
      */
     public <T> T actualOutputAs(String key, Class<T> type) {
-        return convertOutput(actualOutputs.get(key), type);
+        return convertFrom(actualOutputs.get(key), type);
     }
 
     /**
@@ -139,7 +139,7 @@ public record EvalTestCase(
      * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
      */
     public <T> T actualOutputAs(String key, OutputType<T> type) {
-        return convertOutput(actualOutputs.get(key), type);
+        return convertFrom(actualOutputs.get(key), type);
     }
 
     /**
@@ -176,7 +176,7 @@ public record EvalTestCase(
      * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
      */
     public <T> T expectedOutputAs(String key, Class<T> type) {
-        return convertOutput(expectedOutputs.get(key), type);
+        return convertFrom(expectedOutputs.get(key), type);
     }
 
     /**
@@ -189,10 +189,86 @@ public record EvalTestCase(
      * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
      */
     public <T> T expectedOutputAs(String key, OutputType<T> type) {
-        return convertOutput(expectedOutputs.get(key), type);
+        return convertFrom(expectedOutputs.get(key), type);
     }
 
-    private static <T> T convertOutput(Object value, Class<T> type) {
+    /**
+     * Reads the primary input ({@code "input"}) converted to the given type.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "input"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(Class<T> type) {
+        return inputAs("input", type);
+    }
+
+    /**
+     * Reads the primary input ({@code "input"}) converted to the given generic type.
+     *
+     * @param type the target generic type token (for example {@code new OutputType<List<Foo>>() {}})
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "input"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(OutputType<T> type) {
+        return inputAs("input", type);
+    }
+
+    /**
+     * Reads the input under {@code key} converted to the given type.
+     *
+     * @param key the input key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(String key, Class<T> type) {
+        return convertFrom(inputs.get(key), type);
+    }
+
+    /**
+     * Reads the input under {@code key} converted to the given generic type.
+     *
+     * @param key the input key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(String key, OutputType<T> type) {
+        return convertFrom(inputs.get(key), type);
+    }
+
+    /**
+     * Reads the metadata value under {@code key} converted to the given type.
+     *
+     * @param key the metadata key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, Class<T> type) {
+        return convertFrom(metadata.get(key), type);
+    }
+
+    /**
+     * Reads the metadata value under {@code key} converted to the given generic type.
+     *
+     * @param key the metadata key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, OutputType<T> type) {
+        return convertFrom(metadata.get(key), type);
+    }
+
+    private static <T> T convertFrom(Object value, Class<T> type) {
         if (value == null) {
             return null;
         }
@@ -202,18 +278,18 @@ public record EvalTestCase(
         try {
             return Json.convert(value, type);
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException("Cannot convert output value to " + type.getName(), e);
+            throw new DokimosTypeConversionException("Cannot convert value to " + type.getName(), e);
         }
     }
 
-    private static <T> T convertOutput(Object value, OutputType<T> type) {
+    private static <T> T convertFrom(Object value, OutputType<T> type) {
         if (value == null) {
             return null;
         }
         try {
             return Json.convert(value, type.toJavaType());
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException("Cannot convert output value to " + type, e);
+            throw new DokimosTypeConversionException("Cannot convert value to " + type, e);
         }
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/EvalTestCase.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/EvalTestCase.java
@@ -202,8 +202,7 @@ public record EvalTestCase(
         try {
             return Json.convert(value, type);
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException(
-                    "Cannot convert output value to " + type.getName(), e);
+            throw new DokimosTypeConversionException("Cannot convert output value to " + type.getName(), e);
         }
     }
 
@@ -214,8 +213,7 @@ public record EvalTestCase(
         try {
             return Json.convert(value, type.toJavaType());
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException(
-                    "Cannot convert output value to " + type, e);
+            throw new DokimosTypeConversionException("Cannot convert output value to " + type, e);
         }
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/EvalTestCase.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/EvalTestCase.java
@@ -1,5 +1,7 @@
 package dev.dokimos.core;
 
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
+import dev.dokimos.core.internal.Json;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -88,6 +90,133 @@ public record EvalTestCase(
     public String expectedOutput() {
         Object value = expectedOutputs.get("output");
         return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Reads the primary actual output ({@code "output"}) converted to the given type.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "output"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T actualOutputAs(Class<T> type) {
+        return actualOutputAs("output", type);
+    }
+
+    /**
+     * Reads the primary actual output ({@code "output"}) converted to the given generic type.
+     *
+     * @param type the target generic type token (for example {@code new OutputType<List<Foo>>() {}})
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "output"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T actualOutputAs(OutputType<T> type) {
+        return actualOutputAs("output", type);
+    }
+
+    /**
+     * Reads the actual output under {@code key} converted to the given type.
+     *
+     * @param key the actual-output key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T actualOutputAs(String key, Class<T> type) {
+        return convertOutput(actualOutputs.get(key), type);
+    }
+
+    /**
+     * Reads the actual output under {@code key} converted to the given generic type.
+     *
+     * @param key the actual-output key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T actualOutputAs(String key, OutputType<T> type) {
+        return convertOutput(actualOutputs.get(key), type);
+    }
+
+    /**
+     * Reads the primary expected output ({@code "output"}) converted to the given type.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "output"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(Class<T> type) {
+        return expectedOutputAs("output", type);
+    }
+
+    /**
+     * Reads the primary expected output ({@code "output"}) converted to the given generic type.
+     *
+     * @param type the target generic type token (for example {@code new OutputType<List<Foo>>() {}})
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "output"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(OutputType<T> type) {
+        return expectedOutputAs("output", type);
+    }
+
+    /**
+     * Reads the expected output under {@code key} converted to the given type.
+     *
+     * @param key the expected-output key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(String key, Class<T> type) {
+        return convertOutput(expectedOutputs.get(key), type);
+    }
+
+    /**
+     * Reads the expected output under {@code key} converted to the given generic type.
+     *
+     * @param key the expected-output key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(String key, OutputType<T> type) {
+        return convertOutput(expectedOutputs.get(key), type);
+    }
+
+    private static <T> T convertOutput(Object value, Class<T> type) {
+        if (value == null) {
+            return null;
+        }
+        if (type.isInstance(value)) {
+            return type.cast(value);
+        }
+        try {
+            return Json.convert(value, type);
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException(
+                    "Cannot convert output value to " + type.getName(), e);
+        }
+    }
+
+    private static <T> T convertOutput(Object value, OutputType<T> type) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Json.convert(value, type.toJavaType());
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException(
+                    "Cannot convert output value to " + type, e);
+        }
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/Example.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Example.java
@@ -118,7 +118,7 @@ public record Example(
      * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
      */
     public <T> T expectedOutputAs(String key, Class<T> type) {
-        return convertOutput(expectedOutputs.get(key), type);
+        return convertFrom(expectedOutputs.get(key), type);
     }
 
     /**
@@ -131,10 +131,86 @@ public record Example(
      * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
      */
     public <T> T expectedOutputAs(String key, OutputType<T> type) {
-        return convertOutput(expectedOutputs.get(key), type);
+        return convertFrom(expectedOutputs.get(key), type);
     }
 
-    private static <T> T convertOutput(Object value, Class<T> type) {
+    /**
+     * Reads the primary input ({@code "input"}) converted to the given type.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "input"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(Class<T> type) {
+        return inputAs("input", type);
+    }
+
+    /**
+     * Reads the primary input ({@code "input"}) converted to the given generic type.
+     *
+     * @param type the target generic type token (for example {@code new OutputType<List<Foo>>() {}})
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "input"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(OutputType<T> type) {
+        return inputAs("input", type);
+    }
+
+    /**
+     * Reads the input under {@code key} converted to the given type.
+     *
+     * @param key the input key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(String key, Class<T> type) {
+        return convertFrom(inputs.get(key), type);
+    }
+
+    /**
+     * Reads the input under {@code key} converted to the given generic type.
+     *
+     * @param key the input key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T inputAs(String key, OutputType<T> type) {
+        return convertFrom(inputs.get(key), type);
+    }
+
+    /**
+     * Reads the metadata value under {@code key} converted to the given type.
+     *
+     * @param key the metadata key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, Class<T> type) {
+        return convertFrom(metadata.get(key), type);
+    }
+
+    /**
+     * Reads the metadata value under {@code key} converted to the given generic type.
+     *
+     * @param key the metadata key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, OutputType<T> type) {
+        return convertFrom(metadata.get(key), type);
+    }
+
+    private static <T> T convertFrom(Object value, Class<T> type) {
         if (value == null) {
             return null;
         }
@@ -144,18 +220,18 @@ public record Example(
         try {
             return Json.convert(value, type);
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException("Cannot convert output value to " + type.getName(), e);
+            throw new DokimosTypeConversionException("Cannot convert value to " + type.getName(), e);
         }
     }
 
-    private static <T> T convertOutput(Object value, OutputType<T> type) {
+    private static <T> T convertFrom(Object value, OutputType<T> type) {
         if (value == null) {
             return null;
         }
         try {
             return Json.convert(value, type.toJavaType());
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException("Cannot convert output value to " + type, e);
+            throw new DokimosTypeConversionException("Cannot convert value to " + type, e);
         }
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/Example.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Example.java
@@ -34,7 +34,7 @@ public record Example(
     }
 
     /**
-     * Creates an example with no dataset item id. Lets existing positional callers keep compiling.
+     * Creates an example with no dataset item id.
      *
      * @param inputs          the input values
      * @param expectedOutputs the expected output values
@@ -144,8 +144,7 @@ public record Example(
         try {
             return Json.convert(value, type);
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException(
-                    "Cannot convert output value to " + type.getName(), e);
+            throw new DokimosTypeConversionException("Cannot convert output value to " + type.getName(), e);
         }
     }
 
@@ -156,8 +155,7 @@ public record Example(
         try {
             return Json.convert(value, type.toJavaType());
         } catch (RuntimeException e) {
-            throw new DokimosTypeConversionException(
-                    "Cannot convert output value to " + type, e);
+            throw new DokimosTypeConversionException("Cannot convert output value to " + type, e);
         }
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/Example.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Example.java
@@ -1,5 +1,7 @@
 package dev.dokimos.core;
 
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
+import dev.dokimos.core.internal.Json;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -80,6 +82,83 @@ public record Example(
     public String expectedOutput() {
         Object value = expectedOutputs.get("output");
         return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Reads the primary expected output ({@code "output"}) converted to the given type.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "output"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(Class<T> type) {
+        return expectedOutputAs("output", type);
+    }
+
+    /**
+     * Reads the primary expected output ({@code "output"}) converted to the given generic type.
+     *
+     * @param type the target generic type token (for example {@code new OutputType<List<Foo>>() {}})
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if no {@code "output"} entry is present
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(OutputType<T> type) {
+        return expectedOutputAs("output", type);
+    }
+
+    /**
+     * Reads the expected output under {@code key} converted to the given type.
+     *
+     * @param key the expected-output key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(String key, Class<T> type) {
+        return convertOutput(expectedOutputs.get(key), type);
+    }
+
+    /**
+     * Reads the expected output under {@code key} converted to the given generic type.
+     *
+     * @param key the expected-output key
+     * @param type the target generic type token
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code key} is absent
+     * @throws DokimosTypeConversionException if the stored value cannot be converted to {@code type}
+     */
+    public <T> T expectedOutputAs(String key, OutputType<T> type) {
+        return convertOutput(expectedOutputs.get(key), type);
+    }
+
+    private static <T> T convertOutput(Object value, Class<T> type) {
+        if (value == null) {
+            return null;
+        }
+        if (type.isInstance(value)) {
+            return type.cast(value);
+        }
+        try {
+            return Json.convert(value, type);
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException(
+                    "Cannot convert output value to " + type.getName(), e);
+        }
+    }
+
+    private static <T> T convertOutput(Object value, OutputType<T> type) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Json.convert(value, type.toJavaType());
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException(
+                    "Cannot convert output value to " + type, e);
+        }
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
@@ -299,8 +299,8 @@ public class Experiment {
          * sequential execution. Per-item failures are isolated exactly as in the synchronous paths:
          * a failed future becomes a failed {@link ItemResult} and the run continues.
          * <p>
-         * An async task satisfies the task requirement on its own; a synchronous {@link #task(Task)}
-         * or {@link #measuredTask(MeasuredTask)} is not also required.
+         * An async task is mutually exclusive with a synchronous {@link #task(Task)} or
+         * {@link #measuredTask(MeasuredTask)}: configuring both fails fast in {@link #build()}.
          *
          * @param asyncTask the asynchronous task to generate outputs and metrics from examples
          * @return builder
@@ -441,6 +441,9 @@ public class Experiment {
             }
             if (task == null && asyncTask == null) {
                 throw new IllegalStateException("Task is required");
+            }
+            if (task != null && asyncTask != null) {
+                throw new IllegalStateException("Set either a synchronous task/measuredTask or an asyncTask, not both");
             }
             if (dataset.examples().isEmpty()) {
                 throw new IllegalStateException("Dataset must contain at least one example");

--- a/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
@@ -174,9 +174,7 @@ public class Experiment {
                         // A null future would NPE the driving thread and abort the whole run; isolate it.
                         gate.release();
                         return CompletableFuture.completedFuture(failedItemResult(
-                                example,
-                                null,
-                                new NullPointerException("AsyncTask.run(...) returned a null future")));
+                                example, null, new NullPointerException("AsyncTask.run(...) returned a null future")));
                     }
                     return taskFuture
                             .handle((taskResult, error) -> toItemResult(example, taskResult, error))
@@ -186,8 +184,7 @@ public class Experiment {
 
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
 
-        List<ItemResult> results =
-                futures.stream().map(CompletableFuture::join).toList();
+        List<ItemResult> results = futures.stream().map(CompletableFuture::join).toList();
 
         // Report items after completion to maintain ordering in reports.
         results.forEach(itemResult -> reporter.reportItem(runHandle, itemResult));
@@ -197,9 +194,8 @@ public class Experiment {
 
     private ItemResult toItemResult(Example example, TaskResult taskResult, Throwable error) {
         if (error != null) {
-            Throwable cause = error instanceof CompletionException && error.getCause() != null
-                    ? error.getCause()
-                    : error;
+            Throwable cause =
+                    error instanceof CompletionException && error.getCause() != null ? error.getCause() : error;
             return failedItemResult(example, null, cause);
         }
         Map<String, Object> actualOutputs = taskResult.outputs();
@@ -284,9 +280,6 @@ public class Experiment {
 
         /**
          * Sets a measured task that carries {@link CallMetrics} through to each {@link ItemResult}.
-         * <p>
-         * Named distinctly from {@link #task(Task)} so a lambda passed to {@code task(...)} is never
-         * ambiguous between the two functional interfaces.
          *
          * @param measuredTask The task to generate outputs and metrics from examples.
          * @return builder

--- a/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
@@ -5,8 +5,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,7 @@ public class Experiment {
     private final String description;
     private final Dataset dataset;
     private final MeasuredTask task;
+    private final AsyncTask asyncTask;
     private final List<Evaluator> evaluators;
     private final Map<String, Object> metadata;
     private final Reporter reporter;
@@ -37,6 +40,7 @@ public class Experiment {
         this.description = builder.description;
         this.dataset = builder.dataset;
         this.task = builder.task;
+        this.asyncTask = builder.asyncTask;
         this.evaluators = List.copyOf(builder.evaluators);
         this.metadata = Map.copyOf(builder.metadata);
         this.reporter = builder.reporter;
@@ -82,7 +86,9 @@ public class Experiment {
         RunStatus status = RunStatus.FAILED;
 
         try {
-            if (parallelism > 1) {
+            if (asyncTask != null) {
+                itemResults = executeAsync(runHandle);
+            } else if (parallelism > 1) {
                 itemResults = executeParallel(runHandle);
             } else {
                 itemResults = executeSequential(runHandle);
@@ -119,9 +125,12 @@ public class Experiment {
             // Report items after completion to maintain ordering in reports
             results.forEach(itemResult -> reporter.reportItem(runHandle, itemResult));
 
-            return results;
-        } finally {
             executor.shutdown();
+            return results;
+        } catch (RuntimeException | Error e) {
+            // Forcibly terminate the pool on failure so worker threads do not leak.
+            executor.shutdownNow();
+            throw e;
         }
     }
 
@@ -130,18 +139,82 @@ public class Experiment {
         try {
             TaskResult taskResult = task.run(example);
             actualOutputs = taskResult.outputs();
-            EvalTestCase testCase = example.toTestCase(actualOutputs);
-
-            List<EvalResult> evalResults = evaluators.stream()
-                    .map(evaluator -> evaluator.evaluate(testCase))
-                    .toList();
-
-            return new ItemResult(example, actualOutputs, evalResults, taskResult.metrics());
+            return evaluate(example, actualOutputs, taskResult.metrics());
         } catch (RuntimeException e) {
             // Isolate per-example failures so one bad item does not abort the whole run.
-            LOGGER.warn("Evaluation failed for example, recording it as failed: {}", example.input(), e);
-            return new ItemResult(example, actualOutputs, List.of());
+            return failedItemResult(example, actualOutputs, e);
         }
+    }
+
+    /**
+     * Executes examples via the configured {@link AsyncTask}, bounding the number of in-flight
+     * invocations to {@code parallelism} with a {@link Semaphore}.
+     * <p>
+     * The semaphore is acquired before {@code asyncTask.run(...)} is called (the returned futures
+     * are already running, so the cap must gate invocation) and released when each future settles.
+     * Per-item failures use the same isolation as the synchronous paths: a failed future becomes a
+     * failed {@link ItemResult} with empty eval results and the run continues. Dataset order is
+     * preserved in the returned results.
+     */
+    private List<ItemResult> executeAsync(RunHandle runHandle) {
+        Semaphore gate = new Semaphore(parallelism);
+
+        List<CompletableFuture<ItemResult>> futures = dataset.examples().stream()
+                .map(example -> {
+                    gate.acquireUninterruptibly();
+                    CompletableFuture<TaskResult> taskFuture;
+                    try {
+                        taskFuture = asyncTask.run(example);
+                    } catch (RuntimeException e) {
+                        // A synchronous throw from run(...) still isolates as a failed item.
+                        gate.release();
+                        return CompletableFuture.completedFuture(failedItemResult(example, null, e));
+                    }
+                    return taskFuture
+                            .handle((taskResult, error) -> toItemResult(example, taskResult, error))
+                            .whenComplete((itemResult, error) -> gate.release());
+                })
+                .toList();
+
+        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+
+        List<ItemResult> results =
+                futures.stream().map(CompletableFuture::join).toList();
+
+        // Report items after completion to maintain ordering in reports.
+        results.forEach(itemResult -> reporter.reportItem(runHandle, itemResult));
+
+        return results;
+    }
+
+    private ItemResult toItemResult(Example example, TaskResult taskResult, Throwable error) {
+        if (error != null) {
+            Throwable cause = error instanceof CompletionException && error.getCause() != null
+                    ? error.getCause()
+                    : error;
+            return failedItemResult(example, null, cause);
+        }
+        Map<String, Object> actualOutputs = taskResult.outputs();
+        try {
+            return evaluate(example, actualOutputs, taskResult.metrics());
+        } catch (RuntimeException e) {
+            return failedItemResult(example, actualOutputs, e);
+        }
+    }
+
+    private ItemResult evaluate(Example example, Map<String, Object> actualOutputs, CallMetrics metrics) {
+        EvalTestCase testCase = example.toTestCase(actualOutputs);
+
+        List<EvalResult> evalResults = evaluators.stream()
+                .map(evaluator -> evaluator.evaluate(testCase))
+                .toList();
+
+        return new ItemResult(example, actualOutputs, evalResults, metrics);
+    }
+
+    private ItemResult failedItemResult(Example example, Map<String, Object> actualOutputs, Throwable error) {
+        LOGGER.warn("Evaluation failed for example, recording it as failed: {}", example.input(), error);
+        return new ItemResult(example, actualOutputs, List.of());
     }
 
     public static class Builder {
@@ -151,6 +224,7 @@ public class Experiment {
         private String description = "";
         private Dataset dataset;
         private MeasuredTask task;
+        private AsyncTask asyncTask;
         private Reporter reporter = NoOpReporter.INSTANCE;
         private int parallelism = 1;
         private int runs = 1;
@@ -211,6 +285,27 @@ public class Experiment {
          */
         public Builder measuredTask(MeasuredTask measuredTask) {
             this.task = measuredTask;
+            return this;
+        }
+
+        /**
+         * Sets an asynchronous task that produces a {@link TaskResult} as a
+         * {@link java.util.concurrent.CompletableFuture}.
+         * <p>
+         * When an async task is set, the experiment runs through a dedicated non-blocking execution
+         * path that bounds the number of in-flight invocations to {@link #parallelism(int)} using a
+         * semaphore. This path takes precedence over {@link #parallelism(int)}-based parallel and
+         * sequential execution. Per-item failures are isolated exactly as in the synchronous paths:
+         * a failed future becomes a failed {@link ItemResult} and the run continues.
+         * <p>
+         * An async task satisfies the task requirement on its own; a synchronous {@link #task(Task)}
+         * or {@link #measuredTask(MeasuredTask)} is not also required.
+         *
+         * @param asyncTask the asynchronous task to generate outputs and metrics from examples
+         * @return builder
+         */
+        public Builder asyncTask(AsyncTask asyncTask) {
+            this.asyncTask = asyncTask;
             return this;
         }
 
@@ -343,7 +438,7 @@ public class Experiment {
             if (dataset == null) {
                 throw new IllegalStateException("Dataset is required");
             }
-            if (task == null) {
+            if (task == null && asyncTask == null) {
                 throw new IllegalStateException("Task is required");
             }
             if (dataset.examples().isEmpty()) {

--- a/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Experiment.java
@@ -170,6 +170,14 @@ public class Experiment {
                         gate.release();
                         return CompletableFuture.completedFuture(failedItemResult(example, null, e));
                     }
+                    if (taskFuture == null) {
+                        // A null future would NPE the driving thread and abort the whole run; isolate it.
+                        gate.release();
+                        return CompletableFuture.completedFuture(failedItemResult(
+                                example,
+                                null,
+                                new NullPointerException("AsyncTask.run(...) returned a null future")));
+                    }
                     return taskFuture
                             .handle((taskResult, error) -> toItemResult(example, taskResult, error))
                             .whenComplete((itemResult, error) -> gate.release());

--- a/dokimos-core/src/main/java/dev/dokimos/core/OutputType.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/OutputType.java
@@ -10,9 +10,8 @@ import java.util.Objects;
  * A super-type token that captures a full generic type {@code T} (including its type arguments) at
  * compile time so it survives erasure at runtime.
  *
- * <p>This is the "Gafter gadget" pattern (also used by Spring's {@code ParameterizedTypeReference}
- * and Jackson's {@code TypeReference}). It lets the typed output accessors convert a stored value
- * into a generic target such as {@code List<Whisky>}, which a plain {@code Class<T>} cannot express.
+ * <p>It lets the typed output accessors convert a stored value into a generic target such as
+ * {@code List<Whisky>}, which a plain {@code Class<T>} cannot express.
  *
  * <p>Always instantiate it as an anonymous subclass so the type argument is recorded in the class's
  * generic supertype:
@@ -22,10 +21,7 @@ import java.util.Objects;
  * List<Whisky> whiskies = testCase.actualOutputAs(type);
  * }</pre>
  *
- * <p>For a non-generic target a plain {@code Class<T>} accessor is simpler and preferred.
- *
- * <p>This type is Jackson-free on its public surface by design; the Jackson {@link JavaType} it
- * resolves to is an internal implementation detail.
+ * <p>For a non-generic target, use a plain {@code Class<T>} accessor instead.
  *
  * @param <T> the captured output type
  */
@@ -43,16 +39,14 @@ public abstract class OutputType<T> {
     protected OutputType() {
         Type superClass = getClass().getGenericSuperclass();
         if (!(superClass instanceof ParameterizedType parameterized)) {
-            throw new IllegalArgumentException(
-                    "OutputType must be created with an actual type argument, e.g."
-                            + " new OutputType<List<Whisky>>() {} — it was constructed raw.");
+            throw new IllegalArgumentException("OutputType must be created with an actual type argument, e.g."
+                    + " new OutputType<List<Whisky>>() {} — it was constructed raw.");
         }
         this.type = parameterized.getActualTypeArguments()[0];
     }
 
     /**
-     * The captured generic type. Exposed so callers can introspect the token; conversion goes
-     * through the internal resolver.
+     * The captured generic type.
      *
      * @return the captured {@link Type}
      */
@@ -61,9 +55,8 @@ public abstract class OutputType<T> {
     }
 
     /**
-     * Resolves this token to the Jackson {@link JavaType} used internally for value conversion. Not
-     * part of the public API contract — package-private on purpose to keep Jackson off the public
-     * surface.
+     * Resolves this token to the Jackson {@link JavaType} used internally for value conversion.
+     * Package-private; not part of the public API.
      *
      * @return the resolved Jackson type
      */

--- a/dokimos-core/src/main/java/dev/dokimos/core/OutputType.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/OutputType.java
@@ -1,0 +1,91 @@
+package dev.dokimos.core;
+
+import com.fasterxml.jackson.databind.JavaType;
+import dev.dokimos.core.internal.Json;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+/**
+ * A super-type token that captures a full generic type {@code T} (including its type arguments) at
+ * compile time so it survives erasure at runtime.
+ *
+ * <p>This is the "Gafter gadget" pattern (also used by Spring's {@code ParameterizedTypeReference}
+ * and Jackson's {@code TypeReference}). It lets the typed output accessors convert a stored value
+ * into a generic target such as {@code List<Whisky>}, which a plain {@code Class<T>} cannot express.
+ *
+ * <p>Always instantiate it as an anonymous subclass so the type argument is recorded in the class's
+ * generic supertype:
+ *
+ * <pre>{@code
+ * OutputType<List<Whisky>> type = new OutputType<>() {};
+ * List<Whisky> whiskies = testCase.actualOutputAs(type);
+ * }</pre>
+ *
+ * <p>For a non-generic target a plain {@code Class<T>} accessor is simpler and preferred.
+ *
+ * <p>This type is Jackson-free on its public surface by design; the Jackson {@link JavaType} it
+ * resolves to is an internal implementation detail.
+ *
+ * @param <T> the captured output type
+ */
+public abstract class OutputType<T> {
+
+    private final Type type;
+
+    /**
+     * Captures the generic type argument {@code T} from the concrete (usually anonymous) subclass.
+     *
+     * @throws IllegalArgumentException if this token is constructed without an actual type argument
+     *     (i.e. used raw, as {@code new OutputType() {}} rather than {@code new OutputType<List<X>>()
+     *     {}})
+     */
+    protected OutputType() {
+        Type superClass = getClass().getGenericSuperclass();
+        if (!(superClass instanceof ParameterizedType parameterized)) {
+            throw new IllegalArgumentException(
+                    "OutputType must be created with an actual type argument, e.g."
+                            + " new OutputType<List<Whisky>>() {} — it was constructed raw.");
+        }
+        this.type = parameterized.getActualTypeArguments()[0];
+    }
+
+    /**
+     * The captured generic type. Exposed so callers can introspect the token; conversion goes
+     * through the internal resolver.
+     *
+     * @return the captured {@link Type}
+     */
+    public final Type getType() {
+        return type;
+    }
+
+    /**
+     * Resolves this token to the Jackson {@link JavaType} used internally for value conversion. Not
+     * part of the public API contract — package-private on purpose to keep Jackson off the public
+     * surface.
+     *
+     * @return the resolved Jackson type
+     */
+    final JavaType toJavaType() {
+        return Json.resolveType(type);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o instanceof OutputType<?> other && type.equals(other.type);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(type);
+    }
+
+    @Override
+    public final String toString() {
+        return "OutputType<" + type.getTypeName() + ">";
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/Task.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Task.java
@@ -1,6 +1,7 @@
 package dev.dokimos.core;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 @FunctionalInterface
@@ -32,6 +33,8 @@ public interface Task {
      * @param <T> the produced value type
      * @return a {@link Task} that wraps the produced value under {@code "output"} (or uses a returned
      *     map directly)
+     * @throws NullPointerException if {@code fn} returns {@code null} (the output map cannot hold a
+     *     null value; use a raw {@link Task} if an absent output is intended)
      */
     @SuppressWarnings("unchecked")
     static <T> Task typed(Function<Example, T> fn) {
@@ -40,6 +43,9 @@ public interface Task {
             if (value instanceof Map<?, ?> map) {
                 return (Map<String, Object>) map;
             }
+            Objects.requireNonNull(
+                    value,
+                    "typed task function returned null; return a value (or a Map) — use a raw Task if you need an absent output");
             return Map.of("output", value);
         };
     }

--- a/dokimos-core/src/main/java/dev/dokimos/core/Task.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Task.java
@@ -24,9 +24,8 @@ public interface Task {
      * {@code EvalTestCase} and is matched structurally by {@code StructuralMatchEvaluator}.
      * <p>
      * <strong>Map guard:</strong> if {@code fn} itself returns a {@link Map}, that map is used
-     * directly as the output map rather than being nested under {@code "output"}. This lets a task
-     * that already speaks the multi-key output convention coexist with the typed convenience without
-     * accidental double-nesting. The map is assumed to use {@code String} keys.
+     * directly as the output map rather than being nested under {@code "output"}. The map is assumed
+     * to use {@code String} keys.
      *
      * @param fn the function producing the output value for an {@link Example} (may return a
      *     {@link Map}, which is used as the output map directly)

--- a/dokimos-core/src/main/java/dev/dokimos/core/Task.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/Task.java
@@ -1,6 +1,7 @@
 package dev.dokimos.core;
 
 import java.util.Map;
+import java.util.function.Function;
 
 @FunctionalInterface
 public interface Task {
@@ -12,4 +13,34 @@ public interface Task {
      * @return the actual outputs produced by the task
      */
     Map<String, Object> run(Example example);
+
+    /**
+     * Creates a {@link Task} that produces a single typed value and stores it under the
+     * conventional {@code "output"} key, so callers can return a record, list, or other POJO from
+     * their task body instead of hand-building the output map.
+     * <p>
+     * The produced value is read back type-safely via {@code actualOutputAs(...)} on the resulting
+     * {@code EvalTestCase} and is matched structurally by {@code StructuralMatchEvaluator}.
+     * <p>
+     * <strong>Map guard:</strong> if {@code fn} itself returns a {@link Map}, that map is used
+     * directly as the output map rather than being nested under {@code "output"}. This lets a task
+     * that already speaks the multi-key output convention coexist with the typed convenience without
+     * accidental double-nesting. The map is assumed to use {@code String} keys.
+     *
+     * @param fn the function producing the output value for an {@link Example} (may return a
+     *     {@link Map}, which is used as the output map directly)
+     * @param <T> the produced value type
+     * @return a {@link Task} that wraps the produced value under {@code "output"} (or uses a returned
+     *     map directly)
+     */
+    @SuppressWarnings("unchecked")
+    static <T> Task typed(Function<Example, T> fn) {
+        return example -> {
+            T value = fn.apply(example);
+            if (value instanceof Map<?, ?> map) {
+                return (Map<String, Object>) map;
+            }
+            return Map.of("output", value);
+        };
+    }
 }

--- a/dokimos-core/src/main/java/dev/dokimos/core/agents/AgentTrace.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/agents/AgentTrace.java
@@ -1,6 +1,9 @@
 package dev.dokimos.core.agents;
 
 import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.OutputType;
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
+import dev.dokimos.core.internal.Json;
 import java.util.*;
 
 /**
@@ -99,6 +102,48 @@ public record AgentTrace(
             names.add(call.name());
         }
         return Collections.unmodifiableSet(names);
+    }
+
+    /**
+     * Reads the metadata entry stored under {@code key} and converts it into an instance of
+     * {@code type}.
+     * <p>
+     * The value is already in memory, so this converts in place (no textual round-trip). An absent key
+     * (or a {@code null} stored value) yields {@code null}.
+     *
+     * @param key the metadata key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if the key is absent or its value is {@code null}
+     * @throws DokimosTypeConversionException if the value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, Class<T> type) {
+        try {
+            return Json.convert(metadata.get(key), type);
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException(
+                    "Cannot convert agent trace metadata '" + key + "' to " + type.getName(), e);
+        }
+    }
+
+    /**
+     * Reads the metadata entry stored under {@code key} and converts it into a generic target captured
+     * by an {@link OutputType} token, for example {@code new OutputType<List<String>>() {}}.
+     * <p>
+     * An absent key (or a {@code null} stored value) yields {@code null}.
+     *
+     * @param key the metadata key
+     * @param type the captured generic output type
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if the key is absent or its value is {@code null}
+     * @throws DokimosTypeConversionException if the value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, OutputType<T> type) {
+        try {
+            return Json.convert(metadata.get(key), Json.resolveType(type.getType()));
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException("Cannot convert agent trace metadata '" + key + "' to " + type, e);
+        }
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
@@ -1,5 +1,6 @@
 package dev.dokimos.core.agents;
 
+import dev.dokimos.core.internal.Json;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -115,6 +116,28 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
          */
         public Builder result(String result) {
             this.result = result;
+            return this;
+        }
+
+        /**
+         * Sets the tool execution result from an arbitrary value by serializing it to compact
+         * (single-line) JSON and storing it in the same {@code result} string component used by
+         * {@link #result(String)}.
+         * <p>
+         * This is a convenience for callers whose tool produced a structured value (a record, map,
+         * list, or other POJO) rather than a pre-rendered string. A {@code null} value serializes to
+         * the JSON literal {@code "null"}.
+         * <p>
+         * Deliberately given a distinct name rather than overloading {@link #result(String)} so the
+         * serialization behavior is never selected silently by the static type of the argument (see
+         * <em>Effective Java</em>, Item 52).
+         *
+         * @param value the value to serialize as the result (may be {@code null})
+         * @return this builder
+         * @throws IllegalArgumentException if the value cannot be serialized to JSON
+         */
+        public Builder resultJson(Object value) {
+            this.result = Json.writeCompact(value);
             return this;
         }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
@@ -124,13 +124,9 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
          * (single-line) JSON and storing it in the same {@code result} string component used by
          * {@link #result(String)}.
          * <p>
-         * This is a convenience for callers whose tool produced a structured value (a record, map,
-         * list, or other POJO) rather than a pre-rendered string. A {@code null} value serializes to
-         * the JSON literal {@code "null"}.
-         * <p>
-         * Deliberately given a distinct name rather than overloading {@link #result(String)} so the
-         * serialization behavior is never selected silently by the static type of the argument (see
-         * <em>Effective Java</em>, Item 52).
+         * Use for a tool that produced a structured value (a record, map, list, or other POJO)
+         * rather than a pre-rendered string. A {@code null} value serializes to the JSON literal
+         * {@code "null"}.
          *
          * @param value the value to serialize as the result (may be {@code null})
          * @return this builder

--- a/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
@@ -1,5 +1,7 @@
 package dev.dokimos.core.agents;
 
+import dev.dokimos.core.OutputType;
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
 import dev.dokimos.core.internal.Json;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,6 +56,60 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
         Map<String, Object> metadata =
                 map.containsKey("metadata") ? (Map<String, Object>) map.get("metadata") : Map.of();
         return new ToolCall(name, arguments, result, metadata);
+    }
+
+    /**
+     * Deserializes this tool call's {@code result} string into an instance of {@code type}.
+     * <p>
+     * This is the read-side counterpart to {@link Builder#resultJson(Object)}: a structured tool
+     * result stored as compact JSON is round-tripped back into a typed object. A {@code null} or
+     * blank result yields {@code null}, and the JSON literal {@code "null"} also parses to
+     * {@code null}.
+     * <p>
+     * <b>Note:</b> the result must be a JSON string for this to work. {@link Builder#resultJson(Object)}
+     * guarantees that. {@link #fromMap(Map)}, however, stores {@code rawResult.toString()}: a
+     * structured {@code Map} from a deserialized dataset becomes Java-map syntax
+     * (e.g. {@code {a=1}}), which is <b>not</b> valid JSON. So {@code resultAs} after {@code fromMap}
+     * only works when the stored result was already a JSON string.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the deserialized result, or {@code null} if the result is {@code null}/blank/JSON null
+     * @throws DokimosTypeConversionException if the result cannot be parsed into {@code type}
+     */
+    public <T> T resultAs(Class<T> type) {
+        if (result == null || result.isBlank()) {
+            return null;
+        }
+        try {
+            return Json.read(result, type);
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException("Cannot convert tool result to " + type.getName(), e);
+        }
+    }
+
+    /**
+     * Deserializes this tool call's {@code result} string into a generic target captured by an
+     * {@link OutputType} token, for example {@code new OutputType<List<Order>>() {}}.
+     * <p>
+     * Use this overload when the target type has type arguments that a plain {@code Class<T>} cannot
+     * express. The same null/blank/JSON-null and {@code fromMap} caveats described on
+     * {@link #resultAs(Class)} apply.
+     *
+     * @param type the captured generic output type
+     * @param <T> the target type
+     * @return the deserialized result, or {@code null} if the result is {@code null}/blank/JSON null
+     * @throws DokimosTypeConversionException if the result cannot be parsed into {@code type}
+     */
+    public <T> T resultAs(OutputType<T> type) {
+        if (result == null || result.isBlank()) {
+            return null;
+        }
+        try {
+            return Json.read(result, Json.resolveType(type.getType()));
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException("Cannot convert tool result to " + type, e);
+        }
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/agents/ToolCall.java
@@ -52,7 +52,14 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
         Map<String, Object> arguments =
                 map.containsKey("arguments") ? (Map<String, Object>) map.get("arguments") : Map.of();
         Object rawResult = map.get("result");
-        String result = rawResult != null ? rawResult.toString() : null;
+        String result;
+        if (rawResult == null) {
+            result = null;
+        } else if (rawResult instanceof String s) {
+            result = s;
+        } else {
+            result = Json.writeCompact(rawResult);
+        }
         Map<String, Object> metadata =
                 map.containsKey("metadata") ? (Map<String, Object>) map.get("metadata") : Map.of();
         return new ToolCall(name, arguments, result, metadata);
@@ -66,11 +73,10 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
      * blank result yields {@code null}, and the JSON literal {@code "null"} also parses to
      * {@code null}.
      * <p>
-     * <b>Note:</b> the result must be a JSON string for this to work. {@link Builder#resultJson(Object)}
-     * guarantees that. {@link #fromMap(Map)}, however, stores {@code rawResult.toString()}: a
-     * structured {@code Map} from a deserialized dataset becomes Java-map syntax
-     * (e.g. {@code {a=1}}), which is <b>not</b> valid JSON. So {@code resultAs} after {@code fromMap}
-     * only works when the stored result was already a JSON string.
+     * The result must be a JSON string for this to work. Both {@link Builder#resultJson(Object)} and
+     * {@link #fromMap(Map)} guarantee that: {@code fromMap} keeps a {@code String} result verbatim and
+     * serializes any structured value (a {@code Map}, list, or other object) to compact JSON, so a
+     * structured result from a deserialized dataset round-trips here as well.
      *
      * @param type the target class
      * @param <T> the target type
@@ -93,8 +99,7 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
      * {@link OutputType} token, for example {@code new OutputType<List<Order>>() {}}.
      * <p>
      * Use this overload when the target type has type arguments that a plain {@code Class<T>} cannot
-     * express. The same null/blank/JSON-null and {@code fromMap} caveats described on
-     * {@link #resultAs(Class)} apply.
+     * express. The same null/blank/JSON-null handling described on {@link #resultAs(Class)} applies.
      *
      * @param type the captured generic output type
      * @param <T> the target type
@@ -109,6 +114,88 @@ public record ToolCall(String name, Map<String, Object> arguments, String result
             return Json.read(result, Json.resolveType(type.getType()));
         } catch (RuntimeException e) {
             throw new DokimosTypeConversionException("Cannot convert tool result to " + type, e);
+        }
+    }
+
+    /**
+     * Converts this tool call's {@code arguments} map into an instance of {@code type}.
+     * <p>
+     * The arguments are already an in-memory map, so this converts in place (no textual round-trip).
+     * {@link #arguments()} is never {@code null} (it defaults to an empty map); converting an empty map
+     * to a record or bean yields an instance with default/empty fields.
+     *
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted arguments
+     * @throws DokimosTypeConversionException if the arguments cannot be converted to {@code type}
+     */
+    public <T> T argumentsAs(Class<T> type) {
+        try {
+            return Json.convert(arguments, type);
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException("Cannot convert tool arguments to " + type.getName(), e);
+        }
+    }
+
+    /**
+     * Converts this tool call's {@code arguments} map into a generic target captured by an
+     * {@link OutputType} token, for example {@code new OutputType<List<String>>() {}}.
+     * <p>
+     * Use this overload when the target type has type arguments that a plain {@code Class<T>} cannot
+     * express.
+     *
+     * @param type the captured generic output type
+     * @param <T> the target type
+     * @return the converted arguments
+     * @throws DokimosTypeConversionException if the arguments cannot be converted to {@code type}
+     */
+    public <T> T argumentsAs(OutputType<T> type) {
+        try {
+            return Json.convert(arguments, Json.resolveType(type.getType()));
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException("Cannot convert tool arguments to " + type, e);
+        }
+    }
+
+    /**
+     * Reads the metadata entry stored under {@code key} and converts it into an instance of
+     * {@code type}.
+     * <p>
+     * The value is already in memory, so this converts in place (no textual round-trip). An absent key
+     * (or a {@code null} stored value) yields {@code null}.
+     *
+     * @param key the metadata key
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if the key is absent or its value is {@code null}
+     * @throws DokimosTypeConversionException if the value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, Class<T> type) {
+        try {
+            return Json.convert(metadata.get(key), type);
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException(
+                    "Cannot convert tool metadata '" + key + "' to " + type.getName(), e);
+        }
+    }
+
+    /**
+     * Reads the metadata entry stored under {@code key} and converts it into a generic target captured
+     * by an {@link OutputType} token, for example {@code new OutputType<List<String>>() {}}.
+     * <p>
+     * An absent key (or a {@code null} stored value) yields {@code null}.
+     *
+     * @param key the metadata key
+     * @param type the captured generic output type
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if the key is absent or its value is {@code null}
+     * @throws DokimosTypeConversionException if the value cannot be converted to {@code type}
+     */
+    public <T> T metadataAs(String key, OutputType<T> type) {
+        try {
+            return Json.convert(metadata.get(key), Json.resolveType(type.getType()));
+        } catch (RuntimeException e) {
+            throw new DokimosTypeConversionException("Cannot convert tool metadata '" + key + "' to " + type, e);
         }
     }
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
@@ -7,6 +7,7 @@ import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.EvalTestCaseParam;
 import dev.dokimos.core.JudgeLM;
 import dev.dokimos.core.LlmResponseUtils;
+import dev.dokimos.core.internal.Json;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,10 +52,12 @@ public class LLMJudgeEvaluator extends BaseEvaluator {
             switch (param) {
                 case INPUT -> sb.append("Input: ").append(testCase.input()).append("\n");
                 case ACTUAL_OUTPUT ->
-                    sb.append("Actual Output: ").append(testCase.actualOutput()).append("\n");
+                    sb.append("Actual Output: ")
+                            .append(renderOutput(testCase.actualOutputs().get("output")))
+                            .append("\n");
                 case EXPECTED_OUTPUT ->
                     sb.append("Expected Output: ")
-                            .append(testCase.expectedOutput())
+                            .append(renderOutput(testCase.expectedOutputs().get("output")))
                             .append("\n");
             }
         }
@@ -67,6 +70,34 @@ public class LLMJudgeEvaluator extends BaseEvaluator {
         // TODO: Structured outputs?
         sb.append("Respond in JSON format: {\"score\": <number>, \"reason\": \"<explanation>\"}");
         return sb.toString();
+    }
+
+    /**
+     * Renders a raw output value for inclusion in the judge prompt.
+     *
+     * <p>Strings and primitive/boxed-primitive values (numbers, booleans, characters) are rendered
+     * verbatim via {@link String#valueOf(Object)}, which is byte-for-byte identical to the historical
+     * behavior of stringifying the output. Any other value (a POJO, {@link java.util.Map}, {@link
+     * java.util.List}, etc.) is rendered as pretty-printed JSON via {@link Json#writePretty(Object)}.
+     *
+     * <p>This is an intentional, documented behavior change for structured outputs: a {@code Map} or
+     * {@code List} that previously rendered via Java's {@code toString()} now renders as JSON, giving
+     * the judge a faithful, parseable view of the structured value. Scalar outputs are unaffected.
+     *
+     * @param value the raw output value (may be {@code null})
+     * @return the rendered representation; {@code "null"} when {@code value} is {@code null}
+     */
+    private static String renderOutput(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String
+                || value instanceof Number
+                || value instanceof Boolean
+                || value instanceof Character) {
+            return String.valueOf(value);
+        }
+        return Json.writePretty(value);
     }
 
     private EvalResult parseResponse(String response) {

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/LLMJudgeEvaluator.java
@@ -76,13 +76,9 @@ public class LLMJudgeEvaluator extends BaseEvaluator {
      * Renders a raw output value for inclusion in the judge prompt.
      *
      * <p>Strings and primitive/boxed-primitive values (numbers, booleans, characters) are rendered
-     * verbatim via {@link String#valueOf(Object)}, which is byte-for-byte identical to the historical
-     * behavior of stringifying the output. Any other value (a POJO, {@link java.util.Map}, {@link
-     * java.util.List}, etc.) is rendered as pretty-printed JSON via {@link Json#writePretty(Object)}.
-     *
-     * <p>This is an intentional, documented behavior change for structured outputs: a {@code Map} or
-     * {@code List} that previously rendered via Java's {@code toString()} now renders as JSON, giving
-     * the judge a faithful, parseable view of the structured value. Scalar outputs are unaffected.
+     * verbatim via {@link String#valueOf(Object)}. Any other value (a POJO, {@link java.util.Map},
+     * {@link java.util.List}, etc.) is rendered as pretty-printed JSON via
+     * {@link Json#writePretty(Object)}, giving the judge a parseable view of the structured value.
      *
      * @param value the raw output value (may be {@code null})
      * @return the rendered representation; {@code "null"} when {@code value} is {@code null}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchEvaluator.java
@@ -1,0 +1,428 @@
+package dev.dokimos.core.evaluators;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import dev.dokimos.core.BaseEvaluator;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.internal.Json;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Compares the actual output against the expected output as JSON structures rather than as opaque
+ * strings.
+ *
+ * <p>Both operands are normalized to a Jackson {@link JsonNode} tree and compared with a hand-written
+ * recursive comparator (Jackson's {@link JsonNode#equals(Object)} is deliberately <em>not</em> used —
+ * it treats {@code 5} and {@code 5.0} as different and would corrupt eval results). The comparator:
+ *
+ * <ul>
+ *   <li>Compares numeric leaves by {@link BigDecimal#compareTo(BigDecimal)} (scale-insensitive, so
+ *       {@code 1.0} equals {@code 1.00}), with an epsilon tolerance for floating point. {@code 5} and
+ *       {@code 5.0} therefore match by value in <em>both</em> modes.
+ *   <li>Honors {@link StructuralMatchMode}: {@link StructuralMatchMode#STRICT STRICT} requires the
+ *       exact field set and exact array order; {@link StructuralMatchMode#LENIENT LENIENT} allows
+ *       extra actual fields (subset match) and ignores array order as a multiset.
+ *   <li>Treats a {@code null} value and a missing field as equal in LENIENT and distinct in STRICT.
+ *   <li>Fails loudly on duplicate object keys (via the strict-duplicate-detection comparison reader)
+ *       and on non-finite numbers (NaN / Infinity).
+ *   <li>Parses a {@code String} operand as JSON before comparing, so CSV / JSON-string datasets
+ *       compare object-against-object rather than against a quoted string.
+ * </ul>
+ *
+ * <p><strong>Scoring.</strong> By default the score is the fraction of matching leaf paths in
+ * {@code [0.0, 1.0]}. In STRICT the denominator is the union of the expected and actual leaf paths
+ * (extra fields penalize); in LENIENT the denominator is the expected leaf paths only (extras are
+ * ignored). Calling {@link Builder#binary()} collapses the score to {@code 1.0} (everything matches)
+ * or {@code 0.0} (anything differs) for exact-contract gates.
+ */
+public class StructuralMatchEvaluator extends BaseEvaluator {
+
+    /** Tolerance applied when comparing numeric leaves that are not exactly equal in scale. */
+    private static final BigDecimal EPSILON = new BigDecimal("1e-9");
+
+    private final String outputKey;
+    private final StructuralMatchMode mode;
+    private final boolean binary;
+
+    private StructuralMatchEvaluator(Builder builder) {
+        super(builder.name, builder.threshold, builder.evaluationParams);
+        this.outputKey = builder.outputKey;
+        this.mode = builder.mode;
+        this.binary = builder.binary;
+    }
+
+    /**
+     * Creates a new builder for constructing structural match evaluators.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected EvalResult runEvaluation(EvalTestCase testCase) {
+        Object rawExpected = testCase.expectedOutputs().get(outputKey);
+        if (rawExpected == null) {
+            throw new EvaluationException(
+                    "StructuralMatchEvaluator requires '%s' in expectedOutputs".formatted(outputKey));
+        }
+        Object rawActual = testCase.actualOutputs().get(outputKey);
+
+        JsonNode expected = normalize(rawExpected, "expected");
+        JsonNode actual = normalize(rawActual, "actual");
+
+        Diff diff = new Diff();
+        compare(expected, actual, "$", diff);
+
+        double score;
+        if (binary) {
+            score = diff.differences.isEmpty() ? 1.0 : 0.0;
+        } else {
+            score = diff.denominator == 0 ? 1.0 : (double) diff.matched / diff.denominator;
+        }
+
+        String reason;
+        if (diff.differences.isEmpty()) {
+            reason = "The actual and expected structures match.";
+        } else {
+            reason = "Structural differences (%d of %d leaf paths matched): %s"
+                    .formatted(diff.matched, diff.denominator, String.join("; ", diff.differences));
+        }
+
+        return EvalResult.builder()
+                .name(name)
+                .score(score)
+                .threshold(threshold)
+                .reason(reason)
+                .build();
+    }
+
+    /**
+     * Normalizes an operand into a {@link JsonNode}. A {@code String} is parsed as JSON (using the
+     * strict-duplicate-detection comparison reader); any other value is converted via the shared
+     * mapper. A {@code null} operand becomes a JSON null node. Non-finite numbers are rejected.
+     */
+    private JsonNode normalize(Object value, String side) {
+        JsonNode node;
+        if (value == null) {
+            node = Json.toNode(null);
+        } else if (value instanceof String s) {
+            try {
+                node = Json.comparisonReader().readTree(s);
+            } catch (JsonProcessingException e) {
+                throw new EvaluationException(
+                        "The %s output is not valid JSON: %s".formatted(side, e.getOriginalMessage()), e);
+            }
+            if (node == null) {
+                node = Json.toNode(null);
+            }
+        } else {
+            try {
+                node = Json.toNode(value);
+            } catch (RuntimeException e) {
+                throw new EvaluationException(
+                        "The %s output could not be normalized to JSON: %s".formatted(side, e.getMessage()), e);
+            }
+        }
+        rejectNonFinite(node, side);
+        return node;
+    }
+
+    private void rejectNonFinite(JsonNode node, String side) {
+        if (node.isNumber()) {
+            if ((node.isDouble() || node.isFloat()) && !Double.isFinite(node.doubleValue())) {
+                throw new EvaluationException(
+                        "The %s output contains a non-finite number (NaN or Infinity), which cannot be compared structurally."
+                                .formatted(side));
+            }
+        } else if (node.isObject()) {
+            Iterator<JsonNode> it = node.elements();
+            while (it.hasNext()) {
+                rejectNonFinite(it.next(), side);
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                rejectNonFinite(child, side);
+            }
+        }
+    }
+
+    /**
+     * Recursively compares {@code expected} against {@code actual} at the given JSON path, recording
+     * matched / denominator leaf counts and human-readable differences into {@code diff}.
+     */
+    private void compare(JsonNode expected, JsonNode actual, String path, Diff diff) {
+        // null-vs-missing: a Jackson null node vs a missing node.
+        boolean expectedMissing = expected == null || expected.isMissingNode();
+        boolean actualMissing = actual == null || actual.isMissingNode();
+
+        if (expected != null && expected.isObject() && actual != null && actual.isObject()) {
+            compareObjects(expected, actual, path, diff);
+            return;
+        }
+        if (expected != null && expected.isArray() && actual != null && actual.isArray()) {
+            compareArrays(expected, actual, path, diff);
+            return;
+        }
+
+        // Leaf comparison (scalars, null, or type mismatches such as object-vs-array).
+        diff.denominator++;
+        if (expectedMissing && actualMissing) {
+            diff.matched++;
+            return;
+        }
+
+        // null and missing: in LENIENT a null value and a missing field are equal; in STRICT every
+        // distinction matters (null != missing, and a present value != null/missing).
+        boolean expectedNull = expected != null && expected.isNull();
+        boolean actualNull = actual != null && actual.isNull();
+        boolean expectedAbsent = expectedMissing || expectedNull;
+        boolean actualAbsent = actualMissing || actualNull;
+        if (expectedAbsent || actualAbsent) {
+            boolean match;
+            if (mode == StructuralMatchMode.LENIENT) {
+                match = expectedAbsent && actualAbsent;
+            } else {
+                // STRICT: null matches null, missing matches missing, but not across.
+                match = (expectedNull && actualNull) || (expectedMissing && actualMissing);
+            }
+            if (match) {
+                diff.matched++;
+            } else {
+                diff.differences.add(
+                        "%s: expected %s but was %s".formatted(path, render(expected), render(actual)));
+            }
+            return;
+        }
+
+        if (leafEquals(expected, actual)) {
+            diff.matched++;
+        } else {
+            diff.differences.add(
+                    "%s: expected %s but was %s".formatted(path, render(expected), render(actual)));
+        }
+    }
+
+    private void compareObjects(JsonNode expected, JsonNode actual, String path, Diff diff) {
+        Set<String> fields = new LinkedHashSet<>();
+        expected.fieldNames().forEachRemaining(fields::add);
+        // In STRICT, an extra field in the actual output is part of the comparison (it penalizes).
+        if (mode == StructuralMatchMode.STRICT) {
+            actual.fieldNames().forEachRemaining(fields::add);
+        }
+
+        for (String field : fields) {
+            JsonNode expectedChild = expected.get(field);
+            JsonNode actualChild = actual.get(field);
+            compare(expectedChild, actualChild, path + "." + field, diff);
+        }
+    }
+
+    private void compareArrays(JsonNode expected, JsonNode actual, String path, Diff diff) {
+        if (mode == StructuralMatchMode.STRICT) {
+            int max = Math.max(expected.size(), actual.size());
+            for (int i = 0; i < max; i++) {
+                JsonNode expectedChild = i < expected.size() ? expected.get(i) : null;
+                JsonNode actualChild = i < actual.size() ? actual.get(i) : null;
+                compare(expectedChild, actualChild, path + "[" + i + "]", diff);
+            }
+            return;
+        }
+
+        // LENIENT: multiset semantics — order ignored, multiplicity preserved, extras ignored.
+        List<JsonNode> remaining = new ArrayList<>();
+        actual.forEach(remaining::add);
+
+        for (int i = 0; i < expected.size(); i++) {
+            JsonNode expectedChild = expected.get(i);
+            int matchIndex = -1;
+            for (int j = 0; j < remaining.size(); j++) {
+                if (deepMatches(expectedChild, remaining.get(j))) {
+                    matchIndex = j;
+                    break;
+                }
+            }
+            if (matchIndex >= 0) {
+                // A matched element contributes all of its expected leaves as matched.
+                int leaves = leafCount(expectedChild);
+                diff.denominator += leaves;
+                diff.matched += leaves;
+                remaining.remove(matchIndex);
+            } else {
+                diff.denominator += leafCount(expectedChild);
+                diff.differences.add(
+                        "%s: no actual element matched expected %s".formatted(path + "[" + i + "]", render(expectedChild)));
+            }
+        }
+    }
+
+    /** Whether two nodes match completely under the current mode (used for LENIENT array matching). */
+    private boolean deepMatches(JsonNode a, JsonNode b) {
+        Diff probe = new Diff();
+        compare(a, b, "$", probe);
+        return probe.differences.isEmpty();
+    }
+
+    /** Compares two present, non-null scalar nodes by value (null/missing handled by the caller). */
+    private boolean leafEquals(JsonNode expected, JsonNode actual) {
+        if (expected.isNumber() && actual.isNumber()) {
+            BigDecimal e = expected.decimalValue();
+            BigDecimal a = actual.decimalValue();
+            if (e.compareTo(a) == 0) {
+                return true;
+            }
+            return e.subtract(a).abs().compareTo(EPSILON) <= 0;
+        }
+        if (expected.getNodeType() != actual.getNodeType()) {
+            return false;
+        }
+        return switch (expected.getNodeType()) {
+            case STRING -> expected.textValue().equals(actual.textValue());
+            case BOOLEAN -> expected.booleanValue() == actual.booleanValue();
+            default -> expected.equals(actual);
+        };
+    }
+
+    /** Counts the leaf paths under a node (scalars and empty containers each count as one). */
+    private int leafCount(JsonNode node) {
+        if (node == null || node.isMissingNode()) {
+            return 1;
+        }
+        if (node.isObject()) {
+            if (node.isEmpty()) {
+                return 1;
+            }
+            int count = 0;
+            for (JsonNode child : node) {
+                count += leafCount(child);
+            }
+            return count;
+        }
+        if (node.isArray()) {
+            if (node.isEmpty()) {
+                return 1;
+            }
+            int count = 0;
+            for (JsonNode child : node) {
+                count += leafCount(child);
+            }
+            return count;
+        }
+        return 1;
+    }
+
+    private String render(JsonNode node) {
+        if (node == null || node.isMissingNode()) {
+            return "<missing>";
+        }
+        if (node.getNodeType() == JsonNodeType.NULL) {
+            return "null";
+        }
+        return node.toString();
+    }
+
+    /** Accumulates the running comparison result. */
+    private static final class Diff {
+        private int matched;
+        private int denominator;
+        private final List<String> differences = new ArrayList<>();
+    }
+
+    /**
+     * Builder for constructing structural match evaluators.
+     */
+    public static class Builder {
+        private String name = "Structural Match";
+        private double threshold = 1.0;
+        private List<EvalTestCaseParam> evaluationParams = List.of();
+        private String outputKey = "output";
+        private StructuralMatchMode mode = StructuralMatchMode.STRICT;
+        private boolean binary = false;
+
+        /**
+         * Sets the evaluator name.
+         *
+         * @param name the evaluator name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the minimum score threshold for success.
+         *
+         * @param threshold the threshold value
+         * @return this builder
+         */
+        public Builder threshold(double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets which test case parameters to validate.
+         *
+         * @param params the parameters
+         * @return this builder
+         */
+        public Builder evaluationParams(List<EvalTestCaseParam> params) {
+            this.evaluationParams = List.copyOf(params);
+            return this;
+        }
+
+        /**
+         * Sets the map key used to read the value from both the actual and expected output maps.
+         * Defaults to {@code "output"}.
+         *
+         * @param outputKey the output map key
+         * @return this builder
+         */
+        public Builder outputKey(String outputKey) {
+            this.outputKey = outputKey;
+            return this;
+        }
+
+        /**
+         * Sets the comparison mode. Defaults to {@link StructuralMatchMode#STRICT}.
+         *
+         * @param mode the comparison mode
+         * @return this builder
+         */
+        public Builder mode(StructuralMatchMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        /**
+         * Switches scoring to binary: {@code 1.0} when the structures match completely, {@code 0.0}
+         * otherwise. Without this, the score is the fraction of matching leaf paths.
+         *
+         * @return this builder
+         */
+        public Builder binary() {
+            this.binary = true;
+            return this;
+        }
+
+        /**
+         * Builds the evaluator.
+         *
+         * @return a new evaluator
+         */
+        public StructuralMatchEvaluator build() {
+            return new StructuralMatchEvaluator(this);
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchEvaluator.java
@@ -10,10 +10,10 @@ import dev.dokimos.core.EvalTestCaseParam;
 import dev.dokimos.core.internal.Json;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -25,9 +25,9 @@ import java.util.Set;
  * it treats {@code 5} and {@code 5.0} as different and would corrupt eval results). The comparator:
  *
  * <ul>
- *   <li>Compares numeric leaves by {@link BigDecimal#compareTo(BigDecimal)} (scale-insensitive, so
- *       {@code 1.0} equals {@code 1.00}), with an epsilon tolerance for floating point. {@code 5} and
- *       {@code 5.0} therefore match by value in <em>both</em> modes.
+ *   <li>Compares numeric leaves by {@link BigDecimal#compareTo(BigDecimal)} (scale-insensitive but
+ *       otherwise exact, so {@code 1.0} equals {@code 1.00} and {@code 5} equals {@code 5.0}, while
+ *       genuinely distinct values never collapse). Matches by value in <em>both</em> modes.
  *   <li>Honors {@link StructuralMatchMode}: {@link StructuralMatchMode#STRICT STRICT} requires the
  *       exact field set and exact array order; {@link StructuralMatchMode#LENIENT LENIENT} allows
  *       extra actual fields (subset match) and ignores array order as a multiset.
@@ -45,9 +45,6 @@ import java.util.Set;
  * or {@code 0.0} (anything differs) for exact-contract gates.
  */
 public class StructuralMatchEvaluator extends BaseEvaluator {
-
-    /** Tolerance applied when comparing numeric leaves that are not exactly equal in scale. */
-    private static final BigDecimal EPSILON = new BigDecimal("1e-9");
 
     private final String outputKey;
     private final StructuralMatchMode mode;
@@ -239,31 +236,55 @@ public class StructuralMatchEvaluator extends BaseEvaluator {
             return;
         }
 
-        // LENIENT: multiset semantics — order ignored, multiplicity preserved, extras ignored.
-        List<JsonNode> remaining = new ArrayList<>();
-        actual.forEach(remaining::add);
-
-        for (int i = 0; i < expected.size(); i++) {
-            JsonNode expectedChild = expected.get(i);
-            int matchIndex = -1;
-            for (int j = 0; j < remaining.size(); j++) {
-                if (deepMatches(expectedChild, remaining.get(j))) {
-                    matchIndex = j;
-                    break;
+        // LENIENT: multiset semantics — order ignored, multiplicity preserved, extras ignored. Use
+        // maximum bipartite matching (not greedy first-fit) so a subset element cannot steal the
+        // match a more specific element needs: e.g. expected [{a:1},{a:1,b:2}] against actual
+        // [{a:1,b:2},{a:1}] pairs fully instead of scoring a false partial.
+        int n = expected.size();
+        int m = actual.size();
+        List<List<Integer>> candidates = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            List<Integer> matches = new ArrayList<>();
+            for (int j = 0; j < m; j++) {
+                if (deepMatches(expected.get(i), actual.get(j))) {
+                    matches.add(j);
                 }
             }
-            if (matchIndex >= 0) {
-                // A matched element contributes all of its expected leaves as matched.
-                int leaves = leafCount(expectedChild);
-                diff.denominator += leaves;
+            candidates.add(matches);
+        }
+
+        int[] actualMatchedBy = new int[m];
+        Arrays.fill(actualMatchedBy, -1);
+        boolean[] expectedMatched = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            expectedMatched[i] = augment(i, candidates, actualMatchedBy, new boolean[m]);
+        }
+
+        for (int i = 0; i < n; i++) {
+            int leaves = leafCount(expected.get(i));
+            diff.denominator += leaves;
+            if (expectedMatched[i]) {
                 diff.matched += leaves;
-                remaining.remove(matchIndex);
             } else {
-                diff.denominator += leafCount(expectedChild);
                 diff.differences.add(
-                        "%s: no actual element matched expected %s".formatted(path + "[" + i + "]", render(expectedChild)));
+                        "%s: no actual element matched expected %s".formatted(path + "[" + i + "]", render(expected.get(i))));
             }
         }
+    }
+
+    /** Kuhn's augmenting-path step for maximum bipartite matching of expected to actual elements. */
+    private boolean augment(int i, List<List<Integer>> candidates, int[] actualMatchedBy, boolean[] seen) {
+        for (int j : candidates.get(i)) {
+            if (seen[j]) {
+                continue;
+            }
+            seen[j] = true;
+            if (actualMatchedBy[j] == -1 || augment(actualMatchedBy[j], candidates, actualMatchedBy, seen)) {
+                actualMatchedBy[j] = i;
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Whether two nodes match completely under the current mode (used for LENIENT array matching). */
@@ -276,12 +297,9 @@ public class StructuralMatchEvaluator extends BaseEvaluator {
     /** Compares two present, non-null scalar nodes by value (null/missing handled by the caller). */
     private boolean leafEquals(JsonNode expected, JsonNode actual) {
         if (expected.isNumber() && actual.isNumber()) {
-            BigDecimal e = expected.decimalValue();
-            BigDecimal a = actual.decimalValue();
-            if (e.compareTo(a) == 0) {
-                return true;
-            }
-            return e.subtract(a).abs().compareTo(EPSILON) <= 0;
+            // Scale-insensitive but exact: 5 == 5.0 and 1.0 == 1.00, while genuinely distinct values
+            // (including tiny near-zero ones) never collapse.
+            return expected.decimalValue().compareTo(actual.decimalValue()) == 0;
         }
         if (expected.getNodeType() != actual.getNodeType()) {
             return false;

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchEvaluator.java
@@ -196,8 +196,7 @@ public class StructuralMatchEvaluator extends BaseEvaluator {
             if (match) {
                 diff.matched++;
             } else {
-                diff.differences.add(
-                        "%s: expected %s but was %s".formatted(path, render(expected), render(actual)));
+                diff.differences.add("%s: expected %s but was %s".formatted(path, render(expected), render(actual)));
             }
             return;
         }
@@ -205,8 +204,7 @@ public class StructuralMatchEvaluator extends BaseEvaluator {
         if (leafEquals(expected, actual)) {
             diff.matched++;
         } else {
-            diff.differences.add(
-                    "%s: expected %s but was %s".formatted(path, render(expected), render(actual)));
+            diff.differences.add("%s: expected %s but was %s".formatted(path, render(expected), render(actual)));
         }
     }
 
@@ -266,8 +264,8 @@ public class StructuralMatchEvaluator extends BaseEvaluator {
             if (expectedMatched[i]) {
                 diff.matched += leaves;
             } else {
-                diff.differences.add(
-                        "%s: no actual element matched expected %s".formatted(path + "[" + i + "]", render(expected.get(i))));
+                diff.differences.add("%s: no actual element matched expected %s"
+                        .formatted(path + "[" + i + "]", render(expected.get(i))));
             }
         }
     }

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchMode.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchMode.java
@@ -7,8 +7,6 @@ package dev.dokimos.core.evaluators;
  * <p>Both modes are numeric-value-aware: a number compares by value, not by representation, so {@code
  * 5} and {@code 5.0} (and {@code 1.0} versus {@code 1.00}) always match in either mode. The modes
  * differ only on how they treat object field sets and array ordering.
- *
- * <p>Modeled on Spring's {@code org.springframework.test.json.JsonCompareMode}.
  */
 public enum StructuralMatchMode {
 

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchMode.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/StructuralMatchMode.java
@@ -1,0 +1,39 @@
+package dev.dokimos.core.evaluators;
+
+/**
+ * Controls how {@link StructuralMatchEvaluator} compares an expected JSON structure against an actual
+ * one.
+ *
+ * <p>Both modes are numeric-value-aware: a number compares by value, not by representation, so {@code
+ * 5} and {@code 5.0} (and {@code 1.0} versus {@code 1.00}) always match in either mode. The modes
+ * differ only on how they treat object field sets and array ordering.
+ *
+ * <p>Modeled on Spring's {@code org.springframework.test.json.JsonCompareMode}.
+ */
+public enum StructuralMatchMode {
+
+    /**
+     * Strict comparison (the eval-safe default).
+     *
+     * <ul>
+     *   <li>Objects must have the exact same set of fields — an extra field in the actual output is a
+     *       mismatch and penalizes the score.
+     *   <li>Arrays must match element-for-element in the same order.
+     *   <li>A {@code null} value and a missing field are distinct.
+     * </ul>
+     */
+    STRICT,
+
+    /**
+     * Lenient comparison.
+     *
+     * <ul>
+     *   <li>Extra fields in the actual output are ignored (the actual may be a superset of the
+     *       expected object).
+     *   <li>Array order is ignored, but multiplicity is not — arrays are compared as multisets, so
+     *       {@code [1, 1, 2]} does not match {@code [1, 2]}.
+     *   <li>A {@code null} value and a missing field are treated as equal.
+     * </ul>
+     */
+    LENIENT
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/exceptions/DokimosTypeConversionException.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/exceptions/DokimosTypeConversionException.java
@@ -11,8 +11,7 @@ package dev.dokimos.core.exceptions;
  * failed rather than aborting the whole run.
  *
  * <p>The underlying cause (a Jackson conversion error) is attached via {@link #getCause()} for
- * diagnostics, but no Jackson type appears on this class's public API by design — the cause is typed
- * only as {@link Throwable}.
+ * diagnostics, typed as {@link Throwable}.
  */
 public class DokimosTypeConversionException extends RuntimeException {
 
@@ -30,8 +29,7 @@ public class DokimosTypeConversionException extends RuntimeException {
      *
      * @param message a human-readable description of the conversion failure
      * @param cause the underlying error that triggered the failure (for example a Jackson conversion
-     *     error); exposed only as a {@link Throwable} so no JSON-library type leaks onto the public
-     *     API
+     *     error), typed as {@link Throwable}
      */
     public DokimosTypeConversionException(String message, Throwable cause) {
         super(message, cause);

--- a/dokimos-core/src/main/java/dev/dokimos/core/exceptions/DokimosTypeConversionException.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/exceptions/DokimosTypeConversionException.java
@@ -1,0 +1,39 @@
+package dev.dokimos.core.exceptions;
+
+/**
+ * Thrown when a stored output value cannot be converted to the requested type by one of the typed
+ * read accessors (for example {@link dev.dokimos.core.EvalTestCase#actualOutputAs(Class)} or {@link
+ * dev.dokimos.core.Example#expectedOutputAs(dev.dokimos.core.OutputType)}).
+ *
+ * <p>This is an unchecked exception: a conversion failure is a programming/data error (the requested
+ * type does not match the shape of the stored value), not a recoverable condition callers are
+ * expected to handle on every call. The evaluation path catches it and scores the affected item as
+ * failed rather than aborting the whole run.
+ *
+ * <p>The underlying cause (a Jackson conversion error) is attached via {@link #getCause()} for
+ * diagnostics, but no Jackson type appears on this class's public API by design — the cause is typed
+ * only as {@link Throwable}.
+ */
+public class DokimosTypeConversionException extends RuntimeException {
+
+    /**
+     * Creates an exception with the given detail message.
+     *
+     * @param message a human-readable description of the conversion failure
+     */
+    public DokimosTypeConversionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates an exception with the given detail message and underlying cause.
+     *
+     * @param message a human-readable description of the conversion failure
+     * @param cause the underlying error that triggered the failure (for example a Jackson conversion
+     *     error); exposed only as a {@link Throwable} so no JSON-library type leaks onto the public
+     *     API
+     */
+    public DokimosTypeConversionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
@@ -28,9 +28,11 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
  *       silently collapsed.
  *   <li>{@link DeserializationFeature#FAIL_ON_TRAILING_TOKENS} is enabled so trailing garbage after
  *       a value is rejected.
- *   <li>Non-finite floating point values (NaN, Infinity) are rejected on both read and write —
- *       Jackson's default treats {@code NaN == NaN} as true, the opposite of Java semantics, which
- *       would corrupt structural comparison.
+ *   <li>Non-finite floating point values (NaN, Infinity) are rejected when parsing (the
+ *       {@link JsonReadFeature#ALLOW_NON_NUMERIC_NUMBERS} read feature is disabled). Jackson has no
+ *       equivalent throw-on-write for non-finite doubles, so the structural comparator additionally
+ *       rejects in-memory non-finite values before comparison; this keeps Jackson's surprising
+ *       {@code NaN == NaN} out of eval results.
  * </ul>
  *
  * <p>This class is internal API. It is not part of the public, supported surface of dokimos-core

--- a/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
@@ -47,13 +47,12 @@ public final class Json {
     private static final ObjectWriter PRETTY_WRITER;
 
     static {
-        MAPPER =
-                JsonMapper.builder()
-                        // Reject NaN / Infinity tokens when parsing: Jackson's NaN == NaN is the
-                        // opposite of Java, which would silently corrupt structural comparison.
-                        .disable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
-                        .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
-                        .build();
+        MAPPER = JsonMapper.builder()
+                // Reject NaN / Infinity tokens when parsing: Jackson's NaN == NaN is the
+                // opposite of Java, which would silently corrupt structural comparison.
+                .disable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+                .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
 
         READER = MAPPER.reader();
         COMPARISON_READER = MAPPER.reader().with(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
@@ -176,8 +175,7 @@ public final class Json {
 
     /**
      * Resolves a Jackson {@link JavaType} from a generic {@link java.lang.reflect.Type}. Used to
-     * bridge an {@code OutputType<T>}'s captured type into the conversion machinery without exposing
-     * Jackson on the public API.
+     * bridge an {@code OutputType<T>}'s captured type into the conversion machinery.
      *
      * @param type the generic type to resolve
      * @return the corresponding Jackson {@link JavaType}

--- a/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
@@ -3,6 +3,7 @@ package dev.dokimos.core.internal;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -206,6 +207,25 @@ public final class Json {
      */
     public static <T> T read(String json, JavaType type) {
         return readInternal(json, READER.forType(type));
+    }
+
+    /**
+     * Parses a JSON string into the generic target captured by a Jackson {@link TypeReference}, using
+     * the strict {@linkplain #comparisonReader() comparison reader} so duplicate object keys are
+     * rejected alongside the NaN/Infinity and trailing-token tightening that applies to every reader.
+     *
+     * <p>This is the load-path entry point for dataset and server JSON: malformed structured input
+     * (a duplicate key, a {@code NaN} token, trailing garbage) fails here at parse time rather than
+     * surfacing confusingly later during evaluation.
+     *
+     * @param json the JSON text to parse
+     * @param type the captured generic target type
+     * @param <T> the target type
+     * @return the parsed value (the JSON literal {@code null} parses to {@code null})
+     * @throws IllegalArgumentException if the text is not valid JSON or does not match {@code type}
+     */
+    public static <T> T read(String json, TypeReference<T> type) {
+        return readInternal(json, COMPARISON_READER.forType(type));
     }
 
     private static <T> T readInternal(String json, ObjectReader reader) {

--- a/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
@@ -1,0 +1,186 @@
+package dev.dokimos.core.internal;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+/**
+ * Shared, framework-internal JSON utilities backed by a single, immutable Jackson {@link
+ * ObjectMapper}.
+ *
+ * <p>The mapper is constructed once in a static initializer and is never mutated afterwards. Only
+ * the thread-safe {@link ObjectReader} and {@link ObjectWriter} views are exposed (directly or via
+ * convenience helpers), which keeps all usage safe under the parallel experiment runs that
+ * dokimos-core performs.
+ *
+ * <p>Configuration of note:
+ *
+ * <ul>
+ *   <li>{@link StreamReadFeature#STRICT_DUPLICATE_DETECTION} is enabled on the comparison reader so
+ *       duplicate object keys (a real signal in an evaluation) fail loudly rather than being
+ *       silently collapsed.
+ *   <li>{@link DeserializationFeature#FAIL_ON_TRAILING_TOKENS} is enabled so trailing garbage after
+ *       a value is rejected.
+ *   <li>Non-finite floating point values (NaN, Infinity) are rejected on both read and write —
+ *       Jackson's default treats {@code NaN == NaN} as true, the opposite of Java semantics, which
+ *       would corrupt structural comparison.
+ * </ul>
+ *
+ * <p>This class is internal API. It is not part of the public, supported surface of dokimos-core
+ * and may change without notice.
+ */
+public final class Json {
+
+    private static final ObjectMapper MAPPER;
+    private static final ObjectReader READER;
+    private static final ObjectReader COMPARISON_READER;
+    private static final ObjectWriter COMPACT_WRITER;
+    private static final ObjectWriter PRETTY_WRITER;
+
+    static {
+        MAPPER =
+                JsonMapper.builder()
+                        // Reject NaN / Infinity tokens when parsing: Jackson's NaN == NaN is the
+                        // opposite of Java, which would silently corrupt structural comparison.
+                        .disable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+                        .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                        .build();
+
+        READER = MAPPER.reader();
+        COMPARISON_READER = MAPPER.reader().with(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
+        COMPACT_WRITER = MAPPER.writer();
+        PRETTY_WRITER = MAPPER.writerWithDefaultPrettyPrinter();
+    }
+
+    private Json() {}
+
+    /**
+     * A thread-safe reader over the shared, immutable mapper. Use for general value conversion.
+     *
+     * @return the shared {@link ObjectReader}
+     */
+    public static ObjectReader reader() {
+        return READER;
+    }
+
+    /**
+     * A thread-safe reader configured for structural comparison: strict duplicate-key detection is
+     * enabled so {@code {"x":1,"x":2}} fails rather than silently collapsing.
+     *
+     * @return the shared comparison {@link ObjectReader}
+     */
+    public static ObjectReader comparisonReader() {
+        return COMPARISON_READER;
+    }
+
+    /**
+     * A thread-safe writer producing compact (single-line) JSON.
+     *
+     * @return the shared compact {@link ObjectWriter}
+     */
+    public static ObjectWriter compactWriter() {
+        return COMPACT_WRITER;
+    }
+
+    /**
+     * A thread-safe writer producing pretty-printed JSON.
+     *
+     * @return the shared pretty-printing {@link ObjectWriter}
+     */
+    public static ObjectWriter prettyWriter() {
+        return PRETTY_WRITER;
+    }
+
+    /**
+     * Converts a value into an instance of {@code type} without an intermediate textual round-trip.
+     *
+     * @param value the source value (may be {@code null})
+     * @param type the target class
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code value} is {@code null}
+     * @throws IllegalArgumentException if the value cannot be converted to {@code type}
+     */
+    public static <T> T convert(Object value, Class<T> type) {
+        if (value == null) {
+            return null;
+        }
+        return MAPPER.convertValue(value, type);
+    }
+
+    /**
+     * Converts a value into an instance described by a Jackson {@link JavaType}, supporting generic
+     * targets such as {@code List<Foo>}.
+     *
+     * @param value the source value (may be {@code null})
+     * @param type the target Jackson type
+     * @param <T> the target type
+     * @return the converted value, or {@code null} if {@code value} is {@code null}
+     * @throws IllegalArgumentException if the value cannot be converted to {@code type}
+     */
+    public static <T> T convert(Object value, JavaType type) {
+        if (value == null) {
+            return null;
+        }
+        return MAPPER.convertValue(value, type);
+    }
+
+    /**
+     * Converts an arbitrary value to a {@link JsonNode} tree (the in-memory model the structural
+     * comparator works against).
+     *
+     * @param value the source value (may be {@code null})
+     * @return the value as a {@link JsonNode}; a {@code null} value yields a Jackson null node
+     */
+    public static JsonNode toNode(Object value) {
+        return MAPPER.valueToTree(value);
+    }
+
+    /**
+     * Serializes a value to compact (single-line) JSON.
+     *
+     * @param value the value to serialize
+     * @return the compact JSON string
+     * @throws IllegalArgumentException if the value cannot be serialized
+     */
+    public static String writeCompact(Object value) {
+        try {
+            return COMPACT_WRITER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize value to JSON", e);
+        }
+    }
+
+    /**
+     * Serializes a value to pretty-printed JSON.
+     *
+     * @param value the value to serialize
+     * @return the pretty-printed JSON string
+     * @throws IllegalArgumentException if the value cannot be serialized
+     */
+    public static String writePretty(Object value) {
+        try {
+            return PRETTY_WRITER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize value to JSON", e);
+        }
+    }
+
+    /**
+     * Resolves a Jackson {@link JavaType} from a generic {@link java.lang.reflect.Type}. Used to
+     * bridge an {@code OutputType<T>}'s captured type into the conversion machinery without exposing
+     * Jackson on the public API.
+     *
+     * @param type the generic type to resolve
+     * @return the corresponding Jackson {@link JavaType}
+     */
+    public static JavaType resolveType(java.lang.reflect.Type type) {
+        return MAPPER.getTypeFactory().constructType(type);
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/internal/Json.java
@@ -174,6 +174,49 @@ public final class Json {
     }
 
     /**
+     * Parses a JSON string into an instance of {@code type}.
+     *
+     * <p>Backed by {@code reader().forType(type)}, which returns a fresh, type-bound view of the
+     * shared immutable mapper without mutating it — so this is safe under the parallel experiment
+     * runs dokimos-core performs.
+     *
+     * @param json the JSON text to parse
+     * @param type the target class
+     * @param <T> the target type
+     * @return the parsed value (the JSON literal {@code null} parses to {@code null})
+     * @throws IllegalArgumentException if the text is not valid JSON or does not match {@code type}
+     */
+    public static <T> T read(String json, Class<T> type) {
+        return readInternal(json, READER.forType(type));
+    }
+
+    /**
+     * Parses a JSON string into an instance described by a Jackson {@link JavaType}, supporting
+     * generic targets such as {@code List<Foo>}.
+     *
+     * <p>Backed by {@code reader().forType(type)}, which returns a fresh, type-bound view of the
+     * shared immutable mapper without mutating it — so this is safe under the parallel experiment
+     * runs dokimos-core performs.
+     *
+     * @param json the JSON text to parse
+     * @param type the target Jackson type
+     * @param <T> the target type
+     * @return the parsed value (the JSON literal {@code null} parses to {@code null})
+     * @throws IllegalArgumentException if the text is not valid JSON or does not match {@code type}
+     */
+    public static <T> T read(String json, JavaType type) {
+        return readInternal(json, READER.forType(type));
+    }
+
+    private static <T> T readInternal(String json, ObjectReader reader) {
+        try {
+            return reader.readValue(json);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to parse JSON", e);
+        }
+    }
+
+    /**
      * Resolves a Jackson {@link JavaType} from a generic {@link java.lang.reflect.Type}. Used to
      * bridge an {@code OutputType<T>}'s captured type into the conversion machinery.
      *

--- a/dokimos-core/src/test/java/dev/dokimos/core/DatasetParserTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/DatasetParserTest.java
@@ -1,0 +1,95 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.UncheckedIOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the dataset load path is routed through the hardened internal JSON reader, so malformed
+ * structured input (duplicate keys, NaN/Infinity tokens, trailing garbage) is rejected at parse time
+ * rather than surfacing confusingly later during evaluation.
+ */
+class DatasetParserTest {
+
+    @Test
+    void shouldLoadValidDatasetUnchanged() {
+        String json = """
+                {
+                  "name": "refund-qa",
+                  "description": "Questions about refunds",
+                  "examples": [
+                    {
+                      "inputs": {"question": "What is the refund policy?"},
+                      "expectedOutputs": {"answer": "30-day full refund", "confidence": 0.9}
+                    }
+                  ]
+                }
+                """;
+
+        Dataset dataset = DatasetParser.parseJson(json);
+
+        assertThat(dataset.name()).isEqualTo("refund-qa");
+        assertThat(dataset.description()).isEqualTo("Questions about refunds");
+        assertThat(dataset.size()).isEqualTo(1);
+        assertThat(dataset.get(0).inputs()).containsEntry("question", "What is the refund policy?");
+        assertThat(dataset.get(0).expectedOutputs()).containsEntry("answer", "30-day full refund");
+        assertThat(dataset.get(0).expectedOutputs()).containsEntry("confidence", 0.9);
+    }
+
+    @Test
+    void shouldRejectDuplicateKeysAtParse() {
+        // Two "name" keys: a real signal in a dataset, silently collapsed by a default mapper.
+        String json = """
+                {
+                  "name": "first",
+                  "name": "second",
+                  "examples": [{"input": "q", "expectedOutput": "a"}]
+                }
+                """;
+
+        assertThatThrownBy(() -> DatasetParser.parseJson(json))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageContaining("Failed to parse JSON content of dataset")
+                .rootCause()
+                .hasMessageContaining("Duplicate");
+    }
+
+    @Test
+    void shouldRejectNaNTokenAtParse() {
+        String json = """
+                {
+                  "name": "broken",
+                  "examples": [
+                    {"inputs": {"q": "x"}, "expectedOutputs": {"confidence": NaN}}
+                  ]
+                }
+                """;
+
+        assertThatThrownBy(() -> DatasetParser.parseJson(json))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageContaining("Failed to parse JSON content of dataset");
+    }
+
+    @Test
+    void shouldRejectTrailingGarbageAtParse() {
+        String json = "{\"name\":\"d\",\"examples\":[{\"input\":\"q\",\"expectedOutput\":\"a\"}]} trailing";
+
+        assertThatThrownBy(() -> DatasetParser.parseJson(json))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageContaining("Failed to parse JSON content of dataset");
+    }
+
+    @Test
+    void shouldRejectDuplicateKeysInJsonlLine() {
+        String jsonl = """
+                {"input": "valid", "expectedOutput": "ok"}
+                {"input": "dup", "input": "dup2", "expectedOutput": "x"}
+                """;
+
+        assertThatThrownBy(() -> DatasetParser.parseJsonl(jsonl, "test"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("line 2");
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
@@ -40,8 +40,8 @@ class ExperimentAsyncTest {
                 .addExample(Example.of("What is 3*3?", "9"))
                 .build();
 
-        AsyncTask task = example ->
-                CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+        AsyncTask task =
+                example -> CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
 
         var result = Experiment.builder()
                 .name("async-happy")
@@ -289,8 +289,8 @@ class ExperimentAsyncTest {
         Experiment.builder()
                 .name("async-reporter")
                 .dataset(dataset)
-                .asyncTask(example -> CompletableFuture.completedFuture(
-                        TaskResult.of(Map.of("output", example.expectedOutput()))))
+                .asyncTask(example ->
+                        CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput()))))
                 .evaluator(passingEvaluator())
                 .reporter(tracker)
                 .build()

--- a/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
@@ -1,0 +1,392 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ExperimentAsyncTest {
+
+    private static Evaluator passingEvaluator() {
+        return new Evaluator() {
+            @Override
+            public EvalResult evaluate(EvalTestCase testCase) {
+                return EvalResult.success("noop", 1.0, "ok");
+            }
+
+            @Override
+            public String name() {
+                return "noop";
+            }
+
+            @Override
+            public double threshold() {
+                return 0.5;
+            }
+        };
+    }
+
+    @Test
+    void asyncTaskHappyPathProducesResultsForEachExample() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("What is 2+2?", "4"))
+                .addExample(Example.of("What is 3*3?", "9"))
+                .build();
+
+        AsyncTask task = example ->
+                CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+
+        var result = Experiment.builder()
+                .name("async-happy")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.totalCount()).isEqualTo(2);
+        assertThat(result.itemResults().get(0).actualOutputs()).containsEntry("output", "4");
+        assertThat(result.itemResults().get(1).actualOutputs()).containsEntry("output", "9");
+        assertThat(result.itemResults()).allMatch(ItemResult::success);
+    }
+
+    @Test
+    void failedFutureBecomesFailedItemResultAndRunContinues() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("ok1", "a1"))
+                .addExample(Example.of("boom", "a2"))
+                .addExample(Example.of("ok3", "a3"))
+                .build();
+
+        AsyncTask task = example -> {
+            if ("boom".equals(example.input())) {
+                return CompletableFuture.failedFuture(new RuntimeException("async kaboom"));
+            }
+            return CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+        };
+
+        var result = Experiment.builder()
+                .name("async-failure")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(3);
+        assertThat(result.itemResults().get(0).success()).isTrue();
+        assertThat(result.itemResults().get(1).success()).isFalse();
+        assertThat(result.itemResults().get(1).evalResults()).isEmpty();
+        assertThat(result.itemResults().get(2).success()).isTrue();
+    }
+
+    @Test
+    void synchronousThrowFromAsyncTaskIsIsolated() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("ok", "a1"))
+                .addExample(Example.of("boom", "a2"))
+                .build();
+
+        AsyncTask task = example -> {
+            if ("boom".equals(example.input())) {
+                throw new RuntimeException("sync throw from run");
+            }
+            return CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+        };
+
+        var result = Experiment.builder()
+                .name("async-sync-throw")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(2);
+        assertThat(result.itemResults().get(0).success()).isTrue();
+        assertThat(result.itemResults().get(1).success()).isFalse();
+        assertThat(result.itemResults().get(1).evalResults()).isEmpty();
+    }
+
+    @Test
+    void measuredMetricsFlowFromTaskResultToItemResult() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+        var metrics = new CallMetrics(10, 20, 0.5, 123L);
+
+        AsyncTask task = example -> CompletableFuture.completedFuture(new TaskResult(Map.of("output", "a"), metrics));
+
+        var result = Experiment.builder()
+                .name("async-metrics")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(1);
+        assertThat(result.itemResults().get(0).metrics()).isEqualTo(metrics);
+        assertThat(result.itemResults().get(0).actualOutputs()).containsEntry("output", "a");
+    }
+
+    @Test
+    void executeAsyncCapsConcurrencyAtParallelism() {
+        int parallelism = 3;
+        int exampleCount = 20;
+
+        var datasetBuilder = Dataset.builder();
+        for (int i = 0; i < exampleCount; i++) {
+            datasetBuilder.addExample(Example.of("q" + i, "a" + i));
+        }
+        var dataset = datasetBuilder.build();
+
+        // Drive the futures off a separate pool so they actually overlap in time.
+        ExecutorService pool = Executors.newFixedThreadPool(parallelism * 4);
+        AtomicInteger inFlight = new AtomicInteger(0);
+        AtomicInteger maxObserved = new AtomicInteger(0);
+
+        try {
+            AsyncTask task = example -> CompletableFuture.supplyAsync(
+                    () -> {
+                        int current = inFlight.incrementAndGet();
+                        maxObserved.accumulateAndGet(current, Math::max);
+                        try {
+                            // Hold the slot long enough that the cap is exercised.
+                            Thread.sleep(20);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            inFlight.decrementAndGet();
+                        }
+                        return TaskResult.of(Map.of("output", example.expectedOutput()));
+                    },
+                    pool);
+
+            var result = Experiment.builder()
+                    .name("async-concurrency-cap")
+                    .dataset(dataset)
+                    .asyncTask(task)
+                    .evaluator(passingEvaluator())
+                    .parallelism(parallelism)
+                    .build()
+                    .run();
+
+            assertThat(result.totalCount()).isEqualTo(exampleCount);
+            assertThat(maxObserved.get()).isLessThanOrEqualTo(parallelism);
+            assertThat(maxObserved.get()).isGreaterThan(1);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void executeAsyncPreservesDatasetOrder() {
+        int exampleCount = 30;
+        var datasetBuilder = Dataset.builder();
+        for (int i = 0; i < exampleCount; i++) {
+            datasetBuilder.addExample(Example.of("q" + i, "a" + i));
+        }
+        var dataset = datasetBuilder.build();
+
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        try {
+            // Reverse the completion order: earlier examples sleep longer.
+            AsyncTask task = example -> CompletableFuture.supplyAsync(
+                    () -> {
+                        int index = Integer.parseInt(example.input().substring(1));
+                        try {
+                            Thread.sleep((exampleCount - index));
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return TaskResult.of(Map.of("output", example.expectedOutput()));
+                    },
+                    pool);
+
+            var result = Experiment.builder()
+                    .name("async-order")
+                    .dataset(dataset)
+                    .asyncTask(task)
+                    .evaluator(passingEvaluator())
+                    .parallelism(4)
+                    .build()
+                    .run();
+
+            assertThat(result.itemResults()).hasSize(exampleCount);
+            for (int i = 0; i < exampleCount; i++) {
+                assertThat(result.itemResults().get(i).example().input()).isEqualTo("q" + i);
+                assertThat(result.itemResults().get(i).actualOutputs()).containsEntry("output", "a" + i);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void asyncTaskSatisfiesTaskRequirement() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        // No task(...) or measuredTask(...) set — asyncTask alone must satisfy build().
+        var experiment = Experiment.builder()
+                .name("async-only")
+                .dataset(dataset)
+                .asyncTask(example -> CompletableFuture.completedFuture(TaskResult.of(Map.of("output", "a"))))
+                .evaluator(passingEvaluator())
+                .build();
+
+        assertThat(experiment.run().totalCount()).isEqualTo(1);
+    }
+
+    @Test
+    void buildStillRequiresAtLeastATask() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        assertThatThrownBy(() -> Experiment.builder()
+                        .name("no-task")
+                        .dataset(dataset)
+                        .evaluator(passingEvaluator())
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Task");
+    }
+
+    @Test
+    void asyncTaskTakesPrecedenceOverSyncTask() {
+        var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
+
+        // A sync task that would throw, plus an async task that succeeds: the async path must win.
+        var result = Experiment.builder()
+                .name("async-precedence")
+                .dataset(dataset)
+                .task(example -> {
+                    throw new RuntimeException("sync task should not run");
+                })
+                .asyncTask(example -> CompletableFuture.completedFuture(TaskResult.of(Map.of("output", "async"))))
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.itemResults()).hasSize(1);
+        assertThat(result.itemResults().get(0).success()).isTrue();
+        assertThat(result.itemResults().get(0).actualOutputs()).containsEntry("output", "async");
+    }
+
+    @Test
+    void asyncRunReportsEachItemThroughReporter() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("q1", "a1"))
+                .addExample(Example.of("q2", "a2"))
+                .build();
+
+        var tracker = new ItemTrackingReporter();
+
+        Experiment.builder()
+                .name("async-reporter")
+                .dataset(dataset)
+                .asyncTask(example -> CompletableFuture.completedFuture(
+                        TaskResult.of(Map.of("output", example.expectedOutput()))))
+                .evaluator(passingEvaluator())
+                .reporter(tracker)
+                .build()
+                .run();
+
+        assertThat(tracker.reportedInputs).containsExactly("q1", "q2");
+    }
+
+    @Test
+    void executeParallelShutsDownNowWhenTaskThrows() throws InterruptedException {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("q1", "a1"))
+                .addExample(Example.of("q2", "a2"))
+                .build();
+
+        // A reporter that throws inside reportItem forces an exception on the parallel path
+        // AFTER the executor's work has been submitted, exercising the shutdownNow() branch.
+        Reporter throwingReporter = new Reporter() {
+            @Override
+            public RunHandle startRun(String experimentName, Map<String, Object> metadata) {
+                return new RunHandle("id");
+            }
+
+            @Override
+            public void reportItem(RunHandle handle, ItemResult result) {
+                throw new RuntimeException("reporter blew up");
+            }
+
+            @Override
+            public void completeRun(RunHandle handle, RunStatus status) {}
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+
+        var threads = java.util.Collections.synchronizedList(new java.util.ArrayList<Thread>());
+
+        var experiment = Experiment.builder()
+                .name("shutdown-now")
+                .dataset(dataset)
+                .task(example -> {
+                    threads.add(Thread.currentThread());
+                    return Map.of("output", example.expectedOutput());
+                })
+                .evaluator(passingEvaluator())
+                .reporter(throwingReporter)
+                .parallelism(2)
+                .build();
+
+        assertThatThrownBy(experiment::run).hasMessageContaining("reporter blew up");
+
+        // shutdownNow() must terminate the pool's worker threads; they should die promptly.
+        boolean allDead = waitForThreadsToDie(threads, 5000);
+        assertThat(allDead).isTrue();
+    }
+
+    private static boolean waitForThreadsToDie(List<Thread> threads, long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (System.currentTimeMillis() < deadline) {
+            boolean anyAlive;
+            synchronized (threads) {
+                anyAlive = threads.stream().anyMatch(Thread::isAlive);
+            }
+            if (!anyAlive) {
+                return true;
+            }
+            TimeUnit.MILLISECONDS.sleep(20);
+        }
+        synchronized (threads) {
+            return threads.stream().noneMatch(Thread::isAlive);
+        }
+    }
+
+    private static class ItemTrackingReporter implements Reporter {
+        final List<String> reportedInputs = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+        @Override
+        public RunHandle startRun(String experimentName, Map<String, Object> metadata) {
+            return new RunHandle("id");
+        }
+
+        @Override
+        public void reportItem(RunHandle handle, ItemResult result) {
+            reportedInputs.add(result.example().input());
+        }
+
+        @Override
+        public void completeRun(RunHandle handle, RunStatus status) {}
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() {}
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
@@ -2,7 +2,9 @@ package dev.dokimos.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -297,6 +299,183 @@ class ExperimentAsyncTest {
                 .run();
 
         assertThat(tracker.reportedInputs).containsExactly("q1", "q2");
+    }
+
+    @Test
+    void asyncTaskReturningNullFutureIsIsolatedAsFailedItem() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("ok1", "a1"))
+                .addExample(Example.of("nullfuture", "a2"))
+                .addExample(Example.of("ok3", "a3"))
+                .build();
+
+        AsyncTask task = example -> {
+            if ("nullfuture".equals(example.input())) {
+                return null;
+            }
+            return CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+        };
+
+        // parallelism(1) means a leaked permit on the null-future branch would deadlock the run;
+        // an inner timeout turns that hang into a test failure rather than a stuck build.
+        var result = assertTimeoutPreemptively(Duration.ofSeconds(10), () -> Experiment.builder()
+                .name("async-null-future")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .parallelism(1)
+                .build()
+                .run());
+
+        assertThat(result.itemResults()).hasSize(3);
+        assertThat(result.itemResults().get(0).success()).isTrue();
+        assertThat(result.itemResults().get(1).success()).isFalse();
+        assertThat(result.itemResults().get(1).evalResults()).isEmpty();
+        assertThat(result.itemResults().get(2).success()).isTrue();
+    }
+
+    @Test
+    void asyncFailuresAtTightCapDoNotDeadlock() {
+        int exampleCount = 50;
+        var datasetBuilder = Dataset.builder();
+        for (int i = 0; i < exampleCount; i++) {
+            datasetBuilder.addExample(Example.of("q" + i, "a" + i));
+        }
+        var dataset = datasetBuilder.build();
+
+        // Every future completes exceptionally. With parallelism(1), a permit leak on the failure
+        // branch of whenComplete would block forever in allOf(...).join() — the timeout catches it.
+        AsyncTask task = example -> CompletableFuture.failedFuture(new RuntimeException("always fails"));
+
+        var result = assertTimeoutPreemptively(Duration.ofSeconds(10), () -> Experiment.builder()
+                .name("async-all-fail-tight-cap")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .parallelism(1)
+                .build()
+                .run());
+
+        assertThat(result.itemResults()).hasSize(exampleCount);
+        assertThat(result.itemResults()).allMatch(item -> !item.success());
+    }
+
+    @Test
+    void asyncEvaluatorThrowIsIsolatedAsFailedItem() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("ok1", "a1"))
+                .addExample(Example.of("evalboom", "a2"))
+                .addExample(Example.of("ok3", "a3"))
+                .build();
+
+        // The task future succeeds for every example; the evaluator throws for one of them.
+        // The failure originates inside evaluation on the completion stage, exercising the
+        // separate try/catch in toItemResult rather than the failed-future branch.
+        Evaluator throwingEvaluator = new Evaluator() {
+            @Override
+            public EvalResult evaluate(EvalTestCase testCase) {
+                if ("evalboom".equals(testCase.input())) {
+                    throw new RuntimeException("evaluator blew up");
+                }
+                return EvalResult.success("noop", 1.0, "ok");
+            }
+
+            @Override
+            public String name() {
+                return "noop";
+            }
+
+            @Override
+            public double threshold() {
+                return 0.5;
+            }
+        };
+
+        AsyncTask task =
+                example -> CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+
+        var result = assertTimeoutPreemptively(Duration.ofSeconds(10), () -> Experiment.builder()
+                .name("async-eval-throw")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(throwingEvaluator)
+                .build()
+                .run());
+
+        assertThat(result.itemResults()).hasSize(3);
+        assertThat(result.itemResults().get(0).success()).isTrue();
+        assertThat(result.itemResults().get(1).success()).isFalse();
+        assertThat(result.itemResults().get(1).evalResults()).isEmpty();
+        assertThat(result.itemResults().get(2).success()).isTrue();
+    }
+
+    @Test
+    void asyncWithMultipleRunsProducesOneRunResultPerRunAndAggregates() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("q1", "a1"))
+                .addExample(Example.of("q2", "a2"))
+                .build();
+
+        AsyncTask task =
+                example -> CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+
+        var result = Experiment.builder()
+                .name("async-multi-run")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .parallelism(2)
+                .runs(3)
+                .build()
+                .run();
+
+        assertThat(result.runs()).hasSize(3);
+        assertThat(result.runs()).allSatisfy(run -> {
+            assertThat(run.itemResults()).hasSize(2);
+            assertThat(run.itemResults()).allMatch(ItemResult::success);
+        });
+        assertThat(result.totalCount()).isEqualTo(2);
+        // All items pass in every run, so averaged pass count is the full dataset size.
+        assertThat(result.passCount()).isEqualTo(2.0);
+        assertThat(result.passRate()).isEqualTo(1.0);
+    }
+
+    @Test
+    void asyncMixedRunReportsCorrectPassAndFailCounts() {
+        var dataset = Dataset.builder()
+                .addExample(Example.of("ok1", "a1"))
+                .addExample(Example.of("boom1", "a2"))
+                .addExample(Example.of("ok2", "a3"))
+                .addExample(Example.of("boom2", "a4"))
+                .addExample(Example.of("ok3", "a5"))
+                .build();
+
+        AsyncTask task = example -> {
+            if (example.input().startsWith("boom")) {
+                return CompletableFuture.failedFuture(new RuntimeException("async kaboom"));
+            }
+            return CompletableFuture.completedFuture(TaskResult.of(Map.of("output", example.expectedOutput())));
+        };
+
+        var result = Experiment.builder()
+                .name("async-mixed-counts")
+                .dataset(dataset)
+                .asyncTask(task)
+                .evaluator(passingEvaluator())
+                .build()
+                .run();
+
+        assertThat(result.runs()).hasSize(1);
+        RunResult run = result.runs().get(0);
+        assertThat(run.totalCount()).isEqualTo(5);
+        assertThat(run.passCount()).isEqualTo(3);
+        assertThat(run.failCount()).isEqualTo(2);
+        assertThat(run.passRate()).isEqualTo(0.6);
+
+        // Failed items are built via the 3-arg ItemResult ctor, so their metrics are null.
+        assertThat(run.itemResults().stream().filter(item -> !item.success()))
+                .hasSize(2)
+                .allSatisfy(item -> assertThat(item.metrics()).isNull());
     }
 
     @Test

--- a/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/ExperimentAsyncTest.java
@@ -259,24 +259,20 @@ class ExperimentAsyncTest {
     }
 
     @Test
-    void asyncTaskTakesPrecedenceOverSyncTask() {
+    void configuringBothSyncAndAsyncTaskFailsFast() {
         var dataset = Dataset.builder().addExample(Example.of("q", "a")).build();
 
-        // A sync task that would throw, plus an async task that succeeds: the async path must win.
-        var result = Experiment.builder()
-                .name("async-precedence")
+        // A sync task and an async task are mutually exclusive; configuring both is rejected at build().
+        var builder = Experiment.builder()
+                .name("both-tasks")
                 .dataset(dataset)
-                .task(example -> {
-                    throw new RuntimeException("sync task should not run");
-                })
+                .task(example -> Map.of("output", "sync"))
                 .asyncTask(example -> CompletableFuture.completedFuture(TaskResult.of(Map.of("output", "async"))))
-                .evaluator(passingEvaluator())
-                .build()
-                .run();
+                .evaluator(passingEvaluator());
 
-        assertThat(result.itemResults()).hasSize(1);
-        assertThat(result.itemResults().get(0).success()).isTrue();
-        assertThat(result.itemResults().get(0).actualOutputs()).containsEntry("output", "async");
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not both");
     }
 
     @Test

--- a/dokimos-core/src/test/java/dev/dokimos/core/LLMJudgeEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/LLMJudgeEvaluatorTest.java
@@ -3,7 +3,9 @@ package dev.dokimos.core;
 import static org.assertj.core.api.Assertions.*;
 
 import dev.dokimos.core.evaluators.LLMJudgeEvaluator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class LLMJudgeEvaluatorTest {
@@ -238,4 +240,174 @@ class LLMJudgeEvaluatorTest {
         assertThatThrownBy(() -> LLMJudgeEvaluator.builder().scoreRange(5, 1))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    /**
+     * CRITICAL REGRESSION GUARD: for String outputs the produced prompt must be byte-identical to
+     * the pre-change behavior (raw String rendered verbatim). The expected prompt is constructed
+     * explicitly here so any drift in formatting fails loudly.
+     */
+    @Test
+    void shouldProduceByteIdenticalPromptForStringOutput() {
+        var capturedPrompt = new String[] {null};
+        JudgeLM capturingJudge = prompt -> {
+            capturedPrompt[0] = prompt;
+            return "{\"score\": 0.9, \"reason\": \"ok\"}";
+        };
+
+        var evaluator = LLMJudgeEvaluator.builder()
+                .name("correctness")
+                .criteria("Check correctness")
+                .evaluationParams(List.of(EvalTestCaseParam.ACTUAL_OUTPUT, EvalTestCaseParam.EXPECTED_OUTPUT))
+                .judge(capturingJudge)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("30 days refund")
+                .expectedOutput("30 days refund policy")
+                .build();
+
+        evaluator.evaluate(testCase);
+
+        String expected = "Evaluate the following based on this criteria: Check correctness\n\n"
+                + "Actual Output: 30 days refund\n"
+                + "Expected Output: 30 days refund policy\n"
+                + "Provide a score between 0.0 and 1.0, and a brief reasoning."
+                + "Respond in JSON format: {\"score\": <number>, \"reason\": \"<explanation>\"}";
+
+        assertThat(capturedPrompt[0]).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRenderPojoOutputAsPrettyJson() {
+        var capturedPrompt = new String[] {null};
+        JudgeLM capturingJudge = prompt -> {
+            capturedPrompt[0] = prompt;
+            return "{\"score\": 0.9, \"reason\": \"ok\"}";
+        };
+
+        var evaluator = LLMJudgeEvaluator.builder()
+                .name("test")
+                .criteria("Test")
+                .evaluationParams(List.of(EvalTestCaseParam.ACTUAL_OUTPUT))
+                .judge(capturingJudge)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("output", new Whisky("Lagavulin", 16))
+                .build();
+
+        evaluator.evaluate(testCase);
+
+        // Pretty JSON spans multiple lines and uses JSON syntax, not Java toString().
+        assertThat(capturedPrompt[0])
+                .contains("Actual Output: {")
+                .contains("\"name\" : \"Lagavulin\"")
+                .contains("\"age\" : 16")
+                .doesNotContain("Whisky[");
+    }
+
+    @Test
+    void shouldRenderListOutputAsJsonArray() {
+        var capturedPrompt = new String[] {null};
+        JudgeLM capturingJudge = prompt -> {
+            capturedPrompt[0] = prompt;
+            return "{\"score\": 0.9, \"reason\": \"ok\"}";
+        };
+
+        var evaluator = LLMJudgeEvaluator.builder()
+                .name("test")
+                .criteria("Test")
+                .evaluationParams(List.of(EvalTestCaseParam.ACTUAL_OUTPUT))
+                .judge(capturingJudge)
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("output", List.of("a", "b", "c"))
+                .build();
+
+        evaluator.evaluate(testCase);
+
+        assertThat(capturedPrompt[0])
+                .contains("Actual Output: [")
+                .contains("\"a\"")
+                .contains("\"b\"")
+                .contains("\"c\"")
+                .contains("]");
+    }
+
+    /**
+     * Documented INTENTIONAL behavior change: a Map output previously rendered via Java's {@code
+     * toString()} (e.g. {@code {region=Islay}}) now renders as JSON ({@code {"region":"Islay"}}).
+     */
+    @Test
+    void shouldRenderMapOutputAsJsonNotJavaToString() {
+        var capturedPrompt = new String[] {null};
+        JudgeLM capturingJudge = prompt -> {
+            capturedPrompt[0] = prompt;
+            return "{\"score\": 0.9, \"reason\": \"ok\"}";
+        };
+
+        var evaluator = LLMJudgeEvaluator.builder()
+                .name("test")
+                .criteria("Test")
+                .evaluationParams(List.of(EvalTestCaseParam.ACTUAL_OUTPUT))
+                .judge(capturingJudge)
+                .build();
+
+        Map<String, Object> mapOutput = new LinkedHashMap<>();
+        mapOutput.put("region", "Islay");
+
+        var testCase = EvalTestCase.builder()
+                .input("q")
+                .actualOutput("output", mapOutput)
+                .build();
+
+        evaluator.evaluate(testCase);
+
+        assertThat(capturedPrompt[0]).contains("\"region\" : \"Islay\"").doesNotContain("region=Islay");
+    }
+
+    /**
+     * A null output must never surface as an NPE from the rendering path. When the param is required
+     * the documented validation error ({@link IllegalArgumentException}) fires first; either way no
+     * {@link NullPointerException} escapes.
+     */
+    @Test
+    void shouldNotNpeWhenRequiredOutputIsNull() {
+        JudgeLM mockJudge = prompt -> "{\"score\": 0.9, \"reason\": \"ok\"}";
+
+        var evaluator = LLMJudgeEvaluator.builder()
+                .name("test")
+                .criteria("Test")
+                .evaluationParams(List.of(EvalTestCaseParam.ACTUAL_OUTPUT))
+                .judge(mockJudge)
+                .build();
+
+        // No actual output set -> raw value is null.
+        var testCase = EvalTestCase.builder().input("q").build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(IllegalArgumentException.class)
+                .isNotInstanceOf(NullPointerException.class);
+    }
+
+    /**
+     * Directly exercises the defensive rendering branch: a null raw value must render as the literal
+     * {@code "null"} (matching the historical {@code append((String) null)} behavior) rather than
+     * throwing a {@link NullPointerException}.
+     */
+    @Test
+    void shouldRenderNullOutputAsLiteralWithoutNpe() throws Exception {
+        var method = LLMJudgeEvaluator.class.getDeclaredMethod("renderOutput", Object.class);
+        method.setAccessible(true);
+
+        Object rendered = method.invoke(null, new Object[] {null});
+
+        assertThat(rendered).isEqualTo("null");
+    }
+
+    private record Whisky(String name, int age) {}
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/OutputTypeTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/OutputTypeTest.java
@@ -1,0 +1,52 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OutputTypeTest {
+
+    record Whisky(String name, int age) {}
+
+    @Test
+    void capturesSimpleClassTypeArgument() {
+        OutputType<Whisky> type = new OutputType<>() {};
+
+        assertThat(type.getType()).isEqualTo(Whisky.class);
+        assertThat(type.toString()).contains("Whisky");
+    }
+
+    @Test
+    void capturesGenericListTypeArgument() {
+        OutputType<List<Whisky>> type = new OutputType<>() {};
+
+        assertThat(type.getType()).isInstanceOf(ParameterizedType.class);
+        ParameterizedType parameterized = (ParameterizedType) type.getType();
+        assertThat(parameterized.getRawType()).isEqualTo(List.class);
+        assertThat(parameterized.getActualTypeArguments()).containsExactly(Whisky.class);
+    }
+
+    @Test
+    void rawConstructionThrowsIllegalArgumentException() {
+        assertThatThrownBy(
+                        () -> {
+                            @SuppressWarnings({"rawtypes", "unused"})
+                            OutputType raw = new OutputType() {};
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("actual type argument");
+    }
+
+    @Test
+    void equalsAndHashCodeBasedOnCapturedType() {
+        OutputType<List<Whisky>> a = new OutputType<>() {};
+        OutputType<List<Whisky>> b = new OutputType<>() {};
+        OutputType<Whisky> c = new OutputType<>() {};
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(c);
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/OutputTypeTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/OutputTypeTest.java
@@ -30,11 +30,9 @@ class OutputTypeTest {
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
     void rawConstructionThrowsIllegalArgumentException() {
-        assertThatThrownBy(() -> {
-                    @SuppressWarnings({"rawtypes", "unused"})
-                    OutputType raw = new OutputType() {};
-                })
+        assertThatThrownBy(() -> new OutputType() {})
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("actual type argument");
     }
@@ -47,5 +45,12 @@ class OutputTypeTest {
 
         assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
         assertThat(a).isNotEqualTo(c);
+    }
+
+    @Test
+    void equalsRejectsNullAndOtherTypes() {
+        OutputType<Whisky> type = new OutputType<>() {};
+
+        assertThat(type).isNotEqualTo(null).isNotEqualTo("OutputType<Whisky>");
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/OutputTypeTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/OutputTypeTest.java
@@ -31,11 +31,10 @@ class OutputTypeTest {
 
     @Test
     void rawConstructionThrowsIllegalArgumentException() {
-        assertThatThrownBy(
-                        () -> {
-                            @SuppressWarnings({"rawtypes", "unused"})
-                            OutputType raw = new OutputType() {};
-                        })
+        assertThatThrownBy(() -> {
+                    @SuppressWarnings({"rawtypes", "unused"})
+                    OutputType raw = new OutputType() {};
+                })
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("actual type argument");
     }

--- a/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
@@ -20,6 +20,9 @@ class StructuralMatchEvaluatorTest {
     }
 
     private static Map<String, Object> map(Object... kv) {
+        if ((kv.length & 1) != 0) {
+            throw new IllegalArgumentException("map() requires key/value pairs");
+        }
         Map<String, Object> m = new LinkedHashMap<>();
         for (int i = 0; i < kv.length; i += 2) {
             m.put((String) kv[i], kv[i + 1]);
@@ -377,5 +380,165 @@ class StructuralMatchEvaluatorTest {
         var testCase = testCase(map("a", List.of(1)), map("a", map("x", 1)));
 
         assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void lenientUnmatchedArrayElementGivesZeroPartialCreditForAllItsLeaves() {
+        // LENIENT scores array elements all-or-nothing: a near-miss element earns zero, not partial.
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
+
+        Object expected = List.of(map("a", 1, "b", 2, "c", 3));
+        Object actual = List.of(map("a", 1, "b", 2, "c", 999));
+        var result = evaluator.evaluate(testCase(expected, actual));
+
+        // The element's 3 leaves go to the denominator but, since it is not a full deepMatch, 0 matched.
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("no actual element matched expected");
+    }
+
+    @Test
+    void emptyObjectVsEmptyObjectScoresOne() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        // Both empty objects -> no leaves compared -> denominator 0 short-circuits to 1.0.
+        assertThat(evaluator.evaluate(testCase(map(), map())).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void strictEmptyObjectVsNonEmptyScoresZero() {
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build();
+
+        var result = evaluator.evaluate(testCase(map(), map("a", 1)));
+
+        // STRICT folds the actual's extra field into the comparison -> one unmatched leaf.
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("$.a");
+    }
+
+    @Test
+    void lenientEmptyObjectVsNonEmptyScoresOne() {
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
+
+        // LENIENT denominator is expected leaves only; expected {} has none -> denominator 0 -> 1.0.
+        assertThat(evaluator.evaluate(testCase(map(), map("a", 1))).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void emptyObjectVsEmptyArrayIsTypeMismatchLeaf() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = evaluator.evaluate(testCase(map("x", map()), map("x", List.of())));
+
+        // {} vs [] are not the same container type, so they fall to the leaf branch and mismatch.
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("$.x");
+    }
+
+    @Test
+    void scalarCrossTypeLeafMismatches() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var boolVsNumber = evaluator.evaluate(testCase(map("n", 1), map("n", true)));
+        assertThat(boolVsNumber.score()).isEqualTo(0.0);
+        assertThat(boolVsNumber.reason()).contains("$.n");
+
+        var stringVsNumber = evaluator.evaluate(testCase(map("n", 5), map("n", "5")));
+        assertThat(stringVsNumber.score()).isEqualTo(0.0);
+        assertThat(stringVsNumber.reason()).contains("$.n");
+
+        var numberVsBool = evaluator.evaluate(testCase(map("b", false), map("b", 0)));
+        assertThat(numberVsBool.score()).isEqualTo(0.0);
+        assertThat(numberVsBool.reason()).contains("$.b");
+    }
+
+    @Test
+    void strictNestedTypeMismatchCollapsesToOneLeafWithPartialScore() {
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build();
+
+        Object expected = map("ok", 1, "data", map("items", List.of(1, 2, 3)));
+        Object actual = map("ok", 1, "data", map("items", map("0", 1)));
+        var result = evaluator.evaluate(testCase(expected, actual));
+
+        // The array-vs-object mismatch at $.data.items counts as a single leaf, not its 3 children.
+        // ok matches, data.items is one mismatched leaf -> 1/2.
+        assertThat(result.score()).isEqualTo(0.5);
+        assertThat(result.reason()).contains("$.data.items");
+    }
+
+    @Test
+    void thresholdBoundaryWithPartialScore() {
+        Object expected = map("a", 1);
+        Object actual = map("a", 1, "b", 2); // STRICT union denominator 2, matched 1 -> 0.5.
+
+        var atThreshold = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .threshold(0.5)
+                .build();
+        assertThat(atThreshold.evaluate(testCase(expected, actual)).success()).isTrue();
+
+        var aboveThreshold = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .threshold(0.6)
+                .build();
+        assertThat(aboveThreshold.evaluate(testCase(expected, actual)).success())
+                .isFalse();
+    }
+
+    @Test
+    void customOutputKeyMissingActualScoresZero() {
+        var evaluator = StructuralMatchEvaluator.builder().outputKey("answer").build();
+
+        // Expected carries the custom key but actual does not -> actual normalizes to a null node.
+        var testCase =
+                EvalTestCase.builder().expectedOutput("answer", map("a", 1)).build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void customOutputKeyMissingExpectedThrows() {
+        var evaluator = StructuralMatchEvaluator.builder().outputKey("answer").build();
+
+        var testCase =
+                EvalTestCase.builder().actualOutput("answer", map("a", 1)).build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("answer");
+    }
+
+    @Test
+    void lenientNestedArrayWithinElementIsOrderInsensitive() {
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
+
+        // Both the outer element order and the inner tag order are ignored.
+        Object expected = List.of(map("tags", List.of("a", "b")), map("tags", List.of("c")));
+        Object actual = List.of(map("tags", List.of("c")), map("tags", List.of("b", "a")));
+
+        assertThat(evaluator.evaluate(testCase(expected, actual)).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void reasonContainsFullNestedPath() {
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build();
+
+        Object expected = map("user", map("items", List.of(map("qty", 2))));
+        Object actual = map("user", map("items", List.of(map("qty", 3))));
+
+        var result = evaluator.evaluate(testCase(expected, actual));
+
+        assertThat(result.reason()).contains("$.user.items[0].qty");
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
@@ -325,4 +325,39 @@ class StructuralMatchEvaluatorTest {
 
         assertThatThrownBy(() -> evaluator.evaluate(testCase)).isInstanceOf(EvaluationException.class);
     }
+
+    // ---------- regression: comparator correctness ----------
+
+    @Test
+    void lenientArrayMatchingPairsSubsetAndSpecificElementsOptimally() {
+        // Regression: greedy first-fit let the subset element {a:1} steal the {a:1,b:2} actual,
+        // starving the specific expected element. Maximum bipartite matching pairs both -> 1.0.
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        var testCase = testCase(
+                List.of(map("a", 1), map("a", 1, "b", 2)), List.of(map("a", 1, "b", 2), map("a", 1)));
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void smallDistinctNumbersDoNotCollapse() {
+        // No absolute epsilon: genuinely distinct near-zero values must not compare equal.
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        assertThat(evaluator.evaluate(testCase(0, 5e-10)).score()).isEqualTo(0.0);
+        assertThat(evaluator.evaluate(testCase(1e-10, 2e-10)).score()).isEqualTo(0.0);
+        // Scale differences still match by value.
+        assertThat(evaluator.evaluate(testCase(5, 5.0)).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void strictTypeMismatchArrayVsObjectScoresZero() {
+        var evaluator = StructuralMatchEvaluator.builder().mode(StructuralMatchMode.STRICT).build();
+
+        var testCase = testCase(map("a", List.of(1)), map("a", map("x", 1)));
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(0.0);
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
@@ -1,0 +1,328 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.dokimos.core.evaluators.EvaluationException;
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator;
+import dev.dokimos.core.evaluators.StructuralMatchMode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class StructuralMatchEvaluatorTest {
+
+    private static EvalTestCase testCase(Object expected, Object actual) {
+        return EvalTestCase.builder()
+                .expectedOutput("output", expected)
+                .actualOutput("output", actual)
+                .build();
+    }
+
+    private static Map<String, Object> map(Object... kv) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            m.put((String) kv[i], kv[i + 1]);
+        }
+        return m;
+    }
+
+    // ---------- STRICT (default) ----------
+
+    @Test
+    void strictExactMatchScoresOne() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = evaluator.evaluate(testCase(map("a", 1, "b", "x"), map("a", 1, "b", "x")));
+
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    void strictExtraFieldIsPenalized() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        // expected has 1 leaf, actual adds an extra -> union denominator 2, matched 1.
+        var result = evaluator.evaluate(testCase(map("a", 1), map("a", 1, "b", 2)));
+
+        assertThat(result.score()).isEqualTo(0.5);
+        assertThat(result.success()).isFalse();
+        assertThat(result.reason()).contains("$.b");
+    }
+
+    @Test
+    void strictReorderedArrayScoresLow() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = evaluator.evaluate(testCase(List.of(1, 2, 3), List.of(3, 2, 1)));
+
+        // positions 0 and 2 differ, position 1 matches -> 1/3.
+        assertThat(result.score()).isEqualTo(1.0 / 3.0);
+    }
+
+    @Test
+    void strictNumberFiveMatchesFivePointZero() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = evaluator.evaluate(testCase(map("n", 5), map("n", 5.0)));
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void strictDroppedFieldScoresLow() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = evaluator.evaluate(testCase(map("a", 1, "b", 2), map("a", 1)));
+
+        assertThat(result.score()).isEqualTo(0.5);
+        assertThat(result.reason()).contains("$.b");
+    }
+
+    @Test
+    void strictNestedObjectAndListOfObjects() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        Object expected = map(
+                "user", map("name", "Ada", "age", 36),
+                "items", List.of(map("id", 1, "qty", 2), map("id", 2, "qty", 5)));
+        var result = evaluator.evaluate(testCase(expected, expected));
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void strictNullDistinctFromMissing() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        Map<String, Object> expected = map("a", 1);
+        expected.put("b", null);
+        var result = evaluator.evaluate(testCase(expected, map("a", 1)));
+
+        // b: null (expected) vs missing (actual) -> distinct in STRICT.
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    // ---------- LENIENT ----------
+
+    @Test
+    void lenientIgnoresExtraField() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        var result = evaluator.evaluate(testCase(map("a", 1), map("a", 1, "b", 2)));
+
+        // denominator = expected leaves only -> extra ignored.
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    void lenientIgnoresArrayOrderAsMultiset() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        assertThat(evaluator.evaluate(testCase(List.of(1, 2, 3), List.of(3, 1, 2))).score())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    void lenientMultisetRejectsMissingDuplicate() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        // [1,1,2] vs [1,2] -> one of the two expected 1's is unmatched.
+        var result = evaluator.evaluate(testCase(List.of(1, 1, 2), List.of(1, 2)));
+
+        assertThat(result.score()).isLessThan(1.0);
+    }
+
+    @Test
+    void lenientSubsetMatchScoresOne() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        Object expected = map("name", "Ada");
+        Object actual = map("name", "Ada", "age", 36, "email", "ada@example.com");
+        assertThat(evaluator.evaluate(testCase(expected, actual)).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void lenientNullEqualsMissing() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        Map<String, Object> expected = map("a", 1);
+        expected.put("b", null);
+        var result = evaluator.evaluate(testCase(expected, map("a", 1)));
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    // ---------- numerics ----------
+
+    @Test
+    void bigDecimalScaleInsensitive() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = evaluator.evaluate(testCase(map("p", new java.math.BigDecimal("1.0")),
+                map("p", new java.math.BigDecimal("1.00"))));
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    // ---------- partial score ----------
+
+    @Test
+    void partialScoreNineOfTenStrict() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        Map<String, Object> expected = new LinkedHashMap<>();
+        Map<String, Object> actual = new LinkedHashMap<>();
+        for (int i = 0; i < 10; i++) {
+            expected.put("k" + i, i);
+            actual.put("k" + i, i == 9 ? 999 : i);
+        }
+        var result = evaluator.evaluate(testCase(expected, actual));
+
+        assertThat(result.score()).isEqualTo(0.9);
+    }
+
+    @Test
+    void partialScoreNineOfTenLenient() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        Map<String, Object> expected = new LinkedHashMap<>();
+        Map<String, Object> actual = new LinkedHashMap<>();
+        for (int i = 0; i < 10; i++) {
+            expected.put("k" + i, i);
+            actual.put("k" + i, i == 9 ? 999 : i);
+        }
+        var result = evaluator.evaluate(testCase(expected, actual));
+
+        assertThat(result.score()).isEqualTo(0.9);
+    }
+
+    // ---------- binary ----------
+
+    @Test
+    void binaryCollapsesToOneOrZero() {
+        var evaluator = StructuralMatchEvaluator.builder().binary().build();
+
+        assertThat(evaluator.evaluate(testCase(map("a", 1), map("a", 1))).score()).isEqualTo(1.0);
+        assertThat(evaluator.evaluate(testCase(map("a", 1), map("a", 2))).score()).isEqualTo(0.0);
+        // any difference collapses, even a single mismatched leaf among many.
+        assertThat(evaluator.evaluate(testCase(map("a", 1, "b", 2), map("a", 1, "b", 3))).score())
+                .isEqualTo(0.0);
+    }
+
+    // ---------- error / edge cases ----------
+
+    @Test
+    void duplicateKeysFailWithReason() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("output", "{\"x\":1}")
+                .actualOutput("output", "{\"x\":1,\"x\":2}")
+                .build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("Duplicate");
+    }
+
+    @Test
+    void nanFailsWithReason() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = testCase(map("n", Double.NaN), map("n", 1.0));
+        assertThatThrownBy(() -> evaluator.evaluate(result))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("non-finite");
+    }
+
+    @Test
+    void infinityFailsWithReason() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var result = testCase(map("n", 1.0), map("n", Double.POSITIVE_INFINITY));
+        assertThatThrownBy(() -> evaluator.evaluate(result))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("non-finite");
+    }
+
+    @Test
+    void nullExpectedThrows() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder().actualOutput("output", map("a", 1)).build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("expectedOutputs");
+    }
+
+    @Test
+    void absentActualScoresZero() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder().expectedOutput("output", map("a", 1, "b", 2)).build();
+
+        // actual normalizes to a null node; both expected leaves mismatch.
+        var result = evaluator.evaluate(testCase);
+        assertThat(result.score()).isEqualTo(0.0);
+    }
+
+    @Test
+    void customOutputKey() {
+        var evaluator = StructuralMatchEvaluator.builder().outputKey("answer").build();
+
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("answer", map("a", 1))
+                .actualOutput("answer", map("a", 1))
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void stringOperandParsedAsJson() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        // expected is a Map, actual is a JSON string -> compare object vs object.
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("output", map("a", 1, "b", List.of(1, 2)))
+                .actualOutput("output", "{\"a\":1,\"b\":[1,2]}")
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void bothStringOperandsParsedAsJson() {
+        var evaluator =
+                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("output", "{\"a\":1}")
+                .actualOutput("output", "{\"a\":1.0,\"extra\":true}")
+                .build();
+
+        assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void invalidJsonStringFails() {
+        var evaluator = StructuralMatchEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("output", map("a", 1))
+                .actualOutput("output", "{not valid json")
+                .build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase)).isInstanceOf(EvaluationException.class);
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/StructuralMatchEvaluatorTest.java
@@ -108,8 +108,9 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void lenientIgnoresExtraField() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
         var result = evaluator.evaluate(testCase(map("a", 1), map("a", 1, "b", 2)));
 
@@ -120,17 +121,21 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void lenientIgnoresArrayOrderAsMultiset() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
-        assertThat(evaluator.evaluate(testCase(List.of(1, 2, 3), List.of(3, 1, 2))).score())
+        assertThat(evaluator
+                        .evaluate(testCase(List.of(1, 2, 3), List.of(3, 1, 2)))
+                        .score())
                 .isEqualTo(1.0);
     }
 
     @Test
     void lenientMultisetRejectsMissingDuplicate() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
         // [1,1,2] vs [1,2] -> one of the two expected 1's is unmatched.
         var result = evaluator.evaluate(testCase(List.of(1, 1, 2), List.of(1, 2)));
@@ -140,8 +145,9 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void lenientSubsetMatchScoresOne() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
         Object expected = map("name", "Ada");
         Object actual = map("name", "Ada", "age", 36, "email", "ada@example.com");
@@ -150,8 +156,9 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void lenientNullEqualsMissing() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
         Map<String, Object> expected = map("a", 1);
         expected.put("b", null);
@@ -166,8 +173,8 @@ class StructuralMatchEvaluatorTest {
     void bigDecimalScaleInsensitive() {
         var evaluator = StructuralMatchEvaluator.builder().build();
 
-        var result = evaluator.evaluate(testCase(map("p", new java.math.BigDecimal("1.0")),
-                map("p", new java.math.BigDecimal("1.00"))));
+        var result = evaluator.evaluate(
+                testCase(map("p", new java.math.BigDecimal("1.0")), map("p", new java.math.BigDecimal("1.00"))));
 
         assertThat(result.score()).isEqualTo(1.0);
     }
@@ -191,8 +198,9 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void partialScoreNineOfTenLenient() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
         Map<String, Object> expected = new LinkedHashMap<>();
         Map<String, Object> actual = new LinkedHashMap<>();
@@ -211,10 +219,14 @@ class StructuralMatchEvaluatorTest {
     void binaryCollapsesToOneOrZero() {
         var evaluator = StructuralMatchEvaluator.builder().binary().build();
 
-        assertThat(evaluator.evaluate(testCase(map("a", 1), map("a", 1))).score()).isEqualTo(1.0);
-        assertThat(evaluator.evaluate(testCase(map("a", 1), map("a", 2))).score()).isEqualTo(0.0);
+        assertThat(evaluator.evaluate(testCase(map("a", 1), map("a", 1))).score())
+                .isEqualTo(1.0);
+        assertThat(evaluator.evaluate(testCase(map("a", 1), map("a", 2))).score())
+                .isEqualTo(0.0);
         // any difference collapses, even a single mismatched leaf among many.
-        assertThat(evaluator.evaluate(testCase(map("a", 1, "b", 2), map("a", 1, "b", 3))).score())
+        assertThat(evaluator
+                        .evaluate(testCase(map("a", 1, "b", 2), map("a", 1, "b", 3)))
+                        .score())
                 .isEqualTo(0.0);
     }
 
@@ -258,7 +270,8 @@ class StructuralMatchEvaluatorTest {
     void nullExpectedThrows() {
         var evaluator = StructuralMatchEvaluator.builder().build();
 
-        var testCase = EvalTestCase.builder().actualOutput("output", map("a", 1)).build();
+        var testCase =
+                EvalTestCase.builder().actualOutput("output", map("a", 1)).build();
 
         assertThatThrownBy(() -> evaluator.evaluate(testCase))
                 .isInstanceOf(EvaluationException.class)
@@ -269,7 +282,9 @@ class StructuralMatchEvaluatorTest {
     void absentActualScoresZero() {
         var evaluator = StructuralMatchEvaluator.builder().build();
 
-        var testCase = EvalTestCase.builder().expectedOutput("output", map("a", 1, "b", 2)).build();
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("output", map("a", 1, "b", 2))
+                .build();
 
         // actual normalizes to a null node; both expected leaves mismatch.
         var result = evaluator.evaluate(testCase);
@@ -303,8 +318,9 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void bothStringOperandsParsedAsJson() {
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
         var testCase = EvalTestCase.builder()
                 .expectedOutput("output", "{\"a\":1}")
@@ -332,11 +348,11 @@ class StructuralMatchEvaluatorTest {
     void lenientArrayMatchingPairsSubsetAndSpecificElementsOptimally() {
         // Regression: greedy first-fit let the subset element {a:1} steal the {a:1,b:2} actual,
         // starving the specific expected element. Maximum bipartite matching pairs both -> 1.0.
-        var evaluator =
-                StructuralMatchEvaluator.builder().mode(StructuralMatchMode.LENIENT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
 
-        var testCase = testCase(
-                List.of(map("a", 1), map("a", 1, "b", 2)), List.of(map("a", 1, "b", 2), map("a", 1)));
+        var testCase = testCase(List.of(map("a", 1), map("a", 1, "b", 2)), List.of(map("a", 1, "b", 2), map("a", 1)));
 
         assertThat(evaluator.evaluate(testCase).score()).isEqualTo(1.0);
     }
@@ -354,7 +370,9 @@ class StructuralMatchEvaluatorTest {
 
     @Test
     void strictTypeMismatchArrayVsObjectScoresZero() {
-        var evaluator = StructuralMatchEvaluator.builder().mode(StructuralMatchMode.STRICT).build();
+        var evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build();
 
         var testCase = testCase(map("a", List.of(1)), map("a", map("x", 1)));
 

--- a/dokimos-core/src/test/java/dev/dokimos/core/TaskTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TaskTest.java
@@ -1,0 +1,53 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TaskTest {
+
+    private static Example exampleWithInput(String key, Object value) {
+        return new Example(Map.of(key, value), Map.of(), Map.of());
+    }
+
+    @Test
+    void typedShouldWrapValueUnderOutputKey() {
+        record Whisky(String name, int age) {}
+
+        Task task = Task.typed(ex -> new Whisky("Lagavulin", 16));
+
+        Map<String, Object> outputs = task.run(exampleWithInput("query", "islay"));
+
+        assertThat(outputs).containsOnlyKeys("output");
+        assertThat(outputs.get("output")).isEqualTo(new Whisky("Lagavulin", 16));
+    }
+
+    @Test
+    void typedShouldNotDoubleNestWhenFunctionReturnsMap() {
+        Task task = Task.typed(ex -> Map.of("answer", "42", "confidence", 0.9));
+
+        Map<String, Object> outputs = task.run(exampleWithInput("query", "meaning"));
+
+        assertThat(outputs).containsOnlyKeys("answer", "confidence");
+        assertThat(outputs).containsEntry("answer", "42").containsEntry("confidence", 0.9);
+        assertThat(outputs).doesNotContainKey("output");
+    }
+
+    @Test
+    void typedShouldExposeFunctionInputToTheBody() {
+        Task task = Task.typed(ex -> ex.inputs().get("query") + "!");
+
+        Map<String, Object> outputs = task.run(exampleWithInput("query", "hello"));
+
+        assertThat(outputs).containsEntry("output", "hello!");
+    }
+
+    @Test
+    void typedGenericCallShouldCompileWithExplicitTypeWitness() {
+        // Compile-time check that the generic factory infers and accepts a typed function.
+        Task task = Task.<String>typed(ex -> "value");
+
+        assertThat(task.run(exampleWithInput("k", "v"))).containsEntry("output", "value");
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/TaskTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TaskTest.java
@@ -50,4 +50,13 @@ class TaskTest {
 
         assertThat(task.run(exampleWithInput("k", "v"))).containsEntry("output", "value");
     }
+
+    @Test
+    void typedShouldRejectNullReturnWithClearMessage() {
+        Task task = Task.typed(ex -> null);
+
+        assertThatThrownBy(() -> task.run(exampleWithInput("k", "v")))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("returned null");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
@@ -175,4 +175,70 @@ class TypedOutputAccessorTest {
         assertThatThrownBy(() -> example.expectedOutputAs(Whisky.class))
                 .isInstanceOf(DokimosTypeConversionException.class);
     }
+
+    @Test
+    void inputAsReadsTypedRecordPrimaryAndKeyed() {
+        var testCase = EvalTestCase.builder()
+                .input("input", Map.of("name", "Lagavulin", "age", 16))
+                .input("alt", Map.of("name", "Oban", "age", 14))
+                .build();
+
+        assertThat(testCase.inputAs(Whisky.class)).isEqualTo(new Whisky("Lagavulin", 16));
+        assertThat(testCase.inputAs("alt", Whisky.class)).isEqualTo(new Whisky("Oban", 14));
+    }
+
+    @Test
+    void inputAsReadsNestedGenericViaOutputType() {
+        var testCase = EvalTestCase.builder()
+                .input("input", List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14)))
+                .build();
+
+        List<Whisky> whiskies = testCase.inputAs(new OutputType<List<Whisky>>() {});
+
+        assertThat(whiskies).containsExactly(new Whisky("Ardbeg", 10), new Whisky("Oban", 14));
+        assertThat(testCase.inputAs("input", new OutputType<List<Whisky>>() {})).isEqualTo(whiskies);
+    }
+
+    @Test
+    void inputAsAbsentReturnsNullAndBadTypeThrows() {
+        var testCase = EvalTestCase.builder().input("input", "not a whisky").build();
+
+        assertThat(testCase.inputAs("missing", Whisky.class)).isNull();
+        assertThat(testCase.inputAs("missing", new OutputType<List<Whisky>>() {}))
+                .isNull();
+        assertThatThrownBy(() -> testCase.inputAs(Whisky.class)).isInstanceOf(DokimosTypeConversionException.class);
+    }
+
+    @Test
+    void metadataAsReadsTypedValueAbsentNullAndBadTypeThrows() {
+        var testCase = EvalTestCase.builder()
+                .metadata("dram", Map.of("name", "Talisker", "age", 18))
+                .metadata("tags", List.of("smoky", "coastal"))
+                .metadata("bad", "not a whisky")
+                .build();
+
+        assertThat(testCase.metadataAs("dram", Whisky.class)).isEqualTo(new Whisky("Talisker", 18));
+        assertThat(testCase.metadataAs("tags", new OutputType<List<String>>() {}))
+                .containsExactly("smoky", "coastal");
+        assertThat(testCase.metadataAs("missing", Whisky.class)).isNull();
+        assertThatThrownBy(() -> testCase.metadataAs("bad", Whisky.class))
+                .isInstanceOf(DokimosTypeConversionException.class);
+    }
+
+    @Test
+    void exampleInputAndMetadataParityWithTestCase() {
+        var example = Example.builder()
+                .input("input", Map.of("name", "Lagavulin", "age", 16))
+                .input("alt", Map.of("name", "Oban", "age", 14))
+                .metadata("dram", Map.of("name", "Talisker", "age", 18))
+                .build();
+
+        assertThat(example.inputAs(Whisky.class)).isEqualTo(new Whisky("Lagavulin", 16));
+        assertThat(example.inputAs("alt", new OutputType<Whisky>() {})).isEqualTo(new Whisky("Oban", 14));
+        assertThat(example.metadataAs("dram", Whisky.class)).isEqualTo(new Whisky("Talisker", 18));
+        assertThat(example.metadataAs("missing", Whisky.class)).isNull();
+        assertThatThrownBy(() ->
+                        Example.builder().input("input", "not a whisky").build().inputAs(Whisky.class))
+                .isInstanceOf(DokimosTypeConversionException.class);
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
@@ -1,0 +1,123 @@
+package dev.dokimos.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TypedOutputAccessorTest {
+
+    record Whisky(String name, int age) {}
+
+    @Test
+    void readsRecordViaClass() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("output", Map.of("name", "Lagavulin", "age", 16))
+                .build();
+
+        Whisky whisky = testCase.actualOutputAs(Whisky.class);
+
+        assertThat(whisky).isEqualTo(new Whisky("Lagavulin", 16));
+    }
+
+    @Test
+    void readsGenericListViaOutputType() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput(
+                        "output",
+                        List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14)))
+                .build();
+
+        List<Whisky> whiskies = testCase.actualOutputAs(new OutputType<List<Whisky>>() {});
+
+        assertThat(whiskies).containsExactly(new Whisky("Ardbeg", 10), new Whisky("Oban", 14));
+    }
+
+    @Test
+    void readsKeyedOutput() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("dram", Map.of("name", "Talisker", "age", 18))
+                .expectedOutput("dram", Map.of("name", "Talisker", "age", 18))
+                .build();
+
+        assertThat(testCase.actualOutputAs("dram", Whisky.class)).isEqualTo(new Whisky("Talisker", 18));
+        assertThat(testCase.expectedOutputAs("dram", Whisky.class)).isEqualTo(new Whisky("Talisker", 18));
+        assertThat(testCase.expectedOutputAs("dram", new OutputType<Whisky>() {}))
+                .isEqualTo(new Whisky("Talisker", 18));
+    }
+
+    @Test
+    void absentKeyReturnsNull() {
+        var testCase = EvalTestCase.builder().actualOutput("output", "x").build();
+
+        assertThat(testCase.actualOutputAs("missing", Whisky.class)).isNull();
+        assertThat(testCase.actualOutputAs("missing", new OutputType<List<Whisky>>() {}))
+                .isNull();
+        assertThat(testCase.expectedOutputAs("missing", Whisky.class)).isNull();
+        assertThat(testCase.expectedOutputAs(Whisky.class)).isNull();
+    }
+
+    @Test
+    void unconvertibleValueThrowsTypeConversionException() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("output", "not a whisky object")
+                .build();
+
+        assertThatThrownBy(() -> testCase.actualOutputAs(Whisky.class))
+                .isInstanceOf(DokimosTypeConversionException.class)
+                .hasMessageContaining(Whisky.class.getName())
+                .hasCauseInstanceOf(Throwable.class);
+    }
+
+    @Test
+    void unconvertibleValueThrowsForOutputType() {
+        var testCase = EvalTestCase.builder()
+                .actualOutput("output", "not a list")
+                .build();
+
+        assertThatThrownBy(() -> testCase.actualOutputAs(new OutputType<List<Whisky>>() {}))
+                .isInstanceOf(DokimosTypeConversionException.class);
+    }
+
+    @Test
+    void stringReadAsStringPassesThroughWithoutDoubleEncoding() {
+        var testCase = EvalTestCase.builder().actualOutput("output", "Bern").build();
+
+        assertThat(testCase.actualOutputAs(String.class)).isEqualTo("Bern");
+        assertThat(testCase.actualOutputAs("output", String.class)).isEqualTo("Bern");
+    }
+
+    @Test
+    void exampleExpectedAccessorsReadStructuredValues() {
+        var example = Example.builder()
+                .input("question", "best islay")
+                .expectedOutput("output", Map.of("name", "Laphroaig", "age", 10))
+                .expectedOutput("alt", List.of(Map.of("name", "Bowmore", "age", 12)))
+                .build();
+
+        assertThat(example.expectedOutputAs(Whisky.class)).isEqualTo(new Whisky("Laphroaig", 10));
+        assertThat(example.expectedOutputAs("alt", new OutputType<List<Whisky>>() {}))
+                .containsExactly(new Whisky("Bowmore", 12));
+        assertThat(example.expectedOutputAs("missing", Whisky.class)).isNull();
+    }
+
+    @Test
+    void exampleExpectedStringPassesThrough() {
+        var example = Example.of("q", "Bern");
+
+        assertThat(example.expectedOutputAs(String.class)).isEqualTo("Bern");
+    }
+
+    @Test
+    void exampleUnconvertibleValueThrows() {
+        var example = Example.builder()
+                .expectedOutput("output", "not a whisky")
+                .build();
+
+        assertThatThrownBy(() -> example.expectedOutputAs(Whisky.class))
+                .isInstanceOf(DokimosTypeConversionException.class);
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
@@ -26,9 +26,7 @@ class TypedOutputAccessorTest {
     @Test
     void readsGenericListViaOutputType() {
         var testCase = EvalTestCase.builder()
-                .actualOutput(
-                        "output",
-                        List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14)))
+                .actualOutput("output", List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14)))
                 .build();
 
         List<Whisky> whiskies = testCase.actualOutputAs(new OutputType<List<Whisky>>() {});
@@ -74,9 +72,8 @@ class TypedOutputAccessorTest {
 
     @Test
     void unconvertibleValueThrowsForOutputType() {
-        var testCase = EvalTestCase.builder()
-                .actualOutput("output", "not a list")
-                .build();
+        var testCase =
+                EvalTestCase.builder().actualOutput("output", "not a list").build();
 
         assertThatThrownBy(() -> testCase.actualOutputAs(new OutputType<List<Whisky>>() {}))
                 .isInstanceOf(DokimosTypeConversionException.class);
@@ -113,9 +110,7 @@ class TypedOutputAccessorTest {
 
     @Test
     void exampleUnconvertibleValueThrows() {
-        var example = Example.builder()
-                .expectedOutput("output", "not a whisky")
-                .build();
+        var example = Example.builder().expectedOutput("output", "not a whisky").build();
 
         assertThatThrownBy(() -> example.expectedOutputAs(Whisky.class))
                 .isInstanceOf(DokimosTypeConversionException.class);

--- a/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/TypedOutputAccessorTest.java
@@ -35,6 +35,66 @@ class TypedOutputAccessorTest {
     }
 
     @Test
+    void nestedGenericsConvertInnerElements() {
+        var mapTestCase = EvalTestCase.builder()
+                .actualOutput("output", Map.of("islay", List.of(Map.of("name", "Ardbeg", "age", 10))))
+                .build();
+
+        Map<String, List<Whisky>> byRegion = mapTestCase.actualOutputAs(new OutputType<Map<String, List<Whisky>>>() {});
+
+        assertThat(byRegion.get("islay")).containsExactly(new Whisky("Ardbeg", 10));
+        assertThat(byRegion.get("islay").get(0)).isInstanceOf(Whisky.class);
+
+        var listTestCase = EvalTestCase.builder()
+                .actualOutput("output", List.of(List.of(Map.of("name", "Oban", "age", 14))))
+                .build();
+
+        List<List<Whisky>> nested = listTestCase.actualOutputAs(new OutputType<List<List<Whisky>>>() {});
+
+        assertThat(nested.get(0)).containsExactly(new Whisky("Oban", 14));
+        assertThat(nested.get(0).get(0)).isInstanceOf(Whisky.class);
+    }
+
+    @Test
+    void stringReadViaOutputTypePassesThrough() {
+        var testCase = EvalTestCase.builder().actualOutput("output", "Bern").build();
+
+        assertThat(testCase.actualOutputAs(new OutputType<String>() {})).isEqualTo("Bern");
+        assertThat(testCase.actualOutputAs("output", new OutputType<String>() {}))
+                .isEqualTo("Bern");
+    }
+
+    @Test
+    void outputTypeConversionFailureCarriesMessageAndCause() {
+        var testCase =
+                EvalTestCase.builder().actualOutput("output", "not a list").build();
+
+        assertThatThrownBy(() -> testCase.actualOutputAs(new OutputType<List<Whisky>>() {}))
+                .isInstanceOf(DokimosTypeConversionException.class)
+                .hasMessageContaining("OutputType")
+                .hasMessageContaining("Whisky")
+                .hasCauseInstanceOf(Throwable.class);
+    }
+
+    @Test
+    void primaryExpectedOutputTypeOverloadReadsOutputKey() {
+        var example = Example.builder()
+                .input("question", "best oban")
+                .expectedOutput("output", List.of(Map.of("name", "Oban", "age", 14)))
+                .build();
+        var testCase = EvalTestCase.builder()
+                .expectedOutput("output", List.of(Map.of("name", "Oban", "age", 14)))
+                .build();
+
+        List<Whisky> fromExample = example.expectedOutputAs(new OutputType<List<Whisky>>() {});
+        List<Whisky> fromTestCase = testCase.expectedOutputAs(new OutputType<List<Whisky>>() {});
+
+        assertThat(fromExample).containsExactly(new Whisky("Oban", 14));
+        assertThat(fromTestCase).containsExactly(new Whisky("Oban", 14));
+        assertThat(fromExample).isEqualTo(fromTestCase);
+    }
+
+    @Test
     void readsKeyedOutput() {
         var testCase = EvalTestCase.builder()
                 .actualOutput("dram", Map.of("name", "Talisker", "age", 18))

--- a/dokimos-core/src/test/java/dev/dokimos/core/agents/AgentTraceTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/agents/AgentTraceTest.java
@@ -2,6 +2,8 @@ package dev.dokimos.core.agents;
 
 import static org.assertj.core.api.Assertions.*;
 
+import dev.dokimos.core.OutputType;
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -94,5 +96,39 @@ class AgentTraceTest {
         var map = trace.toOutputMap();
 
         assertThat(map.get("output")).isEqualTo("");
+    }
+
+    @Test
+    void metadataAsReadsATypedValue() {
+        var trace = AgentTrace.builder().metadata("totalLatencyMs", 500).build();
+
+        assertThat(trace.metadataAs("totalLatencyMs", Integer.class)).isEqualTo(500);
+    }
+
+    @Test
+    void metadataAsReadsAGenericListViaOutputType() {
+        var trace = AgentTrace.builder()
+                .metadata("models", List.of("gpt-4o", "gpt-4o-mini"))
+                .build();
+
+        List<String> models = trace.metadataAs("models", new OutputType<List<String>>() {});
+
+        assertThat(models).containsExactly("gpt-4o", "gpt-4o-mini");
+    }
+
+    @Test
+    void metadataAsReturnsNullForAbsentKey() {
+        var trace = AgentTrace.builder().build();
+
+        assertThat(trace.metadataAs("missing", Integer.class)).isNull();
+    }
+
+    @Test
+    void metadataAsThrowsForWrongType() {
+        var trace =
+                AgentTrace.builder().metadata("totalLatencyMs", "not-a-number").build();
+
+        assertThatThrownBy(() -> trace.metadataAs("totalLatencyMs", Integer.class))
+                .isInstanceOf(DokimosTypeConversionException.class);
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
@@ -244,6 +244,18 @@ class ToolCallTest {
         assertThat(call.resultAs(Booking.class)).isEqualTo(new Booking("ABC123", 3));
     }
 
+    @Test
+    void resultAsStringThrowsAfterFromMapWhenResultWasPlainText() {
+        // fromMap keeps a plain String result verbatim (it is not re-serialized), so a tool whose
+        // result is plain prose cannot be read back as a String: resultAs parses via Json.read, which
+        // rejects "Found 5 flights" as invalid JSON. Pin this so the verbatim-String storage contract
+        // and the JSON-string read contract cannot drift apart silently in either direction.
+        var call = ToolCall.fromMap(Map.<String, Object>of("name", "search_flights", "result", "Found 5 flights"));
+
+        assertThat(call.result()).isEqualTo("Found 5 flights");
+        assertThatThrownBy(() -> call.resultAs(String.class)).isInstanceOf(DokimosTypeConversionException.class);
+    }
+
     record Coordinates(double lat, double lon) {}
 
     @Test

--- a/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
@@ -121,8 +121,10 @@ class ToolCallTest {
     void shouldSerializeResultJsonForRecordValue() {
         record Booking(String confirmation, int nights) {}
 
-        var call =
-                ToolCall.builder().name("book_hotel").resultJson(new Booking("ABC123", 3)).build();
+        var call = ToolCall.builder()
+                .name("book_hotel")
+                .resultJson(new Booking("ABC123", 3))
+                .build();
 
         assertThat(call.result()).isEqualTo("{\"confirmation\":\"ABC123\",\"nights\":3}");
     }

--- a/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
@@ -2,7 +2,10 @@ package dev.dokimos.core.agents;
 
 import static org.assertj.core.api.Assertions.*;
 
+import dev.dokimos.core.OutputType;
+import dev.dokimos.core.exceptions.DokimosTypeConversionException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -155,5 +158,89 @@ class ToolCallTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> filter = (Map<String, Object>) call.arguments().get("filter");
         assertThat(filter).containsKey("price");
+    }
+
+    record Booking(String confirmation, int nights) {}
+
+    @Test
+    void resultAsReadsBackWhatResultJsonWrote() {
+        var booking = new Booking("ABC123", 3);
+        var call = ToolCall.builder().name("book_hotel").resultJson(booking).build();
+
+        assertThat(call.resultAs(Booking.class)).isEqualTo(booking);
+    }
+
+    @Test
+    void resultAsReadsAGenericListViaOutputType() {
+        var call = ToolCall.builder()
+                .name("list_bookings")
+                .resultJson(List.of(new Booking("A", 1), new Booking("B", 2)))
+                .build();
+
+        List<Booking> bookings = call.resultAs(new OutputType<List<Booking>>() {});
+
+        assertThat(bookings).containsExactly(new Booking("A", 1), new Booking("B", 2));
+    }
+
+    @Test
+    void resultAsReturnsNullForNullResult() {
+        var call = ToolCall.of("get_weather", Map.of());
+
+        assertThat(call.result()).isNull();
+        assertThat(call.resultAs(Booking.class)).isNull();
+    }
+
+    @Test
+    void resultAsReturnsNullForBlankResult() {
+        var call = ToolCall.builder().name("get_weather").result("   ").build();
+
+        assertThat(call.resultAs(Booking.class)).isNull();
+    }
+
+    @Test
+    void resultAsThrowsForNonJsonResult() {
+        var call = ToolCall.builder().name("get_weather").result("not json").build();
+
+        assertThatThrownBy(() -> call.resultAs(Booking.class)).isInstanceOf(DokimosTypeConversionException.class);
+    }
+
+    @Test
+    void resultAsParsesAValidJsonStringResult() {
+        var call = ToolCall.builder()
+                .name("book_hotel")
+                .result("{\"confirmation\":\"ABC123\",\"nights\":3}")
+                .build();
+
+        assertThat(call.resultAs(Booking.class)).isEqualTo(new Booking("ABC123", 3));
+    }
+
+    record NestedResult(Booking booking, List<String> tags) {}
+
+    @Test
+    void resultAsRoundTripsNestedObjects() {
+        var nested = new NestedResult(new Booking("XYZ789", 5), List.of("vip", "refundable"));
+        var call = ToolCall.builder().name("book_hotel").resultJson(nested).build();
+
+        assertThat(call.resultAs(NestedResult.class)).isEqualTo(nested);
+    }
+
+    @Test
+    void resultAsWorksAfterFromMapWhenResultIsJsonString() {
+        var map = Map.<String, Object>of("name", "book_hotel", "result", "{\"confirmation\":\"ABC123\",\"nights\":3}");
+
+        var call = ToolCall.fromMap(map);
+
+        assertThat(call.resultAs(Booking.class)).isEqualTo(new Booking("ABC123", 3));
+    }
+
+    @Test
+    void resultAsFailsAfterFromMapWhenResultWasStructuredObject() {
+        // fromMap stores rawResult.toString(): a Map becomes Java-map syntax ({a=1}), not JSON.
+        var map = Map.<String, Object>of("name", "book_hotel", "result", Map.of("confirmation", "ABC123", "nights", 3));
+
+        var call = ToolCall.fromMap(map);
+
+        assertThat(call.result()).doesNotStartWith("{\"");
+        assertThatThrownBy(() -> call.resultAs(Booking.class)).isInstanceOf(DokimosTypeConversionException.class);
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
@@ -234,13 +234,82 @@ class ToolCallTest {
     }
 
     @Test
-    void resultAsFailsAfterFromMapWhenResultWasStructuredObject() {
-        // fromMap stores rawResult.toString(): a Map becomes Java-map syntax ({a=1}), not JSON.
+    void resultAsRoundTripsAfterFromMapWhenResultWasStructuredObject() {
+        // fromMap now serializes a structured result to compact JSON, so it round-trips back.
         var map = Map.<String, Object>of("name", "book_hotel", "result", Map.of("confirmation", "ABC123", "nights", 3));
 
         var call = ToolCall.fromMap(map);
 
-        assertThat(call.result()).doesNotStartWith("{\"");
-        assertThatThrownBy(() -> call.resultAs(Booking.class)).isInstanceOf(DokimosTypeConversionException.class);
+        assertThat(call.result()).startsWith("{\"");
+        assertThat(call.resultAs(Booking.class)).isEqualTo(new Booking("ABC123", 3));
+    }
+
+    record Coordinates(double lat, double lon) {}
+
+    @Test
+    void argumentsAsRoundTripsARecord() {
+        var call = ToolCall.of("locate", Map.of("lat", 48.85, "lon", 2.35));
+
+        assertThat(call.argumentsAs(Coordinates.class)).isEqualTo(new Coordinates(48.85, 2.35));
+    }
+
+    @Test
+    void argumentsAsReadsAGenericListViaOutputType() {
+        var call = ToolCall.of("search", Map.of("tags", List.of("vip", "refundable")));
+
+        Map<String, List<String>> args = call.argumentsAs(new OutputType<Map<String, List<String>>>() {});
+
+        assertThat(args).containsEntry("tags", List.of("vip", "refundable"));
+    }
+
+    @Test
+    void argumentsAsThrowsForIncompatibleShape() {
+        var call = ToolCall.of("locate", Map.of("lat", "not-a-number", "lon", 2.35));
+
+        assertThatThrownBy(() -> call.argumentsAs(Coordinates.class))
+                .isInstanceOf(DokimosTypeConversionException.class);
+    }
+
+    @Test
+    void metadataAsReadsATypedValue() {
+        var call = ToolCall.builder()
+                .name("search")
+                .argument("q", "test")
+                .metadata("latencyMs", 150)
+                .build();
+
+        assertThat(call.metadataAs("latencyMs", Integer.class)).isEqualTo(150);
+    }
+
+    @Test
+    void metadataAsReadsAGenericListViaOutputType() {
+        var call = ToolCall.builder()
+                .name("search")
+                .argument("q", "test")
+                .metadata("tags", List.of("a", "b"))
+                .build();
+
+        List<String> tags = call.metadataAs("tags", new OutputType<List<String>>() {});
+
+        assertThat(tags).containsExactly("a", "b");
+    }
+
+    @Test
+    void metadataAsReturnsNullForAbsentKey() {
+        var call = ToolCall.of("search", Map.of("q", "test"));
+
+        assertThat(call.metadataAs("missing", Integer.class)).isNull();
+    }
+
+    @Test
+    void metadataAsThrowsForWrongType() {
+        var call = ToolCall.builder()
+                .name("search")
+                .argument("q", "test")
+                .metadata("latencyMs", "not-a-number")
+                .build();
+
+        assertThatThrownBy(() -> call.metadataAs("latencyMs", Integer.class))
+                .isInstanceOf(DokimosTypeConversionException.class);
     }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/agents/ToolCallTest.java
@@ -108,6 +108,42 @@ class ToolCallTest {
     }
 
     @Test
+    void shouldSerializeResultJsonToCompactJson() {
+        var call = ToolCall.builder()
+                .name("book_hotel")
+                .resultJson(Map.of("confirmation", "ABC123"))
+                .build();
+
+        assertThat(call.result()).isEqualTo("{\"confirmation\":\"ABC123\"}");
+    }
+
+    @Test
+    void shouldSerializeResultJsonForRecordValue() {
+        record Booking(String confirmation, int nights) {}
+
+        var call =
+                ToolCall.builder().name("book_hotel").resultJson(new Booking("ABC123", 3)).build();
+
+        assertThat(call.result()).isEqualTo("{\"confirmation\":\"ABC123\",\"nights\":3}");
+    }
+
+    @Test
+    void shouldKeepResultStringVerbatim() {
+        var raw = "{\"confirmation\": \"ABC123\"}";
+
+        var call = ToolCall.builder().name("book_hotel").result(raw).build();
+
+        assertThat(call.result()).isEqualTo(raw);
+    }
+
+    @Test
+    void shouldSerializeNullResultJsonToJsonNullLiteral() {
+        var call = ToolCall.builder().name("book_hotel").resultJson(null).build();
+
+        assertThat(call.result()).isEqualTo("null");
+    }
+
+    @Test
     void shouldHandleNestedArguments() {
         var call = ToolCall.of(
                 "search",

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolErrorEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/ToolErrorEvaluatorTest.java
@@ -157,6 +157,26 @@ class ToolErrorEvaluatorTest {
     }
 
     @Test
+    @DisplayName("a structured map result with a top-level error field is detected through the fromMap path")
+    void mapInputWithStructuredErrorResult() {
+        // A dataset-sourced tool call whose result is a structured Map (not a String) flows through
+        // AgentEvalCasts -> ToolCall.fromMap, which serializes the Map to compact JSON ({"error":"boom"}).
+        // errorReason then parses that valid JSON and flags the top-level "error" field. This is exactly
+        // the regression surface: fromMap previously rendered the Map as a non-JSON toString() that
+        // readTree could not parse, silently scoring the call as a success. Pin the structured-result
+        // detection so that flip stays intentional.
+        var testCase = EvalTestCase.builder()
+                .actualOutput(
+                        "toolCalls",
+                        List.of(
+                                Map.of("name", "a", "result", Map.of("error", "boom")),
+                                Map.of("name", "b", "result", "ok")))
+                .build();
+        var result = ToolErrorEvaluator.builder().build().evaluate(testCase);
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
     @DisplayName("missing toolCalls throws EvaluationException")
     void missingKey() {
         var testCase = EvalTestCase.builder().actualOutput("output", "x").build();

--- a/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
@@ -43,8 +43,7 @@ class JsonTest {
 
     @Test
     void convertRoundTripsAGenericList() throws Exception {
-        List<Map<String, Object>> raw =
-                List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14));
+        List<Map<String, Object>> raw = List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14));
         java.lang.reflect.Type listOfWhisky =
                 JsonTest.class.getDeclaredField("listOfWhiskyField").getGenericType();
         JavaType listType = Json.resolveType(listOfWhisky);
@@ -90,19 +89,17 @@ class JsonTest {
 
     @Test
     void mapperIsThreadSafeUnderParallelUse() {
-        List<Whisky> results =
-                IntStream.range(0, 2000)
-                        .parallel()
-                        .mapToObj(
-                                i -> {
-                                    String json = Json.writeCompact(new Whisky("W" + i, i));
-                                    try {
-                                        return Json.reader().readValue(json, Whisky.class);
-                                    } catch (Exception e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                })
-                        .toList();
+        List<Whisky> results = IntStream.range(0, 2000)
+                .parallel()
+                .mapToObj(i -> {
+                    String json = Json.writeCompact(new Whisky("W" + i, i));
+                    try {
+                        return Json.reader().readValue(json, Whisky.class);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toList();
 
         assertThat(results).hasSize(2000);
         assertThat(results).contains(new Whisky("W7", 7), new Whisky("W1999", 1999));

--- a/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
@@ -1,0 +1,110 @@
+package dev.dokimos.core.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class JsonTest {
+
+    record Whisky(String name, int age) {}
+
+    @Test
+    void readerAndWritersAreStableSingleInstances() {
+        ObjectReader reader = Json.reader();
+        ObjectWriter compact = Json.compactWriter();
+        ObjectWriter pretty = Json.prettyWriter();
+
+        assertThat(Json.reader()).isSameAs(reader);
+        assertThat(Json.compactWriter()).isSameAs(compact);
+        assertThat(Json.prettyWriter()).isSameAs(pretty);
+        assertThat(Json.comparisonReader()).isSameAs(Json.comparisonReader());
+    }
+
+    @Test
+    void convertRoundTripsARecord() {
+        Map<String, Object> map = Map.of("name", "Lagavulin", "age", 16);
+
+        Whisky whisky = Json.convert(map, Whisky.class);
+
+        assertThat(whisky).isEqualTo(new Whisky("Lagavulin", 16));
+    }
+
+    // Field used purely to capture the generic type List<Whisky> reflectively for the test.
+    @SuppressWarnings("unused")
+    private List<Whisky> listOfWhiskyField;
+
+    @Test
+    void convertRoundTripsAGenericList() throws Exception {
+        List<Map<String, Object>> raw =
+                List.of(Map.of("name", "Ardbeg", "age", 10), Map.of("name", "Oban", "age", 14));
+        java.lang.reflect.Type listOfWhisky =
+                JsonTest.class.getDeclaredField("listOfWhiskyField").getGenericType();
+        JavaType listType = Json.resolveType(listOfWhisky);
+
+        List<Whisky> whiskies = Json.convert(raw, listType);
+
+        assertThat(whiskies).containsExactly(new Whisky("Ardbeg", 10), new Whisky("Oban", 14));
+    }
+
+    @Test
+    void convertNullReturnsNull() {
+        assertThat(Json.convert(null, Whisky.class)).isNull();
+        assertThat(Json.<Whisky>convert(null, Json.resolveType(Whisky.class))).isNull();
+    }
+
+    @Test
+    void toNodeAndWritersProduceConsistentJson() {
+        Whisky whisky = new Whisky("Talisker", 10);
+
+        JsonNode node = Json.toNode(whisky);
+        assertThat(node.get("name").asText()).isEqualTo("Talisker");
+        assertThat(node.get("age").asInt()).isEqualTo(10);
+
+        String compact = Json.writeCompact(whisky);
+        assertThat(compact).isEqualTo("{\"name\":\"Talisker\",\"age\":10}");
+
+        String pretty = Json.writePretty(whisky);
+        assertThat(pretty).contains("\n").contains("\"name\" : \"Talisker\"");
+    }
+
+    @Test
+    void comparisonReaderRejectsDuplicateKeys() {
+        assertThatThrownBy(() -> Json.comparisonReader().readTree("{\"x\":1,\"x\":2}"))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Duplicate");
+    }
+
+    @Test
+    void comparisonReaderRejectsNaN() {
+        assertThatThrownBy(() -> Json.comparisonReader().readTree("{\"x\":NaN}"))
+                .isInstanceOf(Exception.class);
+    }
+
+    @Test
+    void mapperIsThreadSafeUnderParallelUse() {
+        List<Whisky> results =
+                IntStream.range(0, 2000)
+                        .parallel()
+                        .mapToObj(
+                                i -> {
+                                    String json = Json.writeCompact(new Whisky("W" + i, i));
+                                    try {
+                                        return Json.reader().readValue(json, Whisky.class);
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .toList();
+
+        assertThat(results).hasSize(2000);
+        assertThat(results).contains(new Whisky("W7", 7), new Whisky("W1999", 1999));
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
@@ -110,4 +110,30 @@ class JsonTest {
         assertThatThrownBy(() -> Json.reader().readValue("{} trailing", Object.class))
                 .isInstanceOf(Exception.class);
     }
+
+    @Test
+    void readRoundTripsARecord() {
+        Whisky whisky = Json.read("{\"name\":\"Lagavulin\",\"age\":16}", Whisky.class);
+
+        assertThat(whisky).isEqualTo(new Whisky("Lagavulin", 16));
+    }
+
+    @Test
+    void readRoundTripsAGenericList() throws Exception {
+        java.lang.reflect.Type listOfWhisky =
+                JsonTest.class.getDeclaredField("listOfWhiskyField").getGenericType();
+        JavaType listType = Json.resolveType(listOfWhisky);
+
+        List<Whisky> whiskies =
+                Json.read("[{\"name\":\"Ardbeg\",\"age\":10},{\"name\":\"Oban\",\"age\":14}]", listType);
+
+        assertThat(whiskies).containsExactly(new Whisky("Ardbeg", 10), new Whisky("Oban", 14));
+    }
+
+    @Test
+    void readRejectsInvalidJson() {
+        assertThatThrownBy(() -> Json.read("not json", Whisky.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Failed to parse JSON");
+    }
 }

--- a/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/internal/JsonTest.java
@@ -107,4 +107,10 @@ class JsonTest {
         assertThat(results).hasSize(2000);
         assertThat(results).contains(new Whisky("W7", 7), new Whisky("W1999", 1999));
     }
+
+    @Test
+    void readerRejectsTrailingTokens() {
+        assertThatThrownBy(() -> Json.reader().readValue("{} trailing", Object.class))
+                .isInstanceOf(Exception.class);
+    }
 }

--- a/dokimos-examples/pom.xml
+++ b/dokimos-examples/pom.xml
@@ -164,6 +164,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/Whisky.java
+++ b/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/Whisky.java
@@ -1,0 +1,12 @@
+package dev.dokimos.examples.springai.agent;
+
+/**
+ * A whisky in the catalog.
+ *
+ * @param id     stable catalog id
+ * @param name   the bottling name
+ * @param region the producing region (for example {@code "Islay"})
+ * @param age    the age statement in years
+ * @param peaty  whether the whisky is peated
+ */
+public record Whisky(String id, String name, String region, int age, boolean peaty) {}

--- a/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyAgentExample.java
+++ b/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyAgentExample.java
@@ -1,0 +1,135 @@
+package dev.dokimos.examples.springai.agent;
+
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.AgentTrace;
+import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator;
+import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator;
+import dev.dokimos.springai.SpringAiSupport;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.method.MethodToolCallback;
+import org.springframework.ai.tool.support.ToolDefinitions;
+
+/**
+ * Live, copy-me reference: run a Spring AI agent over a whisky-catalog tool, capture the trace, and
+ * evaluate the agent's tool use with Dokimos.
+ *
+ * <p>This models the case from jettro's blog "Evals for Spring AI Agents with Dokimos" and shows the
+ * two simplifications we shipped:
+ *
+ * <ol>
+ *   <li>The {@link AssistantMessage} plus the {@link ToolResponseMessage}s become a Dokimos
+ *       {@link AgentTrace} in a single {@link SpringAiSupport#toAgentTrace(AssistantMessage, List)}
+ *       call — replacing the hand-written message-to-trace mapping.
+ *   <li>Tool results stay structured ({@code List<Whisky>}) rather than escaped JSON strings — see
+ *       {@link WhiskyAgentEvaluationTest} for the structured-output comparison.
+ * </ol>
+ *
+ * <p>Requires {@code OPENAI_API_KEY} at runtime; it compiles without one.
+ */
+public class WhiskyAgentExample {
+
+    public static void main(String[] args) {
+        if (System.getenv("OPENAI_API_KEY") == null) {
+            System.err.println("OPENAI_API_KEY not set");
+            System.exit(1);
+        }
+
+        OpenAiApi openAiApi =
+                OpenAiApi.builder().apiKey(System.getenv("OPENAI_API_KEY")).build();
+        ChatModel chatModel = OpenAiChatModel.builder()
+                .openAiApi(openAiApi)
+                .defaultOptions(OpenAiChatOptions.builder().model("gpt-5-nano").build())
+                .build();
+
+        // Build the tool callback from the @Tool-annotated method.
+        WhiskyTools tools = new WhiskyTools(new WhiskyCatalog());
+        Method searchMethod = findToolMethod(WhiskyTools.class, "searchWhiskies");
+        ToolCallback searchCallback = MethodToolCallback.builder()
+                .toolDefinition(ToolDefinitions.from(searchMethod))
+                .toolMethod(searchMethod)
+                .toolObject(tools)
+                .build();
+
+        // Run the model with internal tool execution OFF so we hold both the assistant message
+        // (with its tool calls) and the tool responses we run ourselves.
+        ChatClient client = ChatClient.builder(chatModel)
+                .defaultOptions(OpenAiChatOptions.builder()
+                        .internalToolExecutionEnabled(false)
+                        .toolCallbacks(searchCallback)
+                        .build())
+                .build();
+
+        String userQuery = "Find me a peaty Islay whisky around 12 years old";
+        AssistantMessage assistantMessage =
+                client.prompt().user(userQuery).call().chatResponse().getResult().getOutput();
+
+        // Execute each tool call to collect its result.
+        List<ToolResponseMessage> toolResponses = runToolCalls(assistantMessage, searchCallback);
+
+        // THE simplification: one call turns the Spring AI messages into a Dokimos trace.
+        // Previously this was a hand-written loop mapping each AssistantMessage.ToolCall and its
+        // matching ToolResponse into a ToolCall, parsing the arguments JSON by hand.
+        AgentTrace trace = SpringAiSupport.toAgentTrace(assistantMessage, toolResponses);
+
+        // Tool definitions come straight from the Spring AI tool definition — no manual schema.
+        List<ToolDefinition> toolDefs =
+                SpringAiSupport.toToolDefinitions(List.of(searchCallback.getToolDefinition()));
+
+        // toTestCase wires output, toolCalls, and the tools/tasks metadata the evaluators need.
+        EvalTestCase testCase = trace.toTestCase(userQuery, toolDefs, List.of(userQuery));
+
+        EvalResult validity =
+                ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+        EvalResult correctness = ToolCorrectnessEvaluator.builder()
+                .build()
+                .evaluate(EvalTestCase.builder()
+                        .actualOutputs(testCase.actualOutputs())
+                        .metadata(testCase.metadata())
+                        // The agent was expected to reach for searchWhiskies.
+                        .expectedOutput(
+                                "toolCalls",
+                                List.of(dev.dokimos.core.agents.ToolCall.of("searchWhiskies", java.util.Map.of())))
+                        .build());
+
+        System.out.println("User query: " + userQuery);
+        System.out.println("Tool calls: " + trace.toolNames());
+        System.out.printf("Tool Call Validity: %.2f (%s)%n", validity.score(), validity.reason());
+        System.out.printf("Tool Correctness:   %.2f (%s)%n", correctness.score(), correctness.reason());
+        System.out.println("Final response: " + trace.finalResponse());
+    }
+
+    private static List<ToolResponseMessage> runToolCalls(AssistantMessage message, ToolCallback callback) {
+        List<ToolResponseMessage> responses = new ArrayList<>();
+        if (message == null || message.getToolCalls() == null) {
+            return responses;
+        }
+        for (AssistantMessage.ToolCall call : message.getToolCalls()) {
+            String result = callback.call(call.arguments());
+            responses.add(ToolResponseMessage.builder()
+                    .responses(List.of(new ToolResponseMessage.ToolResponse(call.id(), call.name(), result)))
+                    .build());
+        }
+        return responses;
+    }
+
+    private static Method findToolMethod(Class<?> type, String name) {
+        for (Method m : type.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new IllegalStateException("No method named " + name + " on " + type);
+    }
+}

--- a/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyAgentExample.java
+++ b/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyAgentExample.java
@@ -22,16 +22,15 @@ import org.springframework.ai.tool.method.MethodToolCallback;
 import org.springframework.ai.tool.support.ToolDefinitions;
 
 /**
- * Live, copy-me reference: run a Spring AI agent over a whisky-catalog tool, capture the trace, and
- * evaluate the agent's tool use with Dokimos.
+ * Runs a Spring AI agent over a whisky-catalog tool, captures the trace, and evaluates the agent's
+ * tool use with Dokimos.
  *
- * <p>This models the case from jettro's blog "Evals for Spring AI Agents with Dokimos" and shows the
- * two simplifications we shipped:
+ * <p>Demonstrates two things:
  *
  * <ol>
  *   <li>The {@link AssistantMessage} plus the {@link ToolResponseMessage}s become a Dokimos
  *       {@link AgentTrace} in a single {@link SpringAiSupport#toAgentTrace(AssistantMessage, List)}
- *       call — replacing the hand-written message-to-trace mapping.
+ *       call.
  *   <li>Tool results stay structured ({@code List<Whisky>}) rather than escaped JSON strings — see
  *       {@link WhiskyAgentEvaluationTest} for the structured-output comparison.
  * </ol>
@@ -62,8 +61,8 @@ public class WhiskyAgentExample {
                 .toolObject(tools)
                 .build();
 
-        // Run the model with internal tool execution OFF so we hold both the assistant message
-        // (with its tool calls) and the tool responses we run ourselves.
+        // Internal tool execution OFF so both the assistant message (with its tool calls) and the
+        // tool responses run here are available.
         ChatClient client = ChatClient.builder(chatModel)
                 .defaultOptions(OpenAiChatOptions.builder()
                         .internalToolExecutionEnabled(false)
@@ -72,26 +71,26 @@ public class WhiskyAgentExample {
                 .build();
 
         String userQuery = "Find me a peaty Islay whisky around 12 years old";
-        AssistantMessage assistantMessage =
-                client.prompt().user(userQuery).call().chatResponse().getResult().getOutput();
+        AssistantMessage assistantMessage = client.prompt()
+                .user(userQuery)
+                .call()
+                .chatResponse()
+                .getResult()
+                .getOutput();
 
         // Execute each tool call to collect its result.
         List<ToolResponseMessage> toolResponses = runToolCalls(assistantMessage, searchCallback);
 
-        // THE simplification: one call turns the Spring AI messages into a Dokimos trace.
-        // Previously this was a hand-written loop mapping each AssistantMessage.ToolCall and its
-        // matching ToolResponse into a ToolCall, parsing the arguments JSON by hand.
+        // One call turns the Spring AI messages into a Dokimos trace.
         AgentTrace trace = SpringAiSupport.toAgentTrace(assistantMessage, toolResponses);
 
-        // Tool definitions come straight from the Spring AI tool definition — no manual schema.
-        List<ToolDefinition> toolDefs =
-                SpringAiSupport.toToolDefinitions(List.of(searchCallback.getToolDefinition()));
+        // Tool definitions come from the Spring AI tool definition.
+        List<ToolDefinition> toolDefs = SpringAiSupport.toToolDefinitions(List.of(searchCallback.getToolDefinition()));
 
         // toTestCase wires output, toolCalls, and the tools/tasks metadata the evaluators need.
         EvalTestCase testCase = trace.toTestCase(userQuery, toolDefs, List.of(userQuery));
 
-        EvalResult validity =
-                ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+        EvalResult validity = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
         EvalResult correctness = ToolCorrectnessEvaluator.builder()
                 .build()
                 .evaluate(EvalTestCase.builder()

--- a/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyCatalog.java
+++ b/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyCatalog.java
@@ -1,0 +1,42 @@
+package dev.dokimos.examples.springai.agent;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * An in-memory whisky catalog with a tiny keyword search. Backs the Spring AI tool the agent calls.
+ */
+public class WhiskyCatalog {
+
+    private final List<Whisky> whiskies = List.of(
+            new Whisky("lp10", "Laphroaig 10", "Islay", 10, true),
+            new Whisky("ard12", "Ardbeg An Oa", "Islay", 12, true),
+            new Whisky("lag16", "Lagavulin 16", "Islay", 16, true),
+            new Whisky("glf12", "Glenfiddich 12", "Speyside", 12, false),
+            new Whisky("mac12", "Macallan 12", "Speyside", 12, false));
+
+    /**
+     * Returns whiskies whose name or region contains any whitespace-separated term of {@code query},
+     * case-insensitively. A blank query returns the whole catalog.
+     *
+     * @param query free-text search such as {@code "peaty Islay 12"}
+     * @return the matching whiskies, never null
+     */
+    public List<Whisky> search(String query) {
+        if (query == null || query.isBlank()) {
+            return whiskies;
+        }
+        String[] terms = query.toLowerCase(Locale.ROOT).split("\\s+");
+        return whiskies.stream()
+                .filter(w -> {
+                    String haystack = (w.name() + " " + w.region()).toLowerCase(Locale.ROOT);
+                    for (String term : terms) {
+                        if (haystack.contains(term)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .toList();
+    }
+}

--- a/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyTools.java
+++ b/dokimos-examples/src/main/java/dev/dokimos/examples/springai/agent/WhiskyTools.java
@@ -1,0 +1,37 @@
+package dev.dokimos.examples.springai.agent;
+
+import java.util.List;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+/**
+ * The agent's tool surface: a single {@code searchWhiskies} tool over the {@link WhiskyCatalog}.
+ *
+ * <p>Spring AI turns the {@link Tool @Tool} method into a callable tool the model can invoke; its
+ * name, description, and JSON schema come straight from the annotation and parameter metadata.
+ */
+public class WhiskyTools {
+
+    private final WhiskyCatalog catalog;
+
+    /**
+     * Creates the tool surface over the given catalog.
+     *
+     * @param catalog the catalog to search
+     */
+    public WhiskyTools(WhiskyCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    /**
+     * Searches the whisky catalog. Exposed to the agent as the {@code searchWhiskies} tool.
+     *
+     * @param query free-text search terms such as {@code "peaty Islay"}
+     * @return whiskies matching the query
+     */
+    @Tool(name = "searchWhiskies", description = "Search the whisky catalog by name, region, or flavor terms.")
+    public List<Whisky> searchWhiskies(
+            @ToolParam(description = "Free-text search terms, e.g. 'peaty Islay'") String query) {
+        return catalog.search(query);
+    }
+}

--- a/dokimos-examples/src/test/java/dev/dokimos/examples/agents/SequentialToolCallingIntegrationTest.java
+++ b/dokimos-examples/src/test/java/dev/dokimos/examples/agents/SequentialToolCallingIntegrationTest.java
@@ -1,0 +1,251 @@
+package dev.dokimos.examples.agents;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.core.JsonValue;
+import com.openai.models.ChatModel;
+import com.openai.models.FunctionDefinition;
+import com.openai.models.FunctionParameters;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.chat.completions.ChatCompletionFunctionTool;
+import com.openai.models.chat.completions.ChatCompletionMessageToolCall;
+import com.openai.models.chat.completions.ChatCompletionTool;
+import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.AgentTrace;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * End-to-end integration test for a sequential (output -> input -> output) tool-calling workflow
+ * against a real OpenAI model.
+ *
+ * <p>The model must call {@code lookupOrder} first, receive a structured {@link Order} back, then
+ * feed that order's {@code weightKg} into {@code estimateShipping} to get a {@link ShippingQuote}.
+ * The weight only exists inside tool 1's result, so a correct {@code estimateShipping} weight
+ * argument proves the model chained the first tool's output into the second tool's input.
+ *
+ * <p>The point being proven on the Dokimos side: each executed tool result is attached with {@link
+ * ToolCall.Builder#resultJson(Object)} (a structured record, not a {@code toString()}), and {@link
+ * ToolCall#resultAs(Class)} round-trips it back into a typed object from a <i>real</i> agent trace.
+ *
+ * <p>Model: {@link ChatModel#GPT_4O_MINI}. Chosen because it is a current, cheap, tool-calling model
+ * that honors {@code temperature(0)} (GPT-5 family models reject a non-default temperature), which
+ * keeps the live run deterministic enough for the assertions below.
+ *
+ * <p>Integration-tagged: excluded from {@code mvn test}, runs under {@code mvn verify
+ * -Dgroups=integration}, and requires {@code OPENAI_API_KEY}.
+ */
+@Tag("integration")
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class SequentialToolCallingIntegrationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Structured result of {@code lookupOrder}. */
+    record Order(String id, String item, double weightKg) {}
+
+    /** Structured result of {@code estimateShipping}. */
+    record ShippingQuote(double amountUsd, int days) {}
+
+    /** In-memory order book. The weight lives here and nowhere in the prompt. */
+    private static final Map<String, Order> ORDER_BOOK = Map.of("A123", new Order("A123", "Trail Runner shoes", 2.5));
+
+    private static Order lookupOrder(String orderId) {
+        return ORDER_BOOK.get(orderId);
+    }
+
+    private static ShippingQuote estimateShipping(double weightKg, String destination) {
+        // Deterministic local computation; destination is accepted but does not vary the math here.
+        return new ShippingQuote(5.0 + weightKg * 2.0, 3);
+    }
+
+    private static final ToolDefinition LOOKUP_ORDER_TOOL = ToolDefinition.builder()
+            .name("lookupOrder")
+            .description("Look up an order by its id. Returns the order including its item and weight in kg.")
+            .inputSchema(Map.of(
+                    "type",
+                    "object",
+                    "properties",
+                    Map.of("orderId", Map.of("type", "string", "description", "The order id, e.g. A123")),
+                    "required",
+                    List.of("orderId")))
+            .build();
+
+    private static final ToolDefinition ESTIMATE_SHIPPING_TOOL = ToolDefinition.builder()
+            .name("estimateShipping")
+            .description(
+                    "Estimate the shipping cost and number of days for a package of a given weight to a destination.")
+            .inputSchema(Map.of(
+                    "type",
+                    "object",
+                    "properties",
+                    Map.of(
+                            "weightKg",
+                            Map.of("type", "number", "description", "Package weight in kilograms"),
+                            "destination",
+                            Map.of("type", "string", "description", "Destination city")),
+                    "required",
+                    List.of("weightKg", "destination")))
+            .build();
+
+    private static final List<ToolDefinition> TOOLS = List.of(LOOKUP_ORDER_TOOL, ESTIMATE_SHIPPING_TOOL);
+
+    @Test
+    void chainsStructuredToolResultsFromOneToolIntoTheNext() {
+        OpenAIClient client = OpenAIOkHttpClient.fromEnv();
+
+        String prompt = "How much will it cost to ship order A123 to Berlin, and how many days?";
+
+        AgentTrace trace = runToolCallingLoop(client, prompt);
+
+        // --- Tool names and ordering: lookupOrder before estimateShipping. ---
+        List<String> toolNames = new ArrayList<>(trace.toolNames());
+        assertThat(toolNames).contains("lookupOrder", "estimateShipping");
+        assertThat(toolNames.indexOf("lookupOrder"))
+                .as("lookupOrder must run before estimateShipping")
+                .isLessThan(toolNames.indexOf("estimateShipping"));
+
+        ToolCall lookupCall = firstCallNamed(trace, "lookupOrder");
+        ToolCall shippingCall = firstCallNamed(trace, "estimateShipping");
+
+        // --- resultAs round-trips the structured Order attached via resultJson. ---
+        Order order = lookupCall.resultAs(Order.class);
+        assertThat(order).isEqualTo(new Order("A123", "Trail Runner shoes", 2.5));
+
+        // --- resultAs round-trips the structured ShippingQuote. ---
+        ShippingQuote quote = shippingCall.resultAs(ShippingQuote.class);
+        assertThat(quote).isNotNull();
+        assertThat(quote.amountUsd()).isPositive();
+        assertThat(quote.days()).isPositive();
+
+        // --- output -> input chaining: the weight passed to estimateShipping came from tool 1. ---
+        double passedWeight = ((Number) shippingCall.arguments().get("weightKg")).doubleValue();
+        assertThat(passedWeight)
+                .as("estimateShipping weight must come from the looked-up order (the only place it exists)")
+                .isCloseTo(order.weightKg(), within(0.01));
+
+        // --- The trace passes the agent tool-call validity evaluator. ---
+        EvalTestCase testCase = trace.toTestCase(prompt, TOOLS);
+        EvalResult validity = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+        assertThat(validity.success()).as(validity.reason()).isTrue();
+        assertThat(validity.score()).isEqualTo(1.0);
+    }
+
+    /**
+     * Runs the real tool-calling loop. For each tool the model invokes, this executes the local
+     * implementation, attaches the structured result to a Dokimos {@link ToolCall} via {@code
+     * resultJson(...)} (NOT {@code result(...)} — that would store a toString and break {@code
+     * resultAs}), and feeds the result's JSON back to the model so it can chain into the next call.
+     */
+    private static AgentTrace runToolCallingLoop(OpenAIClient client, String prompt) {
+        AgentTrace.Builder traceBuilder = AgentTrace.builder();
+
+        ChatCompletionCreateParams.Builder params = ChatCompletionCreateParams.builder()
+                .model(ChatModel.GPT_4O_MINI)
+                .temperature(0.0)
+                .addUserMessage(prompt);
+        for (ToolDefinition def : TOOLS) {
+            params.addTool(toOpenAiTool(def));
+        }
+
+        for (int round = 0; round < 8; round++) {
+            var message = client.chat()
+                    .completions()
+                    .create(params.build())
+                    .choices()
+                    .get(0)
+                    .message();
+            params.addMessage(message);
+
+            var toolCalls = message.toolCalls().orElse(List.of());
+            if (toolCalls.isEmpty()) {
+                traceBuilder.finalResponse(message.content().orElse(""));
+                break;
+            }
+
+            for (ChatCompletionMessageToolCall toolCall : toolCalls) {
+                var function = toolCall.asFunction().function();
+                String name = function.name();
+                Map<String, Object> args = parseArgs(function.arguments());
+
+                Object structuredResult = executeTool(name, args);
+                String resultJson = toJson(structuredResult);
+
+                // Attach the STRUCTURED result via resultJson so ToolCall.resultAs can round-trip it.
+                traceBuilder.addToolCall(ToolCall.builder()
+                        .name(name)
+                        .arguments(args)
+                        .resultJson(structuredResult)
+                        .build());
+
+                // Feed the JSON back to the model so the next turn can use it (output -> input).
+                params.addMessage(ChatCompletionToolMessageParam.builder()
+                        .toolCallId(toolCall.asFunction().id())
+                        .content(resultJson)
+                        .build());
+            }
+        }
+
+        return traceBuilder.build();
+    }
+
+    private static Object executeTool(String name, Map<String, Object> args) {
+        return switch (name) {
+            case "lookupOrder" -> lookupOrder((String) args.get("orderId"));
+            case "estimateShipping" ->
+                estimateShipping(((Number) args.get("weightKg")).doubleValue(), (String) args.get("destination"));
+            default -> Map.of("error", "unknown tool: " + name);
+        };
+    }
+
+    private static ToolCall firstCallNamed(AgentTrace trace, String name) {
+        return trace.toolCalls().stream()
+                .filter(c -> c.name().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("trace did not contain a call to " + name));
+    }
+
+    private static ChatCompletionTool toOpenAiTool(ToolDefinition def) {
+        var paramsBuilder = FunctionParameters.builder();
+        for (Map.Entry<String, Object> entry : def.inputSchema().entrySet()) {
+            paramsBuilder.putAdditionalProperty(entry.getKey(), JsonValue.from(entry.getValue()));
+        }
+        return ChatCompletionTool.ofFunction(ChatCompletionFunctionTool.builder()
+                .function(FunctionDefinition.builder()
+                        .name(def.name())
+                        .description(def.description())
+                        .parameters(paramsBuilder.build())
+                        .build())
+                .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parseArgs(String argumentsJson) {
+        try {
+            return MAPPER.readValue(argumentsJson, Map.class);
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to serialize tool result", e);
+        }
+    }
+}

--- a/dokimos-examples/src/test/java/dev/dokimos/examples/agents/SequentialToolCallingIntegrationTest.java
+++ b/dokimos-examples/src/test/java/dev/dokimos/examples/agents/SequentialToolCallingIntegrationTest.java
@@ -60,6 +60,9 @@ class SequentialToolCallingIntegrationTest {
     /** Structured result of {@code estimateShipping}. */
     record ShippingQuote(double amountUsd, int days) {}
 
+    /** Typed view of the arguments the model passed to {@code estimateShipping}. */
+    record ShippingArgs(double weightKg, String destination) {}
+
     /** In-memory order book. The weight lives here and nowhere in the prompt. */
     private static final Map<String, Order> ORDER_BOOK = Map.of("A123", new Order("A123", "Trail Runner shoes", 2.5));
 
@@ -136,6 +139,18 @@ class SequentialToolCallingIntegrationTest {
         assertThat(passedWeight)
                 .as("estimateShipping weight must come from the looked-up order (the only place it exists)")
                 .isCloseTo(order.weightKg(), within(0.01));
+
+        // --- argumentsAs round-trips the model's raw tool arguments into a typed record. ---
+        // Same guarantee as resultAs, but on the input side: the arguments map the model produced
+        // converts cleanly into a ShippingArgs the test code can use without manual map fishing.
+        ShippingArgs shippingArgs = shippingCall.argumentsAs(ShippingArgs.class);
+        assertThat(shippingArgs).isNotNull();
+        assertThat(shippingArgs.weightKg())
+                .as("typed weight argument must match the looked-up order weight")
+                .isCloseTo(order.weightKg(), within(0.01));
+        assertThat(shippingArgs.destination())
+                .as("typed destination argument must be present")
+                .isNotBlank();
 
         // --- The trace passes the agent tool-call validity evaluator. ---
         EvalTestCase testCase = trace.toTestCase(prompt, TOOLS);

--- a/dokimos-examples/src/test/java/dev/dokimos/examples/junit5/EvaluateLlmOutputInJUnitTest.java
+++ b/dokimos-examples/src/test/java/dev/dokimos/examples/junit5/EvaluateLlmOutputInJUnitTest.java
@@ -1,0 +1,154 @@
+package dev.dokimos.examples.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.models.ChatModel;
+import com.openai.models.responses.Response;
+import com.openai.models.responses.ResponseCreateParams;
+import dev.dokimos.core.Assertions;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.Evaluator;
+import dev.dokimos.core.Example;
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.evaluators.ExactMatchEvaluator;
+import dev.dokimos.core.evaluators.LLMJudgeEvaluator;
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator;
+import dev.dokimos.core.evaluators.StructuralMatchMode;
+import dev.dokimos.junit.DatasetSource;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * Companion code for the "Evaluate LLM output in JUnit" tutorial.
+ *
+ * <p>Each test calls a real model through the OpenAI Java SDK Responses API and evaluates the
+ * response with Dokimos. The tests are tagged {@code integration} and gated on {@code
+ * OPENAI_API_KEY}, so they never run in normal CI (only with {@code mvn verify -Dgroups=integration}
+ * and a key present).
+ *
+ * <p>The tutorial shows {@link ChatModel#GPT_5_2}; this code compiles against the openai-java SDK on
+ * the classpath and only needs a key at runtime.
+ */
+@Tag("integration")
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class EvaluateLlmOutputInJUnitTest {
+
+    private static final OpenAIClient CLIENT = OpenAIOkHttpClient.fromEnv();
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /** Sends a prompt to the model and returns the concatenated output text. */
+    private static String ask(String prompt) {
+        Response response = CLIENT.responses()
+                .create(ResponseCreateParams.builder()
+                        .model(ChatModel.GPT_5_2)
+                        .input(prompt)
+                        .build());
+        return response.output().stream()
+                .filter(item -> item.isMessage())
+                .flatMap(item -> item.asMessage().content().stream())
+                .filter(content -> content.isOutputText())
+                .map(content -> content.asOutputText().text())
+                .reduce("", String::concat)
+                .trim();
+    }
+
+    /** A JudgeLM backed by a cheaper model, used by {@link LLMJudgeEvaluator}. */
+    private static JudgeLM judge() {
+        return prompt -> CLIENT
+                .responses()
+                .create(ResponseCreateParams.builder()
+                        .model(ChatModel.GPT_5_MINI)
+                        .input(prompt)
+                        .build())
+                .output()
+                .stream()
+                .filter(item -> item.isMessage())
+                .flatMap(item -> item.asMessage().content().stream())
+                .filter(content -> content.isOutputText())
+                .map(content -> content.asOutputText().text())
+                .reduce("", String::concat);
+    }
+
+    /**
+     * Deterministic check: a short factual answer should match exactly. Drives many cases from a
+     * dataset resource with a single test method via {@code @DatasetSource}.
+     */
+    @ParameterizedTest(name = "[{index}] {0}")
+    @DatasetSource("classpath:datasets/junit-tutorial-qa.json")
+    void factualAnswerMatchesExactly(Example example) {
+        String answer = ask(example.input());
+
+        EvalTestCase testCase = example.toTestCase(answer);
+        Evaluator exactMatch =
+                ExactMatchEvaluator.builder().name("Exact Match").threshold(1.0).build();
+
+        Assertions.assertEval(testCase, exactMatch);
+    }
+
+    /**
+     * Open-ended check: exact match does not fit, so an LLM judge scores the answer against
+     * natural-language criteria.
+     */
+    @Test
+    void openEndedAnswerIsHelpful() {
+        String answer = ask("In one sentence, what does an LLM evaluation framework do?");
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("What does an LLM evaluation framework do?")
+                .actualOutput(answer)
+                .build();
+        Evaluator helpfulness = LLMJudgeEvaluator.builder()
+                .name("Helpfulness")
+                .criteria("Is the answer accurate, clear, and genuinely helpful?")
+                .evaluationParams(List.of(EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT))
+                .threshold(0.7)
+                .judge(judge())
+                .build();
+
+        Assertions.assertEval(testCase, helpfulness);
+    }
+
+    /** Typed view of the structured weather payload the model is asked to return. */
+    record WeatherReport(String city, int temperatureCelsius, String condition) {}
+
+    /**
+     * Structured-output check: ask for JSON, compare it field-by-field with {@link
+     * StructuralMatchEvaluator}, and read it back through the typed accessor.
+     */
+    @Test
+    void structuredOutputMatchesContract() throws Exception {
+        String raw = ask("Return ONLY compact JSON with keys city (string), temperatureCelsius "
+                + "(integer), and condition (string) for this report: it is 21 degrees Celsius and "
+                + "sunny in Paris. Do not wrap it in markdown.");
+
+        Map<String, Object> actual = JSON.readValue(raw, new TypeReference<>() {});
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("weather report for Paris")
+                .actualOutput("output", actual)
+                .expectedOutput("output", Map.of("city", "Paris", "temperatureCelsius", 21, "condition", "sunny"))
+                .build();
+
+        Evaluator structuralMatch = StructuralMatchEvaluator.builder()
+                .name("Structural Match")
+                .mode(StructuralMatchMode.LENIENT)
+                .threshold(1.0)
+                .build();
+
+        Assertions.assertEval(testCase, structuralMatch);
+
+        // Typed accessor: read the same output back as a record, no manual map juggling.
+        WeatherReport report = testCase.actualOutputAs(WeatherReport.class);
+        assertEquals("Paris", report.city());
+        assertEquals(21, report.temperatureCelsius());
+    }
+}

--- a/dokimos-examples/src/test/java/dev/dokimos/examples/springai/agent/WhiskyAgentEvaluationTest.java
+++ b/dokimos-examples/src/test/java/dev/dokimos/examples/springai/agent/WhiskyAgentEvaluationTest.java
@@ -22,11 +22,11 @@ import org.springframework.ai.chat.messages.ToolResponseMessage;
 /**
  * Deterministic, network-free evaluation of the whisky agent. Runs in CI with no API key.
  *
- * <p>Demonstrates the two simplifications jettro's blog asked for:
+ * <p>Demonstrates two things:
  *
  * <ul>
  *   <li>Spring AI messages become a Dokimos {@link AgentTrace} in one
- *       {@code SpringAiSupport.toAgentTrace(...)} call — no hand-written mapping.
+ *       {@code SpringAiSupport.toAgentTrace(...)} call.
  *   <li>Tool results and final outputs stay structured ({@code List<Whisky>}, {@code Whisky})
  *       through {@link ToolCall.Builder#resultJson(Object)} and the typed output accessors — no
  *       escaped JSON strings.
@@ -60,7 +60,7 @@ class WhiskyAgentEvaluationTest {
     @Test
     void mapsSpringAiMessagesToTraceInOneCall() {
         // Build the Spring AI messages by hand (no client, no network) and let the support class do
-        // the AssistantMessage -> AgentTrace mapping jettro previously wrote out longhand.
+        // the AssistantMessage -> AgentTrace mapping.
         List<Whisky> islay12 = CATALOG.search("Islay 12");
         AssistantMessage assistantMessage = AssistantMessage.builder()
                 .content("I'd suggest Ardbeg An Oa.")
@@ -68,12 +68,10 @@ class WhiskyAgentEvaluationTest {
                         "call-1", "function", "searchWhiskies", "{\"query\":\"peaty Islay 12\"}")))
                 .build();
         ToolResponseMessage toolResponse = ToolResponseMessage.builder()
-                .responses(List.of(new ToolResponseMessage.ToolResponse(
-                        "call-1", "searchWhiskies", json(islay12))))
+                .responses(List.of(new ToolResponseMessage.ToolResponse("call-1", "searchWhiskies", json(islay12))))
                 .build();
 
-        AgentTrace trace = dev.dokimos.springai.SpringAiSupport.toAgentTrace(
-                assistantMessage, List.of(toolResponse));
+        AgentTrace trace = dev.dokimos.springai.SpringAiSupport.toAgentTrace(assistantMessage, List.of(toolResponse));
 
         assertThat(trace.toolNames()).containsExactly("searchWhiskies");
         assertThat(trace.toolCalls().get(0).arguments()).containsEntry("query", "peaty Islay 12");
@@ -83,7 +81,8 @@ class WhiskyAgentEvaluationTest {
     @Test
     void validTraceWithStructuredToolResultPassesAgentEvaluators() {
         AgentTrace trace = peatyIslayTrace();
-        EvalTestCase testCase = trace.toTestCase("Find me a peaty Islay whisky around 12 years old", List.of(SEARCH_TOOL));
+        EvalTestCase testCase =
+                trace.toTestCase("Find me a peaty Islay whisky around 12 years old", List.of(SEARCH_TOOL));
 
         EvalResult validity = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
         assertThat(validity.score()).isEqualTo(1.0);
@@ -100,7 +99,10 @@ class WhiskyAgentEvaluationTest {
     void unknownToolFailsValidity() {
         AgentTrace trace = AgentTrace.builder()
                 .finalResponse("done")
-                .addToolCall(ToolCall.builder().name("lookupBottle").argument("query", "Islay").build())
+                .addToolCall(ToolCall.builder()
+                        .name("lookupBottle")
+                        .argument("query", "Islay")
+                        .build())
                 .build();
         EvalTestCase testCase = trace.toTestCase("Find a whisky", List.of(SEARCH_TOOL));
 
@@ -123,7 +125,10 @@ class WhiskyAgentEvaluationTest {
                 .build();
         EvalTestCase testCase = withExpectedToolCalls(
                 trace.toTestCase("Find a peaty Islay whisky", List.of(SEARCH_TOOL)),
-                ToolCall.builder().name("searchWhiskies").argument("query", "Islay").build());
+                ToolCall.builder()
+                        .name("searchWhiskies")
+                        .argument("query", "Islay")
+                        .build());
 
         EvalResult correctness = ToolCorrectnessEvaluator.builder()
                 .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)

--- a/dokimos-examples/src/test/java/dev/dokimos/examples/springai/agent/WhiskyAgentEvaluationTest.java
+++ b/dokimos-examples/src/test/java/dev/dokimos/examples/springai/agent/WhiskyAgentEvaluationTest.java
@@ -1,0 +1,208 @@
+package dev.dokimos.examples.springai.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.OutputType;
+import dev.dokimos.core.agents.AgentTrace;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.agents.ToolDefinition;
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator;
+import dev.dokimos.core.evaluators.StructuralMatchMode;
+import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator;
+import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+
+/**
+ * Deterministic, network-free evaluation of the whisky agent. Runs in CI with no API key.
+ *
+ * <p>Demonstrates the two simplifications jettro's blog asked for:
+ *
+ * <ul>
+ *   <li>Spring AI messages become a Dokimos {@link AgentTrace} in one
+ *       {@code SpringAiSupport.toAgentTrace(...)} call — no hand-written mapping.
+ *   <li>Tool results and final outputs stay structured ({@code List<Whisky>}, {@code Whisky})
+ *       through {@link ToolCall.Builder#resultJson(Object)} and the typed output accessors — no
+ *       escaped JSON strings.
+ * </ul>
+ */
+class WhiskyAgentEvaluationTest {
+
+    private static final WhiskyCatalog CATALOG = new WhiskyCatalog();
+
+    private static final ToolDefinition SEARCH_TOOL = ToolDefinition.builder()
+            .name("searchWhiskies")
+            .description("Search the whisky catalog by name, region, or flavor terms.")
+            .inputSchema(Map.of(
+                    "type",
+                    "object",
+                    "properties",
+                    Map.of("query", Map.of("type", "string")),
+                    "required",
+                    List.of("query")))
+            .build();
+
+    @Test
+    void mapsSpringAiMessagesToTraceInOneCall() {
+        // Build the Spring AI messages by hand (no client, no network) and let the support class do
+        // the AssistantMessage -> AgentTrace mapping jettro previously wrote out longhand.
+        List<Whisky> islay12 = CATALOG.search("Islay 12");
+        AssistantMessage assistantMessage = AssistantMessage.builder()
+                .content("I'd suggest Ardbeg An Oa.")
+                .toolCalls(List.of(new AssistantMessage.ToolCall(
+                        "call-1", "function", "searchWhiskies", "{\"query\":\"peaty Islay 12\"}")))
+                .build();
+        ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+                .responses(List.of(new ToolResponseMessage.ToolResponse(
+                        "call-1", "searchWhiskies", dev.dokimos.core.internal.Json.writeCompact(islay12))))
+                .build();
+
+        AgentTrace trace = dev.dokimos.springai.SpringAiSupport.toAgentTrace(
+                assistantMessage, List.of(toolResponse));
+
+        assertThat(trace.toolNames()).containsExactly("searchWhiskies");
+        assertThat(trace.toolCalls().get(0).arguments()).containsEntry("query", "peaty Islay 12");
+        assertThat(trace.finalResponse()).isEqualTo("I'd suggest Ardbeg An Oa.");
+    }
+
+    @Test
+    void validTraceWithStructuredToolResultPassesAgentEvaluators() {
+        AgentTrace trace = peatyIslayTrace();
+        EvalTestCase testCase = trace.toTestCase("Find me a peaty Islay whisky around 12 years old", List.of(SEARCH_TOOL));
+
+        EvalResult validity = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+        assertThat(validity.score()).isEqualTo(1.0);
+        assertThat(validity.success()).isTrue();
+
+        EvalResult correctness = ToolCorrectnessEvaluator.builder()
+                .build()
+                .evaluate(withExpectedToolCalls(testCase, ToolCall.of("searchWhiskies", Map.of())));
+        assertThat(correctness.score()).isEqualTo(1.0);
+        assertThat(correctness.success()).isTrue();
+    }
+
+    @Test
+    void unknownToolFailsValidity() {
+        AgentTrace trace = AgentTrace.builder()
+                .finalResponse("done")
+                .addToolCall(ToolCall.builder().name("lookupBottle").argument("query", "Islay").build())
+                .build();
+        EvalTestCase testCase = trace.toTestCase("Find a whisky", List.of(SEARCH_TOOL));
+
+        EvalResult validity = ToolCallValidityEvaluator.builder().build().evaluate(testCase);
+        assertThat(validity.score()).isEqualTo(0.0);
+        assertThat(validity.success()).isFalse();
+        assertThat(validity.reason()).contains("0/1");
+    }
+
+    @Test
+    void wrongArgumentFailsCorrectnessWithArgsMode() {
+        // The agent searched "Speyside" when the expected call searched "Islay".
+        AgentTrace trace = AgentTrace.builder()
+                .finalResponse("Try Glenfiddich 12.")
+                .addToolCall(ToolCall.builder()
+                        .name("searchWhiskies")
+                        .argument("query", "Speyside")
+                        .resultJson(CATALOG.search("Speyside"))
+                        .build())
+                .build();
+        EvalTestCase testCase = withExpectedToolCalls(
+                trace.toTestCase("Find a peaty Islay whisky", List.of(SEARCH_TOOL)),
+                ToolCall.builder().name("searchWhiskies").argument("query", "Islay").build());
+
+        EvalResult correctness = ToolCorrectnessEvaluator.builder()
+                .matchMode(ToolCorrectnessEvaluator.MatchMode.NAMES_AND_ARGS)
+                .build()
+                .evaluate(testCase);
+        assertThat(correctness.score()).isEqualTo(0.0);
+        assertThat(correctness.success()).isFalse();
+    }
+
+    @Test
+    void structuredFinalOutputComparesStructurally() {
+        Whisky recommended = new Whisky("ard12", "Ardbeg An Oa", "Islay", 12, true);
+        Whisky expected = new Whisky("ard12", "Ardbeg An Oa", "Islay", 12, true);
+
+        // Structured objects in/out — no stringified JSON to assemble or escape.
+        EvalTestCase testCase = EvalTestCase.builder()
+                .actualOutput("output", recommended)
+                .expectedOutput("output", expected)
+                .build();
+
+        EvalResult strict = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build()
+                .evaluate(testCase);
+        assertThat(strict.score()).isEqualTo(1.0);
+        assertThat(strict.success()).isTrue();
+
+        // Read it back typed, straight off the test case.
+        Whisky readBack = testCase.expectedOutputAs(Whisky.class);
+        assertThat(readBack).isEqualTo(expected);
+        assertThat(testCase.<Whisky>actualOutputAs(Whisky.class).region()).isEqualTo("Islay");
+    }
+
+    @Test
+    void lenientStructuralMatchIgnoresExtraActualFields() {
+        // Actual carries an extra "score" field the expected contract does not mention.
+        Map<String, Object> actual = Map.of("id", "ard12", "name", "Ardbeg An Oa", "region", "Islay", "score", 0.92);
+        Map<String, Object> expected = Map.of("id", "ard12", "name", "Ardbeg An Oa", "region", "Islay");
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .actualOutput("output", actual)
+                .expectedOutput("output", expected)
+                .build();
+
+        EvalResult lenient = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build()
+                .evaluate(testCase);
+        assertThat(lenient.score()).isEqualTo(1.0);
+
+        EvalResult strict = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build()
+                .evaluate(testCase);
+        assertThat(strict.score()).isLessThan(1.0);
+    }
+
+    @Test
+    void typedListReadBackFromStructuredToolResult() {
+        AgentTrace trace = peatyIslayTrace();
+        EvalTestCase testCase = EvalTestCase.builder()
+                .actualOutput("matches", CATALOG.search("Islay"))
+                .build();
+
+        List<Whisky> matches = testCase.actualOutputAs("matches", new OutputType<List<Whisky>>() {});
+        assertThat(matches).isNotEmpty();
+        assertThat(matches).allSatisfy(w -> assertThat(w.region()).isEqualTo("Islay"));
+        // The structured tool result on the trace is the same data, attached via resultJson(...).
+        assertThat(trace.toolCalls().get(0).result()).contains("Ardbeg An Oa");
+    }
+
+    /** A valid trace whose tool result is a structured {@code List<Whisky>} attached via resultJson. */
+    private static AgentTrace peatyIslayTrace() {
+        return AgentTrace.builder()
+                .finalResponse("I'd suggest Ardbeg An Oa, a peaty 12-year-old Islay.")
+                .addToolCall(ToolCall.builder()
+                        .name("searchWhiskies")
+                        .argument("query", "peaty Islay 12")
+                        .resultJson(CATALOG.search("Islay"))
+                        .build())
+                .build();
+    }
+
+    private static EvalTestCase withExpectedToolCalls(EvalTestCase base, ToolCall... expected) {
+        return EvalTestCase.builder()
+                .inputs(base.inputs())
+                .actualOutputs(base.actualOutputs())
+                .metadata(base.metadata())
+                .expectedOutput("toolCalls", List.of(expected))
+                .build();
+    }
+}

--- a/dokimos-examples/src/test/java/dev/dokimos/examples/springai/agent/WhiskyAgentEvaluationTest.java
+++ b/dokimos-examples/src/test/java/dev/dokimos/examples/springai/agent/WhiskyAgentEvaluationTest.java
@@ -2,6 +2,7 @@ package dev.dokimos.examples.springai.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.OutputType;
@@ -34,6 +35,15 @@ import org.springframework.ai.chat.messages.ToolResponseMessage;
 class WhiskyAgentEvaluationTest {
 
     private static final WhiskyCatalog CATALOG = new WhiskyCatalog();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static String json(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to serialize test fixture", e);
+        }
+    }
 
     private static final ToolDefinition SEARCH_TOOL = ToolDefinition.builder()
             .name("searchWhiskies")
@@ -59,7 +69,7 @@ class WhiskyAgentEvaluationTest {
                 .build();
         ToolResponseMessage toolResponse = ToolResponseMessage.builder()
                 .responses(List.of(new ToolResponseMessage.ToolResponse(
-                        "call-1", "searchWhiskies", dev.dokimos.core.internal.Json.writeCompact(islay12))))
+                        "call-1", "searchWhiskies", json(islay12))))
                 .build();
 
         AgentTrace trace = dev.dokimos.springai.SpringAiSupport.toAgentTrace(

--- a/dokimos-examples/src/test/resources/datasets/junit-tutorial-qa.json
+++ b/dokimos-examples/src/test/resources/datasets/junit-tutorial-qa.json
@@ -1,0 +1,20 @@
+{
+  "name": "JUnit Tutorial QA",
+  "examples": [
+    {
+      "input": "What is the capital of France? Reply with only the city name.",
+      "expectedOutput": "Paris",
+      "metadata": { "category": "geography" }
+    },
+    {
+      "input": "What is the capital of Japan? Reply with only the city name.",
+      "expectedOutput": "Tokyo",
+      "metadata": { "category": "geography" }
+    },
+    {
+      "input": "What is the capital of Italy? Reply with only the city name.",
+      "expectedOutput": "Rome",
+      "metadata": { "category": "geography" }
+    }
+  ]
+}

--- a/dokimos-koog/src/main/kotlin/dev/dokimos/koog/KoogSupport.kt
+++ b/dokimos-koog/src/main/kotlin/dev/dokimos/koog/KoogSupport.kt
@@ -1,8 +1,15 @@
 package dev.dokimos.koog
 
 import ai.koog.agents.core.agent.AIAgent
+import dev.dokimos.core.AsyncTask
+import dev.dokimos.core.Example
 import dev.dokimos.core.JudgeLM
+import dev.dokimos.core.TaskResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
 
@@ -51,6 +58,56 @@ fun asJudge(agentCall: suspend (String) -> String): JudgeLM = JudgeLM { prompt -
  * @see asJudge for creating a judge from a direct suspend function
  */
 fun asJudge(agent: () -> AIAgent<String, String>): JudgeLM = asJudge { input -> agent().run(input) }
+
+/**
+ * Adapts a `suspend` agent call into a Dokimos [AsyncTask], so a Koog agent can drive an experiment
+ * through [dev.dokimos.core.Experiment.Builder.asyncTask] without [runBlocking] holding a thread per
+ * example.
+ *
+ * Each invocation launches the suspend body on the given [scope] (the [Dispatchers.IO] dispatcher by
+ * default) and bridges the coroutine to a [java.util.concurrent.CompletableFuture] via the
+ * kotlinx-coroutines `future` builder. A suspend exception surfaces as an exceptionally completed
+ * future, which the experiment isolates as a failed item while the run continues.
+ *
+ * The suspend body receives the full [Example] and returns a [TaskResult] (use [TaskResult.of] when
+ * there are no call metrics).
+ *
+ * @param scope the coroutine scope used to launch each invocation. Defaults to [GlobalScope].
+ * @param agentCall a suspend function that produces a [TaskResult] for an [Example].
+ * @return an [AsyncTask] suitable for the non-blocking experiment execution path.
+ * @see asTask for adapting a suspend call that returns the model output text directly
+ */
+@OptIn(DelicateCoroutinesApi::class)
+fun asTask(
+    scope: CoroutineScope = GlobalScope,
+    agentCall: suspend (Example) -> TaskResult,
+): AsyncTask = AsyncTask { example ->
+    scope.future(Dispatchers.IO) { agentCall(example) }
+}
+
+/**
+ * Adapts a `suspend` agent call that returns the model output text into a Dokimos [AsyncTask].
+ *
+ * Convenience overload of [asTask] for the common case: the suspend body receives the example
+ * [input][Example.input] string and returns the model response, which is stored under [OUTPUT_KEY]
+ * in a metrics-free [TaskResult]. A blank response throws [IllegalArgumentException], surfacing as an
+ * exceptionally completed future that the experiment isolates as a failed item.
+ *
+ * @param scope the coroutine scope used to launch each invocation. Defaults to [GlobalScope].
+ * @param agentCall a suspend function that accepts the example input and returns the model response.
+ *                  The response must not be blank.
+ * @return an [AsyncTask] suitable for the non-blocking experiment execution path.
+ * @throws IllegalArgumentException if the agent response content is blank.
+ */
+@OptIn(DelicateCoroutinesApi::class)
+fun asTextTask(
+    scope: CoroutineScope = GlobalScope,
+    agentCall: suspend (String) -> String,
+): AsyncTask = asTask(scope) { example ->
+    val content = agentCall(example.input())
+    require(content.isNotBlank()) { "Agent response content was blank" }
+    TaskResult.of(mapOf(OUTPUT_KEY to content))
+}
 
 /**
  * Executes the `run` method of the `AIAgent` in a blocking coroutine context.

--- a/dokimos-koog/src/main/kotlin/dev/dokimos/koog/KoogSupport.kt
+++ b/dokimos-koog/src/main/kotlin/dev/dokimos/koog/KoogSupport.kt
@@ -69,8 +69,8 @@ fun asJudge(agent: () -> AIAgent<String, String>): JudgeLM = asJudge { input -> 
  * via the kotlinx-coroutines `future` builder. A suspend exception surfaces as an exceptionally
  * completed future, which the experiment isolates as a failed item while the run continues.
  *
- * [GlobalScope] is the default because this is a fire-and-bridge-to-future adapter with no parent
- * lifecycle to inherit; pass your own [scope] to opt into structured concurrency.
+ * [GlobalScope] is the default (the launched coroutine has no parent lifecycle to inherit); pass your
+ * own [scope] to opt into structured concurrency.
  *
  * The suspend body receives the full [Example] and returns a [TaskResult] (use [TaskResult.of] when
  * there are no call metrics).
@@ -81,12 +81,10 @@ fun asJudge(agent: () -> AIAgent<String, String>): JudgeLM = asJudge { input -> 
  * @see asTask for adapting a suspend call that returns the model output text directly
  */
 @OptIn(DelicateCoroutinesApi::class)
-fun asTask(
-    scope: CoroutineScope = GlobalScope,
-    agentCall: suspend (Example) -> TaskResult,
-): AsyncTask = AsyncTask { example ->
-    scope.future(Dispatchers.IO) { agentCall(example) }
-}
+fun asTask(scope: CoroutineScope = GlobalScope, agentCall: suspend (Example) -> TaskResult): AsyncTask =
+    AsyncTask { example ->
+        scope.future(Dispatchers.IO) { agentCall(example) }
+    }
 
 /**
  * Adapts a `suspend` agent call that returns the model output text into a Dokimos [AsyncTask].
@@ -103,14 +101,12 @@ fun asTask(
  * @throws IllegalArgumentException if the agent response content is blank.
  */
 @OptIn(DelicateCoroutinesApi::class)
-fun asTextTask(
-    scope: CoroutineScope = GlobalScope,
-    agentCall: suspend (String) -> String,
-): AsyncTask = asTask(scope) { example ->
-    val content = agentCall(example.input())
-    require(content.isNotBlank()) { "Agent response content was blank" }
-    TaskResult.of(mapOf(OUTPUT_KEY to content))
-}
+fun asTextTask(scope: CoroutineScope = GlobalScope, agentCall: suspend (String) -> String): AsyncTask =
+    asTask(scope) { example ->
+        val content = agentCall(example.input())
+        require(content.isNotBlank()) { "Agent response content was blank" }
+        TaskResult.of(mapOf(OUTPUT_KEY to content))
+    }
 
 /**
  * Executes the `run` method of the `AIAgent` in a blocking coroutine context.

--- a/dokimos-koog/src/main/kotlin/dev/dokimos/koog/KoogSupport.kt
+++ b/dokimos-koog/src/main/kotlin/dev/dokimos/koog/KoogSupport.kt
@@ -64,10 +64,13 @@ fun asJudge(agent: () -> AIAgent<String, String>): JudgeLM = asJudge { input -> 
  * through [dev.dokimos.core.Experiment.Builder.asyncTask] without [runBlocking] holding a thread per
  * example.
  *
- * Each invocation launches the suspend body on the given [scope] (the [Dispatchers.IO] dispatcher by
- * default) and bridges the coroutine to a [java.util.concurrent.CompletableFuture] via the
- * kotlinx-coroutines `future` builder. A suspend exception surfaces as an exceptionally completed
- * future, which the experiment isolates as a failed item while the run continues.
+ * Each invocation launches the suspend body on the given [scope] (default [GlobalScope]) using the
+ * [Dispatchers.IO] dispatcher, and bridges the coroutine to a [java.util.concurrent.CompletableFuture]
+ * via the kotlinx-coroutines `future` builder. A suspend exception surfaces as an exceptionally
+ * completed future, which the experiment isolates as a failed item while the run continues.
+ *
+ * [GlobalScope] is the default because this is a fire-and-bridge-to-future adapter with no parent
+ * lifecycle to inherit; pass your own [scope] to opt into structured concurrency.
  *
  * The suspend body receives the full [Example] and returns a [TaskResult] (use [TaskResult.of] when
  * there are no call metrics).

--- a/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogSupportTest.kt
+++ b/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogSupportTest.kt
@@ -43,6 +43,26 @@ class KoogSupportTest {
     }
 
     @Test
+    fun `asJudge with agent factory invokes the factory on each generate`() {
+        // The factory overload's contract is a FRESH agent per invocation: capturing a single instance
+        // instead would break statefulness in real multi-example runs. Assert the factory runs once per
+        // generate() and both calls return the agent's response.
+        val calls = java.util.concurrent.atomic.AtomicInteger()
+        val factory: () -> AIAgent<String, String> = {
+            calls.incrementAndGet()
+            mockAgent("agent response")
+        }
+        val judge = asJudge(factory)
+
+        val first = judge.generate("a")
+        val second = judge.generate("b")
+
+        assertThat(calls.get()).isEqualTo(2)
+        assertThat(first).isEqualTo("agent response")
+        assertThat(second).isEqualTo("agent response")
+    }
+
+    @Test
     fun `asJudge rejects blank responses`() {
         val judge = asJudge { _ -> "" }
 
@@ -118,7 +138,7 @@ class KoogSupportTest {
     companion object {
         fun exampleWith(input: String): Example = Example.builder().input("input", input).build()
 
-        fun mockAgent(modelResponse: String) = AIAgent(
+        fun mockAgent(modelResponse: String): AIAgent<String, String> = AIAgent(
             promptExecutor = getMockExecutor {
                 mockLLMAnswer(modelResponse).asDefaultResponse
             },

--- a/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogSupportTest.kt
+++ b/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogSupportTest.kt
@@ -6,10 +6,15 @@ import ai.koog.agents.testing.feature.withTesting
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLModel
+import dev.dokimos.core.Example
+import dev.dokimos.core.TaskResult
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ExecutionException
 
 class KoogSupportTest {
 
@@ -46,7 +51,74 @@ class KoogSupportTest {
             .hasMessageContaining("blank")
     }
 
+    @Test
+    fun `asTask produces a future that completes with the TaskResult`() {
+        val agentCall = mockk<suspend (Example) -> TaskResult>()
+        coEvery { agentCall(any()) } returns TaskResult.of(mapOf("output" to "HELLO"))
+
+        val asyncTask = asTask(agentCall = agentCall)
+        val result = asyncTask.run(exampleWith("hello")).get()
+
+        assertThat(result.outputs()).containsEntry("output", "HELLO")
+        assertThat(result.metrics()).isNull()
+        coVerify(exactly = 1) { agentCall(any()) }
+    }
+
+    @Test
+    fun `asTask carries metrics through the TaskResult`() {
+        val metrics = dev.dokimos.core.CallMetrics(3, 5, 0.01, 42L)
+        val agentCall = mockk<suspend (Example) -> TaskResult>()
+        coEvery { agentCall(any()) } returns TaskResult(mapOf("output" to "x"), metrics)
+
+        val result = asTask(agentCall = agentCall).run(exampleWith("q")).get()
+
+        assertThat(result.metrics()).isEqualTo(metrics)
+    }
+
+    @Test
+    fun `asTask surfaces a failing suspend call as an exceptional future`() {
+        val agentCall = mockk<suspend (Example) -> TaskResult>()
+        coEvery { agentCall(any()) } throws IllegalStateException("boom")
+
+        val future = asTask(agentCall = agentCall).run(exampleWith("q"))
+
+        assertThatThrownBy { future.get() }
+            .isInstanceOf(ExecutionException::class.java)
+            .hasRootCauseInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("boom")
+        assertThat(future.isCompletedExceptionally).isTrue()
+    }
+
+    @Test
+    fun `asTextTask stores the agent response under the output key`() {
+        val agentCall = mockk<suspend (String) -> String>()
+        coEvery { agentCall(any()) } returns "Model response"
+
+        val result = asTextTask(agentCall = agentCall).run(exampleWith("evaluate me")).get()
+
+        assertThat(result.outputs()).containsEntry("output", "Model response")
+        assertThat(result.metrics()).isNull()
+        coVerify(exactly = 1) { agentCall("evaluate me") }
+    }
+
+    @Test
+    fun `asTextTask rejects a blank response as a failed future`() {
+        val agentCall = mockk<suspend (String) -> String>()
+        coEvery { agentCall(any()) } returns ""
+
+        val future = asTextTask(agentCall = agentCall).run(exampleWith("q"))
+
+        assertThatThrownBy { future.get() }
+            .isInstanceOf(ExecutionException::class.java)
+            .hasRootCauseInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("blank")
+        assertThat(future.isCompletedExceptionally).isTrue()
+    }
+
     companion object {
+        fun exampleWith(input: String): Example =
+            Example.builder().input("input", input).build()
+
         fun mockAgent(modelResponse: String) = AIAgent(
             promptExecutor = getMockExecutor {
                 mockLLMAnswer(modelResponse).asDefaultResponse

--- a/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogSupportTest.kt
+++ b/dokimos-koog/src/test/kotlin/dev/dokimos/koog/KoogSupportTest.kt
@@ -116,8 +116,7 @@ class KoogSupportTest {
     }
 
     companion object {
-        fun exampleWith(input: String): Example =
-            Example.builder().input("input", input).build()
+        fun exampleWith(input: String): Example = Example.builder().input("input", input).build()
 
         fun mockAgent(modelResponse: String) = AIAgent(
             promptExecutor = getMockExecutor {

--- a/dokimos-kotlin/pom.xml
+++ b/dokimos-kotlin/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
             <version>${kotlinx.coroutines.version}</version>

--- a/dokimos-kotlin/pom.xml
+++ b/dokimos-kotlin/pom.xml
@@ -12,6 +12,8 @@
 
     <properties>
         <kotlin.version>2.3.10</kotlin.version>
+        <kotlinx.coroutines.version>1.9.0</kotlinx.coroutines.version>
+        <mockk.version>1.14.6</mockk.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
@@ -49,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>${kotlinx.coroutines.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
@@ -57,6 +65,20 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-test</artifactId>
+            <version>${kotlinx.coroutines.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>${mockk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/TypedReads.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/TypedReads.kt
@@ -1,0 +1,154 @@
+package dev.dokimos.kotlin.core
+
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.core.Example
+import dev.dokimos.core.OutputType
+import dev.dokimos.core.agents.ToolCall
+
+/**
+ * Captures a full generic type [T] (including its type arguments) into an [OutputType] super-type
+ * token so it survives Kotlin's reified erasure.
+ *
+ * The reified read extensions below delegate to this rather than to `T::class.java` so that generic
+ * targets such as `List<Whisky>` or `Map<String, Int>` round-trip correctly. The anonymous subclass
+ * `object : OutputType<T>() {}` records [T] in its generic supertype exactly as the Java idiom
+ * `new OutputType<List<Whisky>>() {}` does.
+ *
+ * @param T the captured target type
+ * @return an [OutputType] token carrying the full generic type of [T]
+ */
+inline fun <reified T> outputType(): OutputType<T> = object : OutputType<T>() {}
+
+/**
+ * Reads the primary actual output (`"output"`) converted to the reified type [T].
+ *
+ * Delegates to [EvalTestCase.actualOutputAs] with an [outputType] token, so generic targets like
+ * `List<Whisky>` survive erasure.
+ *
+ * @param T the target type
+ * @return the converted value, or `null` if absent
+ */
+inline fun <reified T> EvalTestCase.actualOutputAs(): T? = actualOutputAs(outputType<T>())
+
+/**
+ * Reads the actual output under [key] converted to the reified type [T].
+ *
+ * @param key the actual-output key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> EvalTestCase.actualOutputAs(key: String): T? = actualOutputAs(key, outputType<T>())
+
+/**
+ * Reads the primary expected output (`"output"`) converted to the reified type [T].
+ *
+ * @param T the target type
+ * @return the converted value, or `null` if absent
+ */
+inline fun <reified T> EvalTestCase.expectedOutputAs(): T? = expectedOutputAs(outputType<T>())
+
+/**
+ * Reads the expected output under [key] converted to the reified type [T].
+ *
+ * @param key the expected-output key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> EvalTestCase.expectedOutputAs(key: String): T? = expectedOutputAs(key, outputType<T>())
+
+/**
+ * Reads the primary input (`"input"`) converted to the reified type [T].
+ *
+ * @param T the target type
+ * @return the converted value, or `null` if absent
+ */
+inline fun <reified T> EvalTestCase.inputAs(): T? = inputAs(outputType<T>())
+
+/**
+ * Reads the input under [key] converted to the reified type [T].
+ *
+ * @param key the input key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> EvalTestCase.inputAs(key: String): T? = inputAs(key, outputType<T>())
+
+/**
+ * Reads the metadata under [key] converted to the reified type [T].
+ *
+ * @param key the metadata key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> EvalTestCase.metadataAs(key: String): T? = metadataAs(key, outputType<T>())
+
+/**
+ * Reads the primary expected output (`"output"`) converted to the reified type [T].
+ *
+ * @param T the target type
+ * @return the converted value, or `null` if absent
+ */
+inline fun <reified T> Example.expectedOutputAs(): T? = expectedOutputAs(outputType<T>())
+
+/**
+ * Reads the expected output under [key] converted to the reified type [T].
+ *
+ * @param key the expected-output key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> Example.expectedOutputAs(key: String): T? = expectedOutputAs(key, outputType<T>())
+
+/**
+ * Reads the primary input (`"input"`) converted to the reified type [T].
+ *
+ * @param T the target type
+ * @return the converted value, or `null` if absent
+ */
+inline fun <reified T> Example.inputAs(): T? = inputAs(outputType<T>())
+
+/**
+ * Reads the input under [key] converted to the reified type [T].
+ *
+ * @param key the input key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> Example.inputAs(key: String): T? = inputAs(key, outputType<T>())
+
+/**
+ * Reads the metadata under [key] converted to the reified type [T].
+ *
+ * @param key the metadata key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> Example.metadataAs(key: String): T? = metadataAs(key, outputType<T>())
+
+/**
+ * Deserializes this tool call's `result` string into the reified type [T].
+ *
+ * Delegates to [ToolCall.resultAs] with an [outputType] token, so generic targets like
+ * `List<Order>` survive erasure. Like the Java method, a `null`/blank/JSON-null result yields `null`.
+ *
+ * @param T the target type
+ * @return the deserialized result, or `null` if the result is `null`/blank/JSON null
+ */
+inline fun <reified T> ToolCall.resultAs(): T? = resultAs(outputType<T>())
+
+/**
+ * Converts this tool call's `arguments` map into the reified type [T].
+ *
+ * @param T the target type
+ * @return the converted arguments
+ */
+inline fun <reified T> ToolCall.argumentsAs(): T = argumentsAs(outputType<T>())
+
+/**
+ * Reads the metadata under [key] converted to the reified type [T].
+ *
+ * @param key the metadata key
+ * @param T the target type
+ * @return the converted value, or `null` if [key] is absent
+ */
+inline fun <reified T> ToolCall.metadataAs(key: String): T? = metadataAs(key, outputType<T>())

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/TypedReads.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/TypedReads.kt
@@ -1,18 +1,21 @@
 package dev.dokimos.kotlin.core
 
+import com.fasterxml.jackson.databind.JavaType
 import dev.dokimos.core.EvalTestCase
 import dev.dokimos.core.Example
 import dev.dokimos.core.OutputType
 import dev.dokimos.core.agents.ToolCall
+import dev.dokimos.core.exceptions.DokimosTypeConversionException
+import dev.dokimos.kotlin.core.internal.KotlinJson
 
 /**
  * Captures a full generic type [T] (including its type arguments) into an [OutputType] super-type
  * token so it survives Kotlin's reified erasure.
  *
- * The reified read extensions below delegate to this rather than to `T::class.java` so that generic
- * targets such as `List<Whisky>` or `Map<String, Int>` round-trip correctly. The anonymous subclass
- * `object : OutputType<T>() {}` records [T] in its generic supertype exactly as the Java idiom
- * `new OutputType<List<Whisky>>() {}` does.
+ * The reified read extensions below use the [Type][OutputType.getType] this token records to resolve a
+ * Jackson `JavaType`, so generic targets such as `List<Whisky>` or `Map<String, Int>` round-trip
+ * correctly. The anonymous subclass `object : OutputType<T>() {}` records [T] in its generic supertype
+ * exactly as the Java idiom `new OutputType<List<Whisky>>() {}` does.
  *
  * @param T the captured target type
  * @return an [OutputType] token carrying the full generic type of [T]
@@ -20,15 +23,61 @@ import dev.dokimos.core.agents.ToolCall
 inline fun <reified T> outputType(): OutputType<T> = object : OutputType<T>() {}
 
 /**
+ * Resolves the Jackson [JavaType] for a reified target [T] via an [outputType] token, so generic
+ * targets survive erasure. Published so the inline extensions below can reference it; not part of the
+ * supported API surface.
+ *
+ * @param T the captured target type
+ * @return the resolved Jackson type
+ */
+@PublishedApi
+internal inline fun <reified T> javaTypeOf(): JavaType = KotlinJson.resolveType(outputType<T>().type)
+
+/**
+ * Converts an already-deserialized [value] into [type] through the Kotlin-aware mapper, wrapping any
+ * conversion failure in [DokimosTypeConversionException]. An absent or `null` [value] yields `null`.
+ *
+ * dokimos-core stays Java-only, so this routes through [KotlinJson] (which registers the Kotlin
+ * module) rather than the core accessor, letting a plain unannotated Kotlin data class read back.
+ */
+@PublishedApi
+internal fun <T> convertValue(value: Any?, type: JavaType): T? {
+    if (value == null) {
+        return null
+    }
+    return try {
+        KotlinJson.convert(value, type)
+    } catch (e: IllegalArgumentException) {
+        throw DokimosTypeConversionException("Failed to convert value to $type", e)
+    }
+}
+
+/**
+ * Parses [json] into [type] through the Kotlin-aware mapper, wrapping any failure in
+ * [DokimosTypeConversionException]. A `null` or blank [json] yields `null`.
+ */
+@PublishedApi
+internal fun <T> readJson(json: String?, type: JavaType): T? {
+    if (json.isNullOrBlank()) {
+        return null
+    }
+    return try {
+        KotlinJson.read(json, type)
+    } catch (e: Exception) {
+        throw DokimosTypeConversionException("Failed to parse JSON as $type", e)
+    }
+}
+
+/**
  * Reads the primary actual output (`"output"`) converted to the reified type [T].
  *
- * Delegates to [EvalTestCase.actualOutputAs] with an [outputType] token, so generic targets like
- * `List<Whisky>` survive erasure.
+ * Converts the raw value through the Kotlin-aware mapper, so generic targets like `List<Whisky>`
+ * survive erasure and a plain unannotated Kotlin data class reads back.
  *
  * @param T the target type
  * @return the converted value, or `null` if absent
  */
-inline fun <reified T> EvalTestCase.actualOutputAs(): T? = actualOutputAs(outputType<T>())
+inline fun <reified T> EvalTestCase.actualOutputAs(): T? = actualOutputAs("output")
 
 /**
  * Reads the actual output under [key] converted to the reified type [T].
@@ -37,7 +86,8 @@ inline fun <reified T> EvalTestCase.actualOutputAs(): T? = actualOutputAs(output
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> EvalTestCase.actualOutputAs(key: String): T? = actualOutputAs(key, outputType<T>())
+inline fun <reified T> EvalTestCase.actualOutputAs(key: String): T? =
+    convertValue(actualOutputs()[key], javaTypeOf<T>())
 
 /**
  * Reads the primary expected output (`"output"`) converted to the reified type [T].
@@ -45,7 +95,7 @@ inline fun <reified T> EvalTestCase.actualOutputAs(key: String): T? = actualOutp
  * @param T the target type
  * @return the converted value, or `null` if absent
  */
-inline fun <reified T> EvalTestCase.expectedOutputAs(): T? = expectedOutputAs(outputType<T>())
+inline fun <reified T> EvalTestCase.expectedOutputAs(): T? = expectedOutputAs("output")
 
 /**
  * Reads the expected output under [key] converted to the reified type [T].
@@ -54,7 +104,8 @@ inline fun <reified T> EvalTestCase.expectedOutputAs(): T? = expectedOutputAs(ou
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> EvalTestCase.expectedOutputAs(key: String): T? = expectedOutputAs(key, outputType<T>())
+inline fun <reified T> EvalTestCase.expectedOutputAs(key: String): T? =
+    convertValue(expectedOutputs()[key], javaTypeOf<T>())
 
 /**
  * Reads the primary input (`"input"`) converted to the reified type [T].
@@ -62,7 +113,7 @@ inline fun <reified T> EvalTestCase.expectedOutputAs(key: String): T? = expected
  * @param T the target type
  * @return the converted value, or `null` if absent
  */
-inline fun <reified T> EvalTestCase.inputAs(): T? = inputAs(outputType<T>())
+inline fun <reified T> EvalTestCase.inputAs(): T? = inputAs("input")
 
 /**
  * Reads the input under [key] converted to the reified type [T].
@@ -71,7 +122,7 @@ inline fun <reified T> EvalTestCase.inputAs(): T? = inputAs(outputType<T>())
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> EvalTestCase.inputAs(key: String): T? = inputAs(key, outputType<T>())
+inline fun <reified T> EvalTestCase.inputAs(key: String): T? = convertValue(inputs()[key], javaTypeOf<T>())
 
 /**
  * Reads the metadata under [key] converted to the reified type [T].
@@ -80,7 +131,7 @@ inline fun <reified T> EvalTestCase.inputAs(key: String): T? = inputAs(key, outp
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> EvalTestCase.metadataAs(key: String): T? = metadataAs(key, outputType<T>())
+inline fun <reified T> EvalTestCase.metadataAs(key: String): T? = convertValue(metadata()[key], javaTypeOf<T>())
 
 /**
  * Reads the primary expected output (`"output"`) converted to the reified type [T].
@@ -88,7 +139,7 @@ inline fun <reified T> EvalTestCase.metadataAs(key: String): T? = metadataAs(key
  * @param T the target type
  * @return the converted value, or `null` if absent
  */
-inline fun <reified T> Example.expectedOutputAs(): T? = expectedOutputAs(outputType<T>())
+inline fun <reified T> Example.expectedOutputAs(): T? = expectedOutputAs("output")
 
 /**
  * Reads the expected output under [key] converted to the reified type [T].
@@ -97,7 +148,7 @@ inline fun <reified T> Example.expectedOutputAs(): T? = expectedOutputAs(outputT
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> Example.expectedOutputAs(key: String): T? = expectedOutputAs(key, outputType<T>())
+inline fun <reified T> Example.expectedOutputAs(key: String): T? = convertValue(expectedOutputs()[key], javaTypeOf<T>())
 
 /**
  * Reads the primary input (`"input"`) converted to the reified type [T].
@@ -105,7 +156,7 @@ inline fun <reified T> Example.expectedOutputAs(key: String): T? = expectedOutpu
  * @param T the target type
  * @return the converted value, or `null` if absent
  */
-inline fun <reified T> Example.inputAs(): T? = inputAs(outputType<T>())
+inline fun <reified T> Example.inputAs(): T? = inputAs("input")
 
 /**
  * Reads the input under [key] converted to the reified type [T].
@@ -114,7 +165,7 @@ inline fun <reified T> Example.inputAs(): T? = inputAs(outputType<T>())
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> Example.inputAs(key: String): T? = inputAs(key, outputType<T>())
+inline fun <reified T> Example.inputAs(key: String): T? = convertValue(inputs()[key], javaTypeOf<T>())
 
 /**
  * Reads the metadata under [key] converted to the reified type [T].
@@ -123,18 +174,19 @@ inline fun <reified T> Example.inputAs(key: String): T? = inputAs(key, outputTyp
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> Example.metadataAs(key: String): T? = metadataAs(key, outputType<T>())
+inline fun <reified T> Example.metadataAs(key: String): T? = convertValue(metadata()[key], javaTypeOf<T>())
 
 /**
  * Deserializes this tool call's `result` string into the reified type [T].
  *
- * Delegates to [ToolCall.resultAs] with an [outputType] token, so generic targets like
- * `List<Order>` survive erasure. Like the Java method, a `null`/blank/JSON-null result yields `null`.
+ * Parses the result JSON through the Kotlin-aware mapper, so generic targets like `List<Order>`
+ * survive erasure and a plain unannotated Kotlin data class reads back. Like the Java method, a
+ * `null`/blank/JSON-null result yields `null`.
  *
  * @param T the target type
  * @return the deserialized result, or `null` if the result is `null`/blank/JSON null
  */
-inline fun <reified T> ToolCall.resultAs(): T? = resultAs(outputType<T>())
+inline fun <reified T> ToolCall.resultAs(): T? = readJson(result(), javaTypeOf<T>())
 
 /**
  * Converts this tool call's `arguments` map into the reified type [T].
@@ -142,7 +194,7 @@ inline fun <reified T> ToolCall.resultAs(): T? = resultAs(outputType<T>())
  * @param T the target type
  * @return the converted arguments
  */
-inline fun <reified T> ToolCall.argumentsAs(): T = argumentsAs(outputType<T>())
+inline fun <reified T> ToolCall.argumentsAs(): T = convertValue<T>(arguments(), javaTypeOf<T>()) as T
 
 /**
  * Reads the metadata under [key] converted to the reified type [T].
@@ -151,4 +203,4 @@ inline fun <reified T> ToolCall.argumentsAs(): T = argumentsAs(outputType<T>())
  * @param T the target type
  * @return the converted value, or `null` if [key] is absent
  */
-inline fun <reified T> ToolCall.metadataAs(key: String): T? = metadataAs(key, outputType<T>())
+inline fun <reified T> ToolCall.metadataAs(key: String): T? = convertValue(metadata()[key], javaTypeOf<T>())

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/internal/KotlinJson.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/internal/KotlinJson.kt
@@ -1,0 +1,58 @@
+package dev.dokimos.kotlin.core.internal
+
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+/**
+ * Framework-internal, Kotlin-aware JSON utilities for the reified typed-read extensions.
+ *
+ * dokimos-core's `internal.Json` mapper is deliberately Java-only — it registers no Kotlin module, so
+ * it cannot construct a plain (unannotated) Kotlin data class, whose constructor parameter names are
+ * invisible to Jackson without the Kotlin module. The Kotlin reified extensions therefore convert raw
+ * values through this mapper instead of delegating to the core accessor.
+ *
+ * The [ObjectMapper] is built once via [jacksonObjectMapper] (which registers `KotlinModule`),
+ * stored as an immutable singleton, and never mutated afterwards — so it is safe to share across the
+ * parallel experiment runs Dokimos performs. Only the thread-safe [convertValue] and reader views are
+ * exercised here.
+ */
+@PublishedApi
+internal object KotlinJson {
+
+    private val MAPPER: ObjectMapper = jacksonObjectMapper()
+
+    /**
+     * Converts an already-deserialized [value] (typically a `Map` or `List` read from a test case) into
+     * an instance described by the Jackson [type], without an intermediate textual round-trip.
+     *
+     * @param value the source value, or `null`
+     * @param type the target Jackson type
+     * @return the converted value, or `null` if [value] is `null`
+     */
+    fun <T> convert(value: Any?, type: JavaType): T? {
+        if (value == null) {
+            return null
+        }
+        return MAPPER.convertValue(value, type)
+    }
+
+    /**
+     * Parses a JSON [json] string into an instance described by the Jackson [type].
+     *
+     * @param json the JSON text to parse
+     * @param type the target Jackson type
+     * @return the parsed value (the JSON literal `null` parses to `null`)
+     */
+    fun <T> read(json: String, type: JavaType): T? = MAPPER.readValue(json, type)
+
+    /**
+     * Resolves a reflective [type] (the generic [java.lang.reflect.Type] captured by an `OutputType`
+     * token) into a Jackson [JavaType], so generic targets such as `List<Foo>` survive erasure.
+     *
+     * @param type the generic type to resolve
+     * @return the corresponding Jackson type
+     */
+    @PublishedApi
+    internal fun resolveType(type: java.lang.reflect.Type): JavaType = MAPPER.typeFactory.constructType(type)
+}

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
@@ -4,6 +4,11 @@ import dev.dokimos.core.*
 import dev.dokimos.core.evaluators.*
 import dev.dokimos.core.evaluators.agents.*
 import dev.dokimos.kotlin.dsl.evaluators.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
+import java.util.concurrent.CompletableFuture
 
 @DslMarker
 annotation class DokimosDsl
@@ -75,6 +80,60 @@ fun example(block: ExampleDsl.() -> Unit): Example = ExampleDsl().apply(block).b
 
 fun task(block: (Example) -> Map<String, Any>): Task = Task(block)
 
+/**
+ * Builds a [Task] that produces a single typed value and stores it under the conventional
+ * `"output"` key, delegating to [Task.typed].
+ *
+ * This is deliberately a distinct name from [task]: a reified overload named `task` would make
+ * every existing `task { mapOf(...) }` call site ambiguous and source-break callers. Use
+ * `typedTask<Whisky> { ... }` to return a record, list, or other POJO directly. If the body itself
+ * returns a [Map], that map is used as the output map directly (no double-nesting), matching the
+ * Java [Task.typed] guard.
+ *
+ * @param fn produces the typed output value for an [Example]
+ * @param T the produced value type
+ * @return a [Task] wrapping the produced value under `"output"`
+ */
+inline fun <reified T> typedTask(crossinline fn: (Example) -> T): Task =
+    Task.typed { example -> fn(example) }
+
+/**
+ * Builds an [AsyncTask] from a `suspend` function returning a [TaskResult], bridging the coroutine
+ * to a [CompletableFuture] via the kotlinx-coroutines `future` builder.
+ *
+ * This is a distinct name from [task]/[typedTask]: it produces an [AsyncTask] for the non-blocking
+ * experiment execution path. Each invocation launches the suspend body on the given [scope] (the
+ * IO dispatcher by default). A suspend exception surfaces as an exceptionally completed future,
+ * which the experiment isolates as a failed item.
+ *
+ * @param scope the coroutine scope used to launch each invocation
+ * @param fn the suspend body producing a [TaskResult] for an [Example]
+ * @return an [AsyncTask] suitable for [Experiment.Builder.asyncTask]
+ */
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+fun suspendTask(
+    scope: CoroutineScope = GlobalScope,
+    fn: suspend (Example) -> TaskResult,
+): AsyncTask = AsyncTask { example ->
+    scope.future(Dispatchers.IO) { fn(example) }
+}
+
+/**
+ * Builds an [AsyncTask] from a `suspend` function returning an output [Map], wrapping it in a
+ * [TaskResult] with no metrics. Convenience overload of [suspendTask].
+ *
+ * @param scope the coroutine scope used to launch each invocation
+ * @param fn the suspend body producing an output map for an [Example]
+ * @return an [AsyncTask] suitable for [Experiment.Builder.asyncTask]
+ */
+@OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
+fun suspendMapTask(
+    scope: CoroutineScope = GlobalScope,
+    fn: suspend (Example) -> Map<String, Any>,
+): AsyncTask = AsyncTask { example ->
+    scope.future(Dispatchers.IO) { TaskResult.of(fn(example)) }
+}
+
 @DokimosDsl
 class ExperimentDsl {
     var name: String = "unnamed"
@@ -85,6 +144,7 @@ class ExperimentDsl {
 
     private var dataset: Dataset? = null
     private var task: Task? = null
+    private var asyncTask: AsyncTask? = null
     private val evaluators: MutableList<Evaluator> = mutableListOf()
     private val metadata: MutableMap<String, Any> = mutableMapOf()
 
@@ -102,6 +162,31 @@ class ExperimentDsl {
 
     fun task(value: Task) {
         task = value
+    }
+
+    /**
+     * Sets a typed task that returns a single value stored under the `"output"` key.
+     *
+     * Distinct from [task] so the existing `task { mapOf(...) }` entry stays unambiguous. See the
+     * top-level [typedTask] for the rationale.
+     */
+    inline fun <reified T> typedTask(crossinline block: (Example) -> T) {
+        task(Task.typed { example -> block(example) })
+    }
+
+    /**
+     * Sets an [AsyncTask] directly, selecting the non-blocking experiment execution path.
+     */
+    fun asyncTask(value: AsyncTask) {
+        asyncTask = value
+    }
+
+    /**
+     * Sets an async task from a `suspend` function returning a [TaskResult]. See the top-level
+     * [suspendTask] for bridging details.
+     */
+    fun suspendTask(scope: CoroutineScope = GlobalScope, block: suspend (Example) -> TaskResult) {
+        asyncTask = dev.dokimos.kotlin.dsl.suspendTask(scope, block)
     }
 
     fun evaluators(block: EvaluatorsDsl.() -> Unit) {
@@ -130,18 +215,23 @@ class ExperimentDsl {
 
     fun build(): Experiment {
         val selectedDataset = dataset ?: error("dataset must be set")
-        val selectedTask = task ?: error("task must be set")
 
         val builder = Experiment.builder()
             .name(name)
             .description(description)
             .dataset(selectedDataset)
-            .task(selectedTask)
             .evaluators(evaluators)
             .metadata(metadata)
             .reporter(reporter)
             .parallelism(parallelism)
             .runs(runs)
+
+        asyncTask?.let { builder.asyncTask(it) }
+        task?.let { builder.task(it) }
+
+        if (task == null && asyncTask == null) {
+            error("task or asyncTask must be set")
+        }
 
         return builder.build()
     }

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
@@ -84,39 +84,33 @@ fun task(block: (Example) -> Map<String, Any>): Task = Task(block)
  * Builds a [Task] that produces a single typed value and stores it under the conventional
  * `"output"` key, delegating to [Task.typed].
  *
- * This is deliberately a distinct name from [task]: a reified overload named `task` would make
- * every existing `task { mapOf(...) }` call site ambiguous and source-break callers. Use
- * `typedTask<Whisky> { ... }` to return a record, list, or other POJO directly. If the body itself
- * returns a [Map], that map is used as the output map directly (no double-nesting), matching the
- * Java [Task.typed] guard.
+ * Use `typedTask<Whisky> { ... }` to return a record, list, or other POJO directly. If the body
+ * itself returns a [Map], that map is used as the output map directly (no double-nesting), matching
+ * the Java [Task.typed] guard.
  *
  * @param fn produces the typed output value for an [Example]
  * @param T the produced value type
  * @return a [Task] wrapping the produced value under `"output"`
  */
-inline fun <reified T> typedTask(crossinline fn: (Example) -> T): Task =
-    Task.typed { example -> fn(example) }
+inline fun <reified T> typedTask(crossinline fn: (Example) -> T): Task = Task.typed { example -> fn(example) }
 
 /**
  * Builds an [AsyncTask] from a `suspend` function returning a [TaskResult], bridging the coroutine
  * to a [CompletableFuture] via the kotlinx-coroutines `future` builder.
  *
- * This is a distinct name from [task]/[typedTask]: it produces an [AsyncTask] for the non-blocking
- * experiment execution path. Each invocation launches the suspend body on the given [scope] (the
- * IO dispatcher by default). A suspend exception surfaces as an exceptionally completed future,
- * which the experiment isolates as a failed item.
+ * Produces an [AsyncTask] for the non-blocking experiment execution path. Each invocation launches
+ * the suspend body on the given [scope] (the IO dispatcher by default). A suspend exception surfaces
+ * as an exceptionally completed future, which the experiment isolates as a failed item.
  *
  * @param scope the coroutine scope used to launch each invocation
  * @param fn the suspend body producing a [TaskResult] for an [Example]
  * @return an [AsyncTask] suitable for [Experiment.Builder.asyncTask]
  */
 @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-fun suspendTask(
-    scope: CoroutineScope = GlobalScope,
-    fn: suspend (Example) -> TaskResult,
-): AsyncTask = AsyncTask { example ->
-    scope.future(Dispatchers.IO) { fn(example) }
-}
+fun suspendTask(scope: CoroutineScope = GlobalScope, fn: suspend (Example) -> TaskResult): AsyncTask =
+    AsyncTask { example ->
+        scope.future(Dispatchers.IO) { fn(example) }
+    }
 
 /**
  * Builds an [AsyncTask] from a `suspend` function returning an output [Map], wrapping it in a
@@ -127,12 +121,10 @@ fun suspendTask(
  * @return an [AsyncTask] suitable for [Experiment.Builder.asyncTask]
  */
 @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
-fun suspendMapTask(
-    scope: CoroutineScope = GlobalScope,
-    fn: suspend (Example) -> Map<String, Any>,
-): AsyncTask = AsyncTask { example ->
-    scope.future(Dispatchers.IO) { TaskResult.of(fn(example)) }
-}
+fun suspendMapTask(scope: CoroutineScope = GlobalScope, fn: suspend (Example) -> Map<String, Any>): AsyncTask =
+    AsyncTask { example ->
+        scope.future(Dispatchers.IO) { TaskResult.of(fn(example)) }
+    }
 
 @DokimosDsl
 class ExperimentDsl {
@@ -165,10 +157,8 @@ class ExperimentDsl {
     }
 
     /**
-     * Sets a typed task that returns a single value stored under the `"output"` key.
-     *
-     * Distinct from [task] so the existing `task { mapOf(...) }` entry stays unambiguous. See the
-     * top-level [typedTask] for the rationale.
+     * Sets a typed task that returns a single value stored under the `"output"` key. See the
+     * top-level [typedTask] for the [Map]-return guard.
      */
     inline fun <reified T> typedTask(crossinline block: (Example) -> T) {
         task(Task.typed { example -> block(example) })

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/TypedReadsTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/TypedReadsTest.kt
@@ -1,7 +1,5 @@
 package dev.dokimos.kotlin.core
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonProperty
 import dev.dokimos.core.EvalTestCase
 import dev.dokimos.core.Example
 import dev.dokimos.core.agents.ToolCall
@@ -11,14 +9,12 @@ import org.junit.jupiter.api.Test
 
 class TypedReadsTest {
 
-    // Annotated so the framework's Java-only Jackson mapper (no kotlin module) can construct this
-    // data class from a map; the constructor parameter names are otherwise invisible to Jackson.
-    data class Whisky
-    @JsonCreator
-    constructor(
-        @JsonProperty("name") val name: String,
-        @JsonProperty("age") val age: Int,
-    )
+    // A PLAIN Kotlin data class: no Jackson annotations. The Kotlin-aware mapper in dokimos-kotlin
+    // reads it back from a map purely from its constructor parameter names.
+    data class Whisky(val name: String, val age: Int)
+
+    // A plain data class with a nullable field and a default, to confirm the Kotlin module honors both.
+    data class Distillery(val name: String, val region: String? = null, val founded: Int = 0)
 
     @Test
     fun `reified actualOutputAs reads a record back`() {
@@ -33,8 +29,8 @@ class TypedReadsTest {
 
     @Test
     fun `reified actualOutputAs preserves generics for a List of records`() {
-        // The reified extension delegates to OutputType, not T class java, so the element type of the
-        // list survives erasure and each element materializes as a Whisky rather than a raw Map.
+        // The reified extension resolves the generic JavaType from OutputType, not T class java, so the
+        // element type of the list survives erasure and each element materializes as a Whisky.
         val testCase = EvalTestCase.builder()
             .actualOutput(
                 "output",
@@ -49,6 +45,17 @@ class TypedReadsTest {
 
         assertThat(whiskies).containsExactly(Whisky("Lagavulin", 16), Whisky("Ardbeg", 10))
         assertThat(whiskies!!.first()).isInstanceOf(Whisky::class.java)
+    }
+
+    @Test
+    fun `reified actualOutputAs honors a nullable field and a default`() {
+        val testCase = EvalTestCase.builder()
+            .actualOutput("output", mapOf("name" to "Talisker"))
+            .build()
+
+        val distillery = testCase.actualOutputAs<Distillery>()
+
+        assertThat(distillery).isEqualTo(Distillery("Talisker", null, 0))
     }
 
     @Test

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/TypedReadsTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/TypedReadsTest.kt
@@ -1,0 +1,162 @@
+package dev.dokimos.kotlin.core
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.core.Example
+import dev.dokimos.core.agents.ToolCall
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class TypedReadsTest {
+
+    // Annotated so the framework's Java-only Jackson mapper (no kotlin module) can construct this
+    // data class from a map; the constructor parameter names are otherwise invisible to Jackson.
+    data class Whisky
+    @JsonCreator
+    constructor(
+        @JsonProperty("name") val name: String,
+        @JsonProperty("age") val age: Int,
+    )
+
+    @Test
+    fun `reified actualOutputAs reads a record back`() {
+        val testCase = EvalTestCase.builder()
+            .actualOutput("output", mapOf("name" to "Lagavulin", "age" to 16))
+            .build()
+
+        val whisky = testCase.actualOutputAs<Whisky>()
+
+        assertThat(whisky).isEqualTo(Whisky("Lagavulin", 16))
+    }
+
+    @Test
+    fun `reified actualOutputAs preserves generics for a List of records`() {
+        // The reified extension delegates to OutputType, not T class java, so the element type of the
+        // list survives erasure and each element materializes as a Whisky rather than a raw Map.
+        val testCase = EvalTestCase.builder()
+            .actualOutput(
+                "output",
+                listOf(
+                    mapOf("name" to "Lagavulin", "age" to 16),
+                    mapOf("name" to "Ardbeg", "age" to 10),
+                ),
+            )
+            .build()
+
+        val whiskies = testCase.actualOutputAs<List<Whisky>>()
+
+        assertThat(whiskies).containsExactly(Whisky("Lagavulin", 16), Whisky("Ardbeg", 10))
+        assertThat(whiskies!!.first()).isInstanceOf(Whisky::class.java)
+    }
+
+    @Test
+    fun `reified keyed actualOutputAs reads under a custom key`() {
+        val testCase = EvalTestCase.builder()
+            .actualOutput("pick", mapOf("name" to "Oban", "age" to 14))
+            .build()
+
+        val whisky = testCase.actualOutputAs<Whisky>("pick")
+
+        assertThat(whisky).isEqualTo(Whisky("Oban", 14))
+    }
+
+    @Test
+    fun `reified actualOutputAs returns null for an absent output`() {
+        val testCase = EvalTestCase.builder().build()
+
+        assertThat(testCase.actualOutputAs<Whisky>()).isNull()
+    }
+
+    @Test
+    fun `reified expectedOutputAs and inputAs and metadataAs read on EvalTestCase`() {
+        val testCase = EvalTestCase.builder()
+            .input("input", mapOf("name" to "Talisker", "age" to 10))
+            .expectedOutput("output", mapOf("name" to "Talisker", "age" to 10))
+            .metadata("featured", mapOf("name" to "Springbank", "age" to 15))
+            .build()
+
+        assertThat(testCase.inputAs<Whisky>()).isEqualTo(Whisky("Talisker", 10))
+        assertThat(testCase.expectedOutputAs<Whisky>()).isEqualTo(Whisky("Talisker", 10))
+        assertThat(testCase.metadataAs<Whisky>("featured")).isEqualTo(Whisky("Springbank", 15))
+    }
+
+    @Test
+    fun `reified readers work on Example`() {
+        val example = Example.builder()
+            .input("input", mapOf("name" to "Bowmore", "age" to 12))
+            .expectedOutput("output", mapOf("name" to "Bowmore", "age" to 12))
+            .metadata("featured", mapOf("name" to "Highland Park", "age" to 18))
+            .build()
+
+        assertThat(example.inputAs<Whisky>()).isEqualTo(Whisky("Bowmore", 12))
+        assertThat(example.expectedOutputAs<Whisky>()).isEqualTo(Whisky("Bowmore", 12))
+        assertThat(example.metadataAs<Whisky>("featured")).isEqualTo(Whisky("Highland Park", 18))
+    }
+
+    @Test
+    fun `reified resultAs reads a record back from a tool call`() {
+        val toolCall = ToolCall.builder()
+            .name("lookup")
+            .resultJson(Whisky("Macallan", 18))
+            .build()
+
+        val whisky = toolCall.resultAs<Whisky>()
+
+        assertThat(whisky).isEqualTo(Whisky("Macallan", 18))
+    }
+
+    @Test
+    fun `reified resultAs preserves generics for a List of records`() {
+        val toolCall = ToolCall.builder()
+            .name("search")
+            .resultJson(listOf(Whisky("Macallan", 18), Whisky("Glenlivet", 12)))
+            .build()
+
+        val whiskies = toolCall.resultAs<List<Whisky>>()
+
+        assertThat(whiskies).containsExactly(Whisky("Macallan", 18), Whisky("Glenlivet", 12))
+        assertThat(whiskies!!.first()).isInstanceOf(Whisky::class.java)
+    }
+
+    @Test
+    fun `reified argumentsAs converts the arguments map`() {
+        val toolCall = ToolCall.builder()
+            .name("create")
+            .argument("name", "Dalmore")
+            .argument("age", 12)
+            .build()
+
+        val whisky = toolCall.argumentsAs<Whisky>()
+
+        assertThat(whisky).isEqualTo(Whisky("Dalmore", 12))
+    }
+
+    @Test
+    fun `reified metadataAs reads a tool call metadata entry`() {
+        val toolCall = ToolCall.builder()
+            .name("create")
+            .metadata("featured", mapOf("name" to "Aberlour", "age" to 16))
+            .build()
+
+        assertThat(toolCall.metadataAs<Whisky>("featured")).isEqualTo(Whisky("Aberlour", 16))
+    }
+
+    @Test
+    fun `reified resultAs returns null for a blank result`() {
+        val toolCall = ToolCall.builder().name("noop").build()
+
+        assertThat(toolCall.resultAs<Whisky>()).isNull()
+    }
+
+    @Test
+    fun `reified actualOutputAs wraps a conversion failure`() {
+        val testCase = EvalTestCase.builder()
+            .actualOutput("output", mapOf("name" to "x", "age" to "not-a-number"))
+            .build()
+
+        assertThatThrownBy { testCase.actualOutputAs<Whisky>() }
+            .isInstanceOf(dev.dokimos.core.exceptions.DokimosTypeConversionException::class.java)
+    }
+}

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
@@ -52,29 +52,28 @@ class TaskDslTest {
     }
 
     @Test
-    fun `experiment DSL lets asyncTask win when both task and asyncTask are configured`() {
-        // The DSL forwards both to the builder; Experiment runs the async path first, so asyncTask takes
-        // precedence and the sync task is silently ignored. Pin that precedence: the run must produce the
-        // async output, not the sync one.
-        val result = experiment {
-            name = "both-tasks-experiment"
-            dataset {
-                name = "ds"
-                example {
-                    input = "hello"
-                    expected = "ASYNC"
+    fun `experiment DSL rejects configuring both task and asyncTask`() {
+        // task and asyncTask are mutually exclusive; the builder fails fast rather than silently
+        // ignoring one.
+        assertThatThrownBy {
+            experiment {
+                name = "both-tasks-experiment"
+                dataset {
+                    name = "ds"
+                    example {
+                        input = "hello"
+                        expected = "ASYNC"
+                    }
+                }
+                task { mapOf("output" to "SYNC") }
+                suspendTask { TaskResult(mapOf("output" to "ASYNC"), null) }
+                evaluators {
+                    exactMatch { threshold = 1.0 }
                 }
             }
-            task { mapOf("output" to "SYNC") }
-            suspendTask { TaskResult(mapOf("output" to "ASYNC"), null) }
-            evaluators {
-                exactMatch { threshold = 1.0 }
-            }
-        }.run()
-
-        assertThat(result.itemResults()).hasSize(1)
-        assertThat(result.itemResults().first().actualOutputs()).containsEntry("output", "ASYNC")
-        assertThat(result.passRate()).isEqualTo(1.0)
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("not both")
     }
 
     @Test

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
@@ -41,6 +41,43 @@ class TaskDslTest {
     }
 
     @Test
+    fun `typedTask rejects a null produced value`() {
+        // Task.typed cannot put null into the output map; a null-returning body must throw NPE with the
+        // documented message rather than silently dropping the output.
+        val task: Task = typedTask<String?> { null }
+
+        assertThatThrownBy { task.run(exampleWith("q")) }
+            .isInstanceOf(NullPointerException::class.java)
+            .hasMessageContaining("returned null")
+    }
+
+    @Test
+    fun `experiment DSL lets asyncTask win when both task and asyncTask are configured`() {
+        // The DSL forwards both to the builder; Experiment runs the async path first, so asyncTask takes
+        // precedence and the sync task is silently ignored. Pin that precedence: the run must produce the
+        // async output, not the sync one.
+        val result = experiment {
+            name = "both-tasks-experiment"
+            dataset {
+                name = "ds"
+                example {
+                    input = "hello"
+                    expected = "ASYNC"
+                }
+            }
+            task { mapOf("output" to "SYNC") }
+            suspendTask { TaskResult(mapOf("output" to "ASYNC"), null) }
+            evaluators {
+                exactMatch { threshold = 1.0 }
+            }
+        }.run()
+
+        assertThat(result.itemResults()).hasSize(1)
+        assertThat(result.itemResults().first().actualOutputs()).containsEntry("output", "ASYNC")
+        assertThat(result.passRate()).isEqualTo(1.0)
+    }
+
+    @Test
     fun `existing task DSL still compiles and runs without ambiguity`() {
         // Guards the source-compat invariant: a reified overload named `task` would break this.
         val task: Task = task { example -> mapOf("output" to example.input()) }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
@@ -1,0 +1,185 @@
+package dev.dokimos.kotlin.dsl
+
+import dev.dokimos.core.CallMetrics
+import dev.dokimos.core.Example
+import dev.dokimos.core.Task
+import dev.dokimos.core.TaskResult
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class TaskDslTest {
+
+    data class Whisky(val name: String, val age: Int)
+
+    private fun exampleWith(input: String): Example =
+        Example.builder().input("input", input).build()
+
+    @Test
+    fun `typedTask wraps the produced value under the output key`() {
+        val task: Task = typedTask { Whisky("Lagavulin", 16) }
+
+        val outputs = task.run(exampleWith("q"))
+
+        assertThat(outputs).containsExactly(
+            org.assertj.core.api.Assertions.entry("output", Whisky("Lagavulin", 16)),
+        )
+    }
+
+    @Test
+    fun `typedTask does not double-nest a map value`() {
+        val task: Task = typedTask { mapOf("output" to "world", "score" to 1) }
+
+        val outputs = task.run(exampleWith("q"))
+
+        assertThat(outputs)
+            .containsEntry("output", "world")
+            .containsEntry("score", 1)
+            .doesNotContainKey("__nested__")
+        assertThat(outputs["output"]).isEqualTo("world")
+    }
+
+    @Test
+    fun `existing task DSL still compiles and runs without ambiguity`() {
+        // Guards the source-compat invariant: a reified overload named `task` would break this.
+        val task: Task = task { example -> mapOf("output" to example.input()) }
+
+        val outputs = task.run(exampleWith("hello"))
+
+        assertThat(outputs).containsEntry("output", "hello")
+    }
+
+    @Test
+    fun `suspendTask bridges a suspend body to an AsyncTask`() {
+        val asyncTask = suspendTask { example ->
+            TaskResult(mapOf("output" to example.input().uppercase()), null)
+        }
+
+        val result = asyncTask.run(exampleWith("hello")).get()
+
+        assertThat(result.outputs()).containsEntry("output", "HELLO")
+        assertThat(result.metrics()).isNull()
+    }
+
+    @Test
+    fun `suspendTask carries metrics through the TaskResult`() {
+        val metrics = CallMetrics(3, 5, 0.01, 42L)
+        val asyncTask = suspendTask { TaskResult(mapOf("output" to "x"), metrics) }
+
+        val result = asyncTask.run(exampleWith("q")).get()
+
+        assertThat(result.metrics()).isEqualTo(metrics)
+    }
+
+    @Test
+    fun `suspendMapTask wraps an output map with no metrics`() {
+        val asyncTask = suspendMapTask { example -> mapOf("output" to example.input()) }
+
+        val result = asyncTask.run(exampleWith("hi")).get()
+
+        assertThat(result.outputs()).containsEntry("output", "hi")
+        assertThat(result.metrics()).isNull()
+    }
+
+    @Test
+    fun `suspendTask surfaces a suspend exception as a failed future`() {
+        val asyncTask = suspendTask {
+            throw IllegalStateException("boom")
+        }
+
+        val future = asyncTask.run(exampleWith("q"))
+
+        assertThatThrownBy { future.get() }
+            .isInstanceOf(java.util.concurrent.ExecutionException::class.java)
+            .hasRootCauseInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("boom")
+        assertThat(future.isCompletedExceptionally).isTrue()
+    }
+
+    @Test
+    fun `typedTask runs end to end through the experiment DSL`() {
+        val result = experiment {
+            name = "typed-task-experiment"
+            dataset {
+                name = "ds"
+                example {
+                    input = "hello"
+                    expected = "HELLO"
+                }
+            }
+            typedTask { example -> example.input().uppercase() }
+            evaluators {
+                exactMatch { threshold = 1.0 }
+            }
+        }.run()
+
+        assertThat(result.passRate()).isEqualTo(1.0)
+        assertThat(result.itemResults()).hasSize(1)
+        assertThat(result.itemResults().first().actualOutputs()).containsEntry("output", "HELLO")
+    }
+
+    @Test
+    fun `suspendTask runs end to end through the experiment DSL`() {
+        val result = experiment {
+            name = "suspend-task-experiment"
+            parallelism = 2
+            dataset {
+                name = "ds"
+                example {
+                    input = "hello"
+                    expected = "HELLO"
+                }
+            }
+            suspendTask { example ->
+                TaskResult(mapOf("output" to example.input().uppercase()), null)
+            }
+            evaluators {
+                exactMatch { threshold = 1.0 }
+            }
+        }.run()
+
+        assertThat(result.passRate()).isEqualTo(1.0)
+        assertThat(result.itemResults().first().actualOutputs()).containsEntry("output", "HELLO")
+    }
+
+    @Test
+    fun `suspendTask in the experiment DSL isolates a suspend failure as a failed item`() {
+        val result = experiment {
+            name = "suspend-fail-experiment"
+            dataset {
+                name = "ds"
+                example {
+                    input = "hello"
+                    expected = "HELLO"
+                }
+            }
+            suspendTask {
+                throw IllegalStateException("boom")
+            }
+            evaluators {
+                exactMatch { threshold = 1.0 }
+            }
+        }.run()
+
+        assertThat(result.passRate()).isEqualTo(0.0)
+        assertThat(result.itemResults()).hasSize(1)
+    }
+
+    @Test
+    fun `suspend body can call other suspend functions`() {
+        suspend fun fetch(input: String): String {
+            kotlinx.coroutines.delay(1)
+            return input.reversed()
+        }
+
+        val asyncTask = suspendTask { example ->
+            TaskResult(mapOf("output" to fetch(example.input())), null)
+        }
+
+        val output = runBlocking { asyncTask.run(exampleWith("abc")).await() }
+
+        assertThat(output.outputs()).containsEntry("output", "cba")
+    }
+}

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
@@ -14,8 +14,7 @@ class TaskDslTest {
 
     data class Whisky(val name: String, val age: Int)
 
-    private fun exampleWith(input: String): Example =
-        Example.builder().input("input", input).build()
+    private fun exampleWith(input: String): Example = Example.builder().input("input", input).build()
 
     @Test
     fun `typedTask wraps the produced value under the output key`() {

--- a/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
+++ b/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
@@ -257,12 +257,12 @@ public final class LangChain4jSupport {
     /**
      * Creates an {@link AsyncTask} for RAG evaluation from a function that returns {@link Result}.
      *
-     * <p>This is the asynchronous counterpart to {@link #ragTask(Function)}: the blocking assistant
-     * call is dispatched on the common {@link java.util.concurrent.ForkJoinPool} via
+     * <p>Async version of {@link #ragTask(Function)}: the blocking assistant call is dispatched on the
+     * common {@link java.util.concurrent.ForkJoinPool} via
      * {@link CompletableFuture#supplyAsync(java.util.function.Supplier)}, so the experiment's async
      * execution path can keep many calls in flight without a thread blocked per example. The output
      * and retrieved context are written under the {@link #OUTPUT_KEY default} and
-     * {@link #CONTEXT_KEY context} keys, mirroring {@link #ragTask(Function)}.
+     * {@link #CONTEXT_KEY context} keys.
      *
      * <p>Note: because the call blocks on the common pool, the experiment's {@code parallelism} bounds
      * how many invocations are launched, but the effective concurrency of the blocking call is also
@@ -389,9 +389,8 @@ public final class LangChain4jSupport {
     /**
      * Creates a simple {@link AsyncTask} for Q&amp;A evaluation from a LangChain4j {@link ChatModel}.
      *
-     * <p>This is the asynchronous counterpart to {@link #simpleTask(ChatModel)}: the blocking
-     * {@code model.chat(...)} call is dispatched on the common
-     * {@link java.util.concurrent.ForkJoinPool} via
+     * <p>Async version of {@link #simpleTask(ChatModel)}: the blocking {@code model.chat(...)} call is
+     * dispatched on the common {@link java.util.concurrent.ForkJoinPool} via
      * {@link CompletableFuture#supplyAsync(java.util.function.Supplier)}. The response is written
      * under the {@link #OUTPUT_KEY default output key}.
      *

--- a/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
+++ b/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
@@ -27,7 +27,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Utilities for integrating with LangChain4j.
@@ -265,8 +267,8 @@ public final class LangChain4jSupport {
      * <p>Note: because the call blocks on the common pool, the experiment's {@code parallelism} bounds
      * how many invocations are launched, but the effective concurrency of the blocking call is also
      * limited by the common pool (~one less than the CPU count), which is shared process-wide. For
-     * higher, isolated concurrency, wrap the call in your own {@link AsyncTask} backed by a dedicated
-     * {@link java.util.concurrent.Executor}.
+     * higher, isolated concurrency use the {@link Executor}-accepting overload
+     * ({@link #asyncRagTask(Function, java.util.concurrent.Executor)}) to run calls on a pool you control.
      *
      * <p>Example:
      * <pre>{@code
@@ -298,6 +300,22 @@ public final class LangChain4jSupport {
     }
 
     /**
+     * Creates an {@link AsyncTask} for RAG evaluation with default key names, dispatching each blocking
+     * assistant call on the supplied {@link Executor} so you control and isolate concurrency.
+     *
+     * @param assistantCall a function that takes the input string and returns a Result, never null
+     * @param executor      the executor each blocking call runs on, never null
+     * @return an AsyncTask suitable for RAG evaluation
+     * @throws IllegalArgumentException if {@code assistantCall} or {@code executor} is null
+     */
+    public static AsyncTask asyncRagTask(Function<String, Result<String>> assistantCall, Executor executor) {
+        if (executor == null) {
+            throw new IllegalArgumentException("executor cannot be null");
+        }
+        return asyncRagTask(assistantCall, INPUT_KEY, OUTPUT_KEY, CONTEXT_KEY, executor);
+    }
+
+    /**
      * Creates an {@link AsyncTask} for RAG evaluation with custom key names.
      *
      * <p>Behaves like {@link #asyncRagTask(Function)} but reads the input from {@code inputKey} and
@@ -313,6 +331,33 @@ public final class LangChain4jSupport {
      */
     public static AsyncTask asyncRagTask(
             Function<String, Result<String>> assistantCall, String inputKey, String outputKey, String contextKey) {
+        return asyncRagTask(assistantCall, inputKey, outputKey, contextKey, null);
+    }
+
+    /**
+     * Creates an {@link AsyncTask} for RAG evaluation that dispatches each blocking assistant call on
+     * the supplied {@link Executor} (or the common {@link java.util.concurrent.ForkJoinPool} when
+     * {@code executor} is {@code null}).
+     *
+     * <p>Supplying an executor lets you control and isolate concurrency: the experiment's
+     * {@code parallelism} bounds in-flight invocations, and a pool sized to match gives true parallel
+     * blocking calls instead of the common pool's ~CPU-count, process-wide ceiling.
+     *
+     * @param assistantCall a function that takes the input string and returns a Result, never null
+     * @param inputKey      the key to read from example inputs, never null
+     * @param outputKey     the key for the output in the result map, never null
+     * @param contextKey    the key for the retrieval context in the result map, never null
+     * @param executor      the executor each blocking call runs on, or {@code null} for the common pool
+     * @return an AsyncTask suitable for RAG evaluation
+     * @throws IllegalArgumentException if {@code assistantCall}, {@code inputKey}, {@code outputKey},
+     *     or {@code contextKey} is null
+     */
+    public static AsyncTask asyncRagTask(
+            Function<String, Result<String>> assistantCall,
+            String inputKey,
+            String outputKey,
+            String contextKey,
+            Executor executor) {
         if (assistantCall == null) {
             throw new IllegalArgumentException("assistantCall cannot be null");
         }
@@ -325,15 +370,20 @@ public final class LangChain4jSupport {
         if (contextKey == null) {
             throw new IllegalArgumentException("contextKey cannot be null");
         }
-        return example -> CompletableFuture.supplyAsync(() -> {
-            String input = (String) example.inputs().get(inputKey);
-            Result<String> result = assistantCall.apply(input);
+        return example -> {
+            Supplier<TaskResult> call = () -> {
+                String input = (String) example.inputs().get(inputKey);
+                Result<String> result = assistantCall.apply(input);
 
-            Map<String, Object> outputs = new HashMap<>();
-            outputs.put(outputKey, result.content());
-            outputs.put(contextKey, extractTexts(result.sources()));
-            return TaskResult.of(outputs);
-        });
+                Map<String, Object> outputs = new HashMap<>();
+                outputs.put(outputKey, result.content());
+                outputs.put(contextKey, extractTexts(result.sources()));
+                return TaskResult.of(outputs);
+            };
+            return executor == null
+                    ? CompletableFuture.supplyAsync(call)
+                    : CompletableFuture.supplyAsync(call, executor);
+        };
     }
 
     /**
@@ -360,6 +410,23 @@ public final class LangChain4jSupport {
     }
 
     /**
+     * Creates a simple {@link AsyncTask} for Q&amp;A evaluation with the default output key, dispatching
+     * each blocking {@code model.chat(...)} call on the supplied {@link Executor} so you control and
+     * isolate concurrency.
+     *
+     * @param model    the ChatModel to evaluate, never null
+     * @param executor the executor each blocking call runs on, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code model} or {@code executor} is null
+     */
+    public static AsyncTask asyncTask(ChatModel model, Executor executor) {
+        if (executor == null) {
+            throw new IllegalArgumentException("executor cannot be null");
+        }
+        return asyncTask(model, OUTPUT_KEY, executor);
+    }
+
+    /**
      * Creates a simple {@link AsyncTask} for Q&amp;A evaluation that writes the response under a
      * caller-chosen key.
      *
@@ -372,16 +439,40 @@ public final class LangChain4jSupport {
      * @throws IllegalArgumentException if any argument is null
      */
     public static AsyncTask asyncTask(ChatModel model, String outputKey) {
+        return asyncTask(model, outputKey, null);
+    }
+
+    /**
+     * Creates a simple {@link AsyncTask} for Q&amp;A evaluation that dispatches each blocking
+     * {@code model.chat(...)} call on the supplied {@link Executor} (or the common
+     * {@link java.util.concurrent.ForkJoinPool} when {@code executor} is {@code null}).
+     *
+     * <p>Supplying an executor lets you control and isolate concurrency: the experiment's
+     * {@code parallelism} bounds in-flight invocations, and a pool sized to match gives true parallel
+     * blocking calls instead of the common pool's ~CPU-count, process-wide ceiling.
+     *
+     * @param model     the ChatModel to evaluate, never null
+     * @param outputKey the key for the output in the result map, never null
+     * @param executor  the executor each blocking call runs on, or {@code null} for the common pool
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code model} or {@code outputKey} is null
+     */
+    public static AsyncTask asyncTask(ChatModel model, String outputKey, Executor executor) {
         if (model == null) {
             throw new IllegalArgumentException("ChatModel cannot be null");
         }
         if (outputKey == null) {
             throw new IllegalArgumentException("outputKey cannot be null");
         }
-        return example -> CompletableFuture.supplyAsync(() -> {
-            String output = model.chat(example.input());
-            return TaskResult.of(Map.of(outputKey, output != null ? output : ""));
-        });
+        return example -> {
+            Supplier<TaskResult> call = () -> {
+                String output = model.chat(example.input());
+                return TaskResult.of(Map.of(outputKey, output != null ? output : ""));
+            };
+            return executor == null
+                    ? CompletableFuture.supplyAsync(call)
+                    : CompletableFuture.supplyAsync(call, executor);
+        };
     }
 
     /**

--- a/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
+++ b/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
@@ -262,6 +262,12 @@ public final class LangChain4jSupport {
      * and retrieved context are written under the {@link #OUTPUT_KEY default} and
      * {@link #CONTEXT_KEY context} keys, mirroring {@link #ragTask(Function)}.
      *
+     * <p>Note: because the call blocks on the common pool, the experiment's {@code parallelism} bounds
+     * how many invocations are launched, but the effective concurrency of the blocking call is also
+     * limited by the common pool (~one less than the CPU count), which is shared process-wide. For
+     * higher, isolated concurrency, wrap the call in your own {@link AsyncTask} backed by a dedicated
+     * {@link java.util.concurrent.Executor}.
+     *
      * <p>Example:
      * <pre>{@code
      * interface Assistant {

--- a/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
+++ b/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
@@ -216,7 +216,7 @@ public final class LangChain4jSupport {
             Result<String> result = assistantCall.apply(input);
 
             Map<String, Object> outputs = new HashMap<>();
-            outputs.put(outputKey, result.content());
+            outputs.put(outputKey, result.content() != null ? result.content() : "");
             outputs.put(contextKey, extractTexts(result.sources()));
             return outputs;
         };
@@ -376,7 +376,7 @@ public final class LangChain4jSupport {
                 Result<String> result = assistantCall.apply(input);
 
                 Map<String, Object> outputs = new HashMap<>();
-                outputs.put(outputKey, result.content());
+                outputs.put(outputKey, result.content() != null ? result.content() : "");
                 outputs.put(contextKey, extractTexts(result.sources()));
                 return TaskResult.of(outputs);
             };

--- a/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
+++ b/dokimos-langchain4j/src/main/java/dev/dokimos/langchain4j/LangChain4jSupport.java
@@ -2,8 +2,10 @@ package dev.dokimos.langchain4j;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.AsyncTask;
 import dev.dokimos.core.JudgeLM;
 import dev.dokimos.core.Task;
+import dev.dokimos.core.TaskResult;
 import dev.dokimos.core.agents.AgentTrace;
 import dev.dokimos.core.agents.ToolCall;
 import dev.dokimos.core.agents.ToolDefinition;
@@ -24,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 /**
@@ -247,6 +250,132 @@ public final class LangChain4jSupport {
      */
     public static Task customTask(Task taskFunction) {
         return taskFunction;
+    }
+
+    /**
+     * Creates an {@link AsyncTask} for RAG evaluation from a function that returns {@link Result}.
+     *
+     * <p>This is the asynchronous counterpart to {@link #ragTask(Function)}: the blocking assistant
+     * call is dispatched on the common {@link java.util.concurrent.ForkJoinPool} via
+     * {@link CompletableFuture#supplyAsync(java.util.function.Supplier)}, so the experiment's async
+     * execution path can keep many calls in flight without a thread blocked per example. The output
+     * and retrieved context are written under the {@link #OUTPUT_KEY default} and
+     * {@link #CONTEXT_KEY context} keys, mirroring {@link #ragTask(Function)}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * interface Assistant {
+     *     Result<String> chat(String userMessage);
+     * }
+     *
+     * Assistant assistant = AiServices.builder(Assistant.class)
+     *     .chatModel(chatModel)
+     *     .retrievalAugmentor(retrievalAugmentor)
+     *     .build();
+     *
+     * AsyncTask task = LangChain4jSupport.asyncRagTask(assistant::chat);
+     *
+     * Experiment.builder()
+     *     .asyncTask(task)
+     *     .parallelism(8)
+     *     .evaluators(List.of(faithfulness, contextRelevancy))
+     *     .build()
+     *     .run();
+     * }</pre>
+     *
+     * @param assistantCall a function that takes the input string and returns a Result, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code assistantCall} is null
+     */
+    public static AsyncTask asyncRagTask(Function<String, Result<String>> assistantCall) {
+        return asyncRagTask(assistantCall, INPUT_KEY, OUTPUT_KEY, CONTEXT_KEY);
+    }
+
+    /**
+     * Creates an {@link AsyncTask} for RAG evaluation with custom key names.
+     *
+     * <p>Behaves like {@link #asyncRagTask(Function)} but reads the input from {@code inputKey} and
+     * writes the output and context under {@code outputKey} and {@code contextKey}, for datasets or
+     * evaluators that use different key names.
+     *
+     * @param assistantCall a function that takes the input string and returns a Result, never null
+     * @param inputKey      the key to read from example inputs, never null
+     * @param outputKey     the key for the output in the result map, never null
+     * @param contextKey    the key for the retrieval context in the result map, never null
+     * @return an AsyncTask suitable for RAG evaluation
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public static AsyncTask asyncRagTask(
+            Function<String, Result<String>> assistantCall, String inputKey, String outputKey, String contextKey) {
+        if (assistantCall == null) {
+            throw new IllegalArgumentException("assistantCall cannot be null");
+        }
+        if (inputKey == null) {
+            throw new IllegalArgumentException("inputKey cannot be null");
+        }
+        if (outputKey == null) {
+            throw new IllegalArgumentException("outputKey cannot be null");
+        }
+        if (contextKey == null) {
+            throw new IllegalArgumentException("contextKey cannot be null");
+        }
+        return example -> CompletableFuture.supplyAsync(() -> {
+            String input = (String) example.inputs().get(inputKey);
+            Result<String> result = assistantCall.apply(input);
+
+            Map<String, Object> outputs = new HashMap<>();
+            outputs.put(outputKey, result.content());
+            outputs.put(contextKey, extractTexts(result.sources()));
+            return TaskResult.of(outputs);
+        });
+    }
+
+    /**
+     * Creates a simple {@link AsyncTask} for Q&amp;A evaluation from a LangChain4j {@link ChatModel}.
+     *
+     * <p>This is the asynchronous counterpart to {@link #simpleTask(ChatModel)}: the blocking
+     * {@code model.chat(...)} call is dispatched on the common
+     * {@link java.util.concurrent.ForkJoinPool} via
+     * {@link CompletableFuture#supplyAsync(java.util.function.Supplier)}. The response is written
+     * under the {@link #OUTPUT_KEY default output key}.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * ChatModel model = OpenAiChatModel.builder()...build();
+     * AsyncTask task = LangChain4jSupport.asyncTask(model);
+     * }</pre>
+     *
+     * @param model the ChatModel to evaluate, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code model} is null
+     */
+    public static AsyncTask asyncTask(ChatModel model) {
+        return asyncTask(model, OUTPUT_KEY);
+    }
+
+    /**
+     * Creates a simple {@link AsyncTask} for Q&amp;A evaluation that writes the response under a
+     * caller-chosen key.
+     *
+     * <p>Behaves like {@link #asyncTask(ChatModel)} but lets you override the
+     * {@link #OUTPUT_KEY default output key}.
+     *
+     * @param model     the ChatModel to evaluate, never null
+     * @param outputKey the key for the output in the result map, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public static AsyncTask asyncTask(ChatModel model, String outputKey) {
+        if (model == null) {
+            throw new IllegalArgumentException("ChatModel cannot be null");
+        }
+        if (outputKey == null) {
+            throw new IllegalArgumentException("outputKey cannot be null");
+        }
+        return example -> CompletableFuture.supplyAsync(() -> {
+            String output = model.chat(example.input());
+            return TaskResult.of(Map.of(outputKey, output != null ? output : ""));
+        });
     }
 
     /**

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
@@ -45,6 +45,24 @@ class LangChain4jAsyncTaskTest {
     }
 
     @Test
+    void asyncRagTask_passesNullContentThroughUnderTheOutputKey() throws Exception {
+        // Contract pin: asyncRagTask (like the synchronous ragTask) writes result.content() into a
+        // HashMap with no null-coercion, so a null-content Result surfaces output == null. This is the
+        // RAG contract — deliberately distinct from asyncTask/simpleTask, which coerce null to "".
+        // Asserting it makes the asymmetry intentional: a regression that started coercing (or that
+        // switched to Map.of and NPE'd) would change this and fail here.
+        Result<String> mockResult =
+                Result.<String>builder().content(null).sources(List.of()).build();
+
+        AsyncTask task = LangChain4jSupport.asyncRagTask(input -> mockResult);
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsKey("output");
+        assertThat(result.outputs().get("output")).isNull();
+    }
+
+    @Test
     void asyncRagTask_shouldSupportCustomKeys() throws Exception {
         List<Content> sources = List.of(Content.from(TextSegment.from("Source document")));
 
@@ -111,6 +129,29 @@ class LangChain4jAsyncTaskTest {
         TaskResult result = task.run(Example.of("What is 45+2?", "47")).get();
 
         assertThat(result.outputs()).containsEntry("output", "The answer is 47");
+    }
+
+    @Test
+    void asyncTask_shouldStoreEmptyStringWhenChatReturnsNull() throws Exception {
+        // A model that yields null (e.g. an empty/tool-only completion) must be coerced to "" by the
+        // null-guard rather than passed to Map.of(...), which would NPE on the worker thread.
+        ChatModel chatModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                throw new UnsupportedOperationException("not used");
+            }
+
+            @Override
+            public String chat(String userMessage) {
+                return null;
+            }
+        };
+
+        AsyncTask task = LangChain4jSupport.asyncTask(chatModel);
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "");
     }
 
     @Test

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
@@ -92,8 +92,7 @@ class LangChain4jAsyncTaskTest {
 
     @Test
     void asyncRagTask_shouldRejectNullAssistantCall() {
-        assertThatThrownBy(() -> LangChain4jSupport.asyncRagTask(null))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LangChain4jSupport.asyncRagTask(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -135,8 +134,7 @@ class LangChain4jAsyncTaskTest {
 
     @Test
     void asyncTask_shouldRejectNullModel() {
-        assertThatThrownBy(() -> LangChain4jSupport.asyncTask(null))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LangChain4jSupport.asyncTask(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
@@ -45,12 +45,9 @@ class LangChain4jAsyncTaskTest {
     }
 
     @Test
-    void asyncRagTask_passesNullContentThroughUnderTheOutputKey() throws Exception {
-        // Contract pin: asyncRagTask (like the synchronous ragTask) writes result.content() into a
-        // HashMap with no null-coercion, so a null-content Result surfaces output == null. This is the
-        // RAG contract — deliberately distinct from asyncTask/simpleTask, which coerce null to "".
-        // Asserting it makes the asymmetry intentional: a regression that started coercing (or that
-        // switched to Map.of and NPE'd) would change this and fail here.
+    void asyncRagTask_coercesNullContentToEmptyString() throws Exception {
+        // A null-content Result is coerced to "" under the output key, consistent with
+        // asyncTask/simpleTask, so callers see one null-handling contract across the adapter.
         Result<String> mockResult =
                 Result.<String>builder().content(null).sources(List.of()).build();
 
@@ -58,8 +55,7 @@ class LangChain4jAsyncTaskTest {
 
         TaskResult result = task.run(Example.of("q", "a")).get();
 
-        assertThat(result.outputs()).containsKey("output");
-        assertThat(result.outputs().get("output")).isNull();
+        assertThat(result.outputs()).containsEntry("output", "");
     }
 
     @Test

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
@@ -138,4 +138,55 @@ class LangChain4jAsyncTaskTest {
         assertThatThrownBy(() -> LangChain4jSupport.asyncTask(null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void asyncTask_shouldRunOnProvidedExecutor() throws Exception {
+        ChatModel chatModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+            }
+        };
+        java.util.concurrent.atomic.AtomicInteger used = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.Executor executor = command -> {
+            used.incrementAndGet();
+            command.run();
+        };
+
+        AsyncTask task = LangChain4jSupport.asyncTask(chatModel, executor);
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(used.get()).isEqualTo(1);
+        assertThat(result.outputs()).containsEntry("output", "ok");
+    }
+
+    @Test
+    void asyncRagTask_shouldRunOnProvidedExecutor() throws Exception {
+        Result<String> mockResult =
+                Result.<String>builder().content("answer").sources(List.of()).build();
+        java.util.concurrent.atomic.AtomicInteger used = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.Executor executor = command -> {
+            used.incrementAndGet();
+            command.run();
+        };
+
+        AsyncTask task = LangChain4jSupport.asyncRagTask(input -> mockResult, executor);
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(used.get()).isEqualTo(1);
+        assertThat(result.outputs()).containsEntry("output", "answer");
+    }
+
+    @Test
+    void asyncTask_shouldRejectNullExecutor() {
+        ChatModel chatModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                return ChatResponse.builder().aiMessage(AiMessage.from("ok")).build();
+            }
+        };
+
+        assertThatThrownBy(() -> LangChain4jSupport.asyncTask(chatModel, (java.util.concurrent.Executor) null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/LangChain4jAsyncTaskTest.java
@@ -1,0 +1,141 @@
+package dev.dokimos.langchain4j;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.dokimos.core.AsyncTask;
+import dev.dokimos.core.Example;
+import dev.dokimos.core.TaskResult;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.service.Result;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the async {@link AsyncTask} factory methods on {@link LangChain4jSupport}.
+ */
+class LangChain4jAsyncTaskTest {
+
+    @Test
+    void asyncRagTask_shouldCompleteFutureWithOutputAndContext() throws Exception {
+        List<Content> sources = List.of(
+                Content.from(TextSegment.from("90-day money-back guarantee")),
+                Content.from(TextSegment.from("Contact support for refunds")));
+
+        Result<String> mockResult = Result.<String>builder()
+                .content("You can get a refund within 90 days.")
+                .sources(sources)
+                .build();
+
+        AsyncTask task = LangChain4jSupport.asyncRagTask(input -> mockResult);
+
+        var example = Example.of("What is the refund policy?", "90 days");
+        TaskResult result = task.run(example).get();
+
+        assertThat(result.outputs()).containsEntry("output", "You can get a refund within 90 days.");
+
+        @SuppressWarnings("unchecked")
+        List<String> context = (List<String>) result.outputs().get("context");
+        assertThat(context).containsExactly("90-day money-back guarantee", "Contact support for refunds");
+    }
+
+    @Test
+    void asyncRagTask_shouldSupportCustomKeys() throws Exception {
+        List<Content> sources = List.of(Content.from(TextSegment.from("Source document")));
+
+        Result<String> mockResult =
+                Result.<String>builder().content("The answer").sources(sources).build();
+
+        AsyncTask task = LangChain4jSupport.asyncRagTask(input -> mockResult, "question", "answer", "documentContext");
+
+        var example = Example.builder().input("question", "What?").build();
+        TaskResult result = task.run(example).get();
+
+        assertThat(result.outputs()).containsKey("answer");
+        assertThat(result.outputs()).containsKey("documentContext");
+        assertThat(result.outputs()).doesNotContainKey("output");
+        assertThat(result.outputs()).doesNotContainKey("context");
+    }
+
+    @Test
+    void asyncRagTask_shouldPassInputToAssistantCall() throws Exception {
+        final String[] captured = {null};
+        Result<String> mockResult =
+                Result.<String>builder().content("ok").sources(List.of()).build();
+
+        AsyncTask task = LangChain4jSupport.asyncRagTask(input -> {
+            captured[0] = input;
+            return mockResult;
+        });
+
+        task.run(Example.of("the question", "the answer")).get();
+
+        assertThat(captured[0]).isEqualTo("the question");
+    }
+
+    @Test
+    void asyncRagTask_shouldCompleteExceptionallyWhenAssistantThrows() {
+        AsyncTask task = LangChain4jSupport.asyncRagTask(input -> {
+            throw new IllegalStateException("model down");
+        });
+
+        assertThatThrownBy(() -> task.run(Example.of("q", "a")).get())
+                .isInstanceOf(ExecutionException.class)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("model down");
+    }
+
+    @Test
+    void asyncRagTask_shouldRejectNullAssistantCall() {
+        assertThatThrownBy(() -> LangChain4jSupport.asyncRagTask(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void asyncTask_shouldCompleteFutureWithChatOutput() throws Exception {
+        ChatModel chatModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("The answer is 47"))
+                        .build();
+            }
+        };
+
+        AsyncTask task = LangChain4jSupport.asyncTask(chatModel);
+
+        TaskResult result = task.run(Example.of("What is 45+2?", "47")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "The answer is 47");
+    }
+
+    @Test
+    void asyncTask_shouldSupportCustomOutputKey() throws Exception {
+        ChatModel chatModel = new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("response"))
+                        .build();
+            }
+        };
+
+        AsyncTask task = LangChain4jSupport.asyncTask(chatModel, "answer");
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("answer", "response");
+        assertThat(result.outputs()).doesNotContainKey("output");
+    }
+
+    @Test
+    void asyncTask_shouldRejectNullModel() {
+        assertThatThrownBy(() -> LangChain4jSupport.asyncTask(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/dokimos-server-client/src/main/java/dev/dokimos/server/client/ServerDatasetResolver.java
+++ b/dokimos-server-client/src/main/java/dev/dokimos/server/client/ServerDatasetResolver.java
@@ -6,6 +6,7 @@ import dev.dokimos.core.Dataset;
 import dev.dokimos.core.DatasetResolutionException;
 import dev.dokimos.core.DatasetResolver;
 import dev.dokimos.core.Example;
+import dev.dokimos.core.internal.Json;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -176,7 +177,8 @@ public class ServerDatasetResolver implements DatasetResolver {
         String url = base + API_PATH + encode(name) + "/versions/" + encode(versionSegment);
         String body = sendWithRetry(url, apiKey);
         try {
-            JsonNode node = objectMapper.readTree(body);
+            // Hardened load path: reject duplicate keys, NaN/Infinity, and trailing garbage at parse.
+            JsonNode node = Json.comparisonReader().readTree(body);
             JsonNode versionNode = node.get("version");
             if (versionNode == null || !versionNode.isInt()) {
                 throw new DatasetResolutionException("Version response missing 'version' field: " + url);
@@ -197,7 +199,7 @@ public class ServerDatasetResolver implements DatasetResolver {
             String body = sendWithRetry(url, apiKey);
             JsonNode root;
             try {
-                root = objectMapper.readTree(body);
+                root = Json.comparisonReader().readTree(body);
             } catch (IOException e) {
                 throw new DatasetResolutionException("Failed to parse items response from " + url, e);
             }
@@ -242,7 +244,7 @@ public class ServerDatasetResolver implements DatasetResolver {
             return Map.of();
         }
         try {
-            return objectMapper.convertValue(node, Map.class);
+            return Json.convert(node, Map.class);
         } catch (IllegalArgumentException e) {
             return Map.of();
         }
@@ -361,8 +363,10 @@ public class ServerDatasetResolver implements DatasetResolver {
         if (target == null || !Files.isRegularFile(target)) {
             return null;
         }
-        try {
-            JsonNode root = objectMapper.readTree(target.toFile());
+        try (java.io.InputStream in = Files.newInputStream(target)) {
+            // Hardened load path: even an offline cache file is parsed strictly (duplicate keys,
+            // NaN/Infinity, trailing garbage) so a corrupt cache fails rather than degrading silently.
+            JsonNode root = Json.comparisonReader().readTree(in);
             JsonNode items = root.get("items");
             if (items == null || !items.isArray()) {
                 return null;

--- a/dokimos-server-client/src/test/java/dev/dokimos/server/client/StructuredOutputRoundTripTest.java
+++ b/dokimos-server-client/src/test/java/dev/dokimos/server/client/StructuredOutputRoundTripTest.java
@@ -130,6 +130,31 @@ class StructuredOutputRoundTripTest {
     }
 
     @Test
+    void mismatchStillFailsAfterTheServerHop() throws Exception {
+        // The negative counterpart to the round-trip tests: re-typing (5 vs 5.0) must be absorbed, but a
+        // genuine difference (count 5 vs 6) must still register as a mismatch. This guards against the
+        // opposite failure mode — a comparator bug that makes everything "match" would pass every
+        // positive assertion above while silently erasing real regressions.
+        StructuralMatchEvaluator evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .binary()
+                .build();
+
+        Map<String, Object> expected = Map.of("output", Map.of("count", 5));
+        Map<String, Object> actualOverWire = roundTrip(Map.of("output", Map.of("count", 6)));
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("query", "count")
+                .actualOutputs(actualOverWire)
+                .expectedOutputs(expected)
+                .build();
+
+        EvalResult result = evaluator.evaluate(testCase);
+        assertThat(result.score()).isLessThan(1.0);
+        assertThat(result.success()).isFalse();
+    }
+
+    @Test
     void integerExpectedMatchesFloatingActualAcrossTheHop() throws Exception {
         // The classic 5 vs 5.0 hazard: the dataset stored an integer, the server returned a double
         // (or the JSON literal carried a trailing .0). The BigDecimal comparator must treat them as

--- a/dokimos-server-client/src/test/java/dev/dokimos/server/client/StructuredOutputRoundTripTest.java
+++ b/dokimos-server-client/src/test/java/dev/dokimos/server/client/StructuredOutputRoundTripTest.java
@@ -154,6 +154,51 @@ class StructuredOutputRoundTripTest {
         assertThat(result.success()).isFalse();
     }
 
+    /** A typed target with an integral field — the shape a user reads a server-pulled dataset into. */
+    record WhiskyRecord(String name, int age) {}
+
+    @Test
+    void typedAccessorReadsAnIntegralFieldBackAcrossTheServerHop() throws Exception {
+        // The StructuralMatch round-trip tests above only exercise the BigDecimal-aware comparator. The
+        // typed-accessor path (EvalTestCase.expectedOutputAs -> convertFrom -> Json.convert ->
+        // MAPPER.convertValue) over the wire-retyped map had zero coverage in this module. This is the
+        // exact user flow: pull a dataset from the server, then read it back into a record. The dataset
+        // stored age as a floating-point literal (5.0); after the hop it is a Double, and the record
+        // field is an int. Json's MAPPER sets no number-coercion features, yet the integral-valued
+        // Double materializes cleanly into the int field. Pin that so the read does not start throwing.
+        Map<String, Object> expected = Map.of("output", Map.of("name", "Oban", "age", 5.0));
+        Map<String, Object> overWire = roundTrip(expected);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wireInner = (Map<String, Object>) overWire.get("output");
+        // Sanity: the hop really did box age as a floating-point Double, not an Integer.
+        assertThat(wireInner.get("age")).isInstanceOf(Double.class).isEqualTo(5.0);
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("query", "describe the whisky")
+                .expectedOutputs(overWire)
+                .build();
+
+        assertThat(testCase.expectedOutputAs(WhiskyRecord.class)).isEqualTo(new WhiskyRecord("Oban", 5));
+    }
+
+    @Test
+    void typedAccessorTruncatesANonIntegralFieldAcrossTheServerHop() throws Exception {
+        // Companion to the test above, documenting the sharp edge of the same path: a NON-integral
+        // value (5.5) read into an int record field does NOT throw — Jackson's convertValue silently
+        // truncates it to 5. This is the default, unguarded coercion behavior; pinning it makes the
+        // data-loss visible so a future tightening (e.g. enabling a fail-on-coercion feature) is a
+        // deliberate, reviewed change rather than a silent behavior swing.
+        Map<String, Object> overWire = roundTrip(Map.of("output", Map.of("name", "Oban", "age", 5.5)));
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("query", "describe the whisky")
+                .expectedOutputs(overWire)
+                .build();
+
+        assertThat(testCase.expectedOutputAs(WhiskyRecord.class)).isEqualTo(new WhiskyRecord("Oban", 5));
+    }
+
     @Test
     void integerExpectedMatchesFloatingActualAcrossTheHop() throws Exception {
         // The classic 5 vs 5.0 hazard: the dataset stored an integer, the server returned a double

--- a/dokimos-server-client/src/test/java/dev/dokimos/server/client/StructuredOutputRoundTripTest.java
+++ b/dokimos-server-client/src/test/java/dev/dokimos/server/client/StructuredOutputRoundTripTest.java
@@ -1,0 +1,154 @@
+package dev.dokimos.server.client;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator;
+import dev.dokimos.core.evaluators.StructuralMatchMode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the wire mapping that {@link ServerDatasetResolver} performs for structured
+ * {@code expectedOutputs}: an {@link dev.dokimos.core.Example}'s {@code expectedOutputs} map is
+ * serialized to JSON when cached and re-materialized with {@code convertValue(node, Map.class)} when
+ * read back from the server. That hop is where JSON loses the distinction between an integer and a
+ * floating-point literal (a Java {@code 5} can come back as {@code 5.0}, and vice versa), and where a
+ * nested object or list of objects has to survive intact.
+ *
+ * <p>The outside-voice concern (design test plan, server/client round-trip) is that numbers re-type
+ * across the hop and silently corrupt eval scores. This test serializes a structured payload through
+ * the <em>same</em> {@link ObjectMapper} the resolver uses, materializes it the same way the resolver
+ * does, and asserts that {@link StructuralMatchEvaluator} produces an identical score before and
+ * after the round trip — proving the BigDecimal-aware comparator absorbs the re-typing.
+ */
+class StructuredOutputRoundTripTest {
+
+    /** Mirrors the mapper {@link ServerDatasetResolver} constructs for the wire mapping. */
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Replays the exact server hop the resolver performs: serialize the structured map to JSON, then
+     * read it back into a {@code Map<String,Object>} via {@code convertValue(node, Map.class)} (the
+     * same call {@link ServerDatasetResolver}'s {@code readMap} makes on a server response).
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> roundTrip(Map<String, Object> outputs) throws Exception {
+        String json = objectMapper.writeValueAsString(outputs);
+        JsonNode node = objectMapper.readTree(json);
+        return objectMapper.convertValue(node, Map.class);
+    }
+
+    /** A structured payload: nested object + a mix of integral and floating-point numbers + a list. */
+    private Map<String, Object> structuredExpected() {
+        Map<String, Object> dimensions = new LinkedHashMap<>();
+        dimensions.put("width", 5); // integral literal — JSON round-trip may re-type to 5 or 5.0
+        dimensions.put("height", 5.0); // floating-point literal
+        dimensions.put("depth", 2.50); // trailing-zero scale that BigDecimal must treat as 2.5
+
+        Map<String, Object> nested = new LinkedHashMap<>();
+        nested.put("name", "whisky");
+        nested.put("proof", 90);
+        nested.put("rating", 4.5);
+        nested.put("dimensions", dimensions);
+        nested.put("tags", List.of("peaty", "smoky"));
+        nested.put("scores", List.of(8, 9.0, 10));
+
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("output", nested);
+        return output;
+    }
+
+    private EvalResult evaluate(StructuralMatchEvaluator evaluator, Map<String, Object> expected) {
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("query", "describe the whisky")
+                // The actual output is the structured value verbatim — the score should be a perfect
+                // match both before and after the wire hop.
+                .actualOutputs(expected)
+                .expectedOutputs(expected)
+                .build();
+        return evaluator.evaluate(testCase);
+    }
+
+    @Test
+    void strictScoreIsIdenticalBeforeAndAfterTheServerHop() throws Exception {
+        StructuralMatchEvaluator evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build();
+
+        Map<String, Object> local = structuredExpected();
+        Map<String, Object> overWire = roundTrip(structuredExpected());
+
+        // Sanity: the round trip really did move values through Jackson's number boxing (otherwise the
+        // test would be vacuous). The integral literal comes back as an Integer and the trailing-zero
+        // scale (2.50) is normalized to 2.5 — exactly the re-typing the comparator has to absorb.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wireNested = (Map<String, Object>) overWire.get("output");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> wireDimensions = (Map<String, Object>) wireNested.get("dimensions");
+        assertThat(wireDimensions.get("width")).isInstanceOf(Integer.class).isEqualTo(5);
+        assertThat(wireDimensions.get("height")).isInstanceOf(Double.class).isEqualTo(5.0);
+        assertThat(wireDimensions.get("depth")).isEqualTo(2.5);
+
+        double localScore = evaluate(evaluator, local).score();
+        double wireScore = evaluate(evaluator, overWire).score();
+
+        assertThat(localScore).isEqualTo(1.0);
+        assertThat(wireScore).isEqualTo(localScore);
+    }
+
+    @Test
+    void lenientScoreIsIdenticalBeforeAndAfterTheServerHop() throws Exception {
+        StructuralMatchEvaluator evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.LENIENT)
+                .build();
+
+        double localScore = evaluate(evaluator, structuredExpected()).score();
+        double wireScore = evaluate(evaluator, roundTrip(structuredExpected())).score();
+
+        assertThat(localScore).isEqualTo(1.0);
+        assertThat(wireScore).isEqualTo(localScore);
+    }
+
+    @Test
+    void binaryGateStillPassesAfterTheServerHop() throws Exception {
+        StructuralMatchEvaluator evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .binary()
+                .build();
+
+        double localScore = evaluate(evaluator, structuredExpected()).score();
+        double wireScore = evaluate(evaluator, roundTrip(structuredExpected())).score();
+
+        assertThat(localScore).isEqualTo(1.0);
+        assertThat(wireScore).isEqualTo(1.0);
+    }
+
+    @Test
+    void integerExpectedMatchesFloatingActualAcrossTheHop() throws Exception {
+        // The classic 5 vs 5.0 hazard: the dataset stored an integer, the server returned a double
+        // (or the JSON literal carried a trailing .0). The BigDecimal comparator must treat them as
+        // equal so the eval does not flip from pass to fail purely because of the transport.
+        StructuralMatchEvaluator evaluator = StructuralMatchEvaluator.builder()
+                .mode(StructuralMatchMode.STRICT)
+                .build();
+
+        Map<String, Object> expected = Map.of("output", Map.of("count", 5, "ratio", 2.50));
+        Map<String, Object> actualOverWire = roundTrip(Map.of("output", Map.of("count", 5.0, "ratio", 2.5)));
+
+        EvalTestCase testCase = EvalTestCase.builder()
+                .input("query", "count")
+                .actualOutputs(actualOverWire)
+                .expectedOutputs(expected)
+                .build();
+
+        EvalResult result = evaluator.evaluate(testCase);
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.reason()).contains("match");
+    }
+}

--- a/dokimos-spring-ai/pom.xml
+++ b/dokimos-spring-ai/pom.xml
@@ -32,6 +32,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Provided: only the reactiveTask(...) adapter needs the Mono type; callers
+             already have Reactor on their classpath via Spring AI. -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
+++ b/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
@@ -2,9 +2,11 @@ package dev.dokimos.springai;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.AsyncTask;
 import dev.dokimos.core.EvalResult;
 import dev.dokimos.core.EvalTestCase;
 import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.TaskResult;
 import dev.dokimos.core.agents.AgentTrace;
 import dev.dokimos.core.agents.ToolCall;
 import dev.dokimos.core.agents.ToolDefinition;
@@ -12,6 +14,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
@@ -19,6 +23,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.evaluation.EvaluationRequest;
 import org.springframework.ai.evaluation.EvaluationResponse;
+import reactor.core.publisher.Mono;
 
 /**
  * Utilities for integrating with Spring AI.
@@ -218,6 +223,127 @@ public final class SpringAiSupport {
         metadata.put("score", (float) result.score());
 
         return new EvaluationResponse(result.success(), (float) result.score(), result.reason(), metadata);
+    }
+
+    /**
+     * Creates an {@link AsyncTask} that calls a Spring AI {@link ChatClient} off the calling
+     * thread and writes the response under the {@link #OUTPUT_KEY default output key}.
+     *
+     * <p>The example's {@link dev.dokimos.core.Example#input() input} is sent as the user message.
+     * The {@link ChatClient#prompt()} call is dispatched on the common {@link java.util.concurrent.ForkJoinPool}
+     * via {@link CompletableFuture#supplyAsync(java.util.function.Supplier)} so the experiment's
+     * async execution path can keep many calls in flight without a blocked thread per example.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * ChatClient client = ChatClient.builder(chatModel).build();
+     * AsyncTask task = SpringAiSupport.asyncTask(client);
+     *
+     * Experiment.builder()
+     *     .asyncTask(task)
+     *     .parallelism(8)
+     *     .evaluators(List.of(evaluator))
+     *     .build()
+     *     .run();
+     * }</pre>
+     *
+     * @param client the ChatClient to call, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code client} is null
+     */
+    public static AsyncTask asyncTask(ChatClient client) {
+        return asyncTask(client, INPUT_KEY, OUTPUT_KEY);
+    }
+
+    /**
+     * Creates an {@link AsyncTask} that calls a Spring AI {@link ChatClient} off the calling thread
+     * using caller-chosen input and output keys.
+     *
+     * <p>Behaves like {@link #asyncTask(ChatClient)} but reads the user message from {@code inputKey}
+     * and writes the response under {@code outputKey}, for datasets or evaluators that use different
+     * key names.
+     *
+     * @param client    the ChatClient to call, never null
+     * @param inputKey  the key to read the user message from the example inputs, never null
+     * @param outputKey the key the response is written under in the result, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if any argument is null
+     */
+    public static AsyncTask asyncTask(ChatClient client, String inputKey, String outputKey) {
+        if (client == null) {
+            throw new IllegalArgumentException("ChatClient cannot be null");
+        }
+        if (inputKey == null) {
+            throw new IllegalArgumentException("inputKey cannot be null");
+        }
+        if (outputKey == null) {
+            throw new IllegalArgumentException("outputKey cannot be null");
+        }
+        return example -> CompletableFuture.supplyAsync(() -> {
+            Object input = example.inputs().get(inputKey);
+            String content =
+                    client.prompt().user(String.valueOf(input)).call().content();
+            return TaskResult.of(Map.of(outputKey, content != null ? content : ""));
+        });
+    }
+
+    /**
+     * Adapts a Reactor {@link Mono} of {@link TaskResult} to an {@link AsyncTask}.
+     *
+     * <p>This is the bridge for reactive Spring AI pipelines: supply a function that produces a
+     * {@code Mono<TaskResult>} for an example, and the resulting task converts each Mono to a
+     * {@link CompletableFuture} via {@link Mono#toFuture()}. Reactor lives on the Spring AI classpath
+     * (provided scope), so dokimos-core stays free of any Reactor dependency.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * AsyncTask task = SpringAiSupport.reactiveTask(example ->
+     *     reactiveChatClient.prompt()
+     *         .user(example.input())
+     *         .stream()
+     *         .content()
+     *         .collectList()
+     *         .map(parts -> TaskResult.of(Map.of("output", String.join("", parts)))));
+     * }</pre>
+     *
+     * @param taskFunction a function producing a {@code Mono<TaskResult>} for an example, never null
+     * @return an AsyncTask backed by the supplied Mono
+     * @throws IllegalArgumentException if {@code taskFunction} is null
+     */
+    public static AsyncTask reactiveTask(Function<dev.dokimos.core.Example, Mono<TaskResult>> taskFunction) {
+        if (taskFunction == null) {
+            throw new IllegalArgumentException("taskFunction cannot be null");
+        }
+        return example -> taskFunction.apply(example).toFuture();
+    }
+
+    /**
+     * Adapts a Reactor {@link Mono} of {@code String} output to an {@link AsyncTask}, wrapping the
+     * emitted string under the {@link #OUTPUT_KEY default output key}.
+     *
+     * <p>Convenience over {@link #reactiveTask(Function)} for the common case where the reactive
+     * pipeline yields the model's textual response directly. A {@code null} emission is stored as an
+     * empty string.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * AsyncTask task = SpringAiSupport.reactiveStringTask(example ->
+     *     reactiveChatClient.prompt().user(example.input()).stream().content().last());
+     * }</pre>
+     *
+     * @param taskFunction a function producing a {@code Mono<String>} response for an example, never null
+     * @return an AsyncTask that writes the emitted string under the default output key
+     * @throws IllegalArgumentException if {@code taskFunction} is null
+     */
+    public static AsyncTask reactiveStringTask(Function<dev.dokimos.core.Example, Mono<String>> taskFunction) {
+        if (taskFunction == null) {
+            throw new IllegalArgumentException("taskFunction cannot be null");
+        }
+        return example -> taskFunction
+                .apply(example)
+                .map(output -> TaskResult.of(Map.of(OUTPUT_KEY, output != null ? output : "")))
+                .defaultIfEmpty(TaskResult.of(Map.of(OUTPUT_KEY, "")))
+                .toFuture();
     }
 
     private static final ObjectMapper TOOL_ARG_MAPPER = new ObjectMapper();

--- a/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
+++ b/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
@@ -234,6 +234,12 @@ public final class SpringAiSupport {
      * via {@link CompletableFuture#supplyAsync(java.util.function.Supplier)} so the experiment's
      * async execution path can keep many calls in flight without a blocked thread per example.
      *
+     * <p>Note: because the call blocks on the common pool, the experiment's {@code parallelism} bounds
+     * how many invocations are launched, but the effective concurrency of the blocking HTTP call is
+     * also limited by the common pool (~one less than the CPU count), which is shared process-wide.
+     * For higher, isolated concurrency, wrap the call in your own {@link AsyncTask} backed by a
+     * dedicated {@link java.util.concurrent.Executor}.
+     *
      * <p>Example:
      * <pre>{@code
      * ChatClient client = ChatClient.builder(chatModel).build();

--- a/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
+++ b/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
@@ -15,7 +15,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
@@ -237,8 +239,8 @@ public final class SpringAiSupport {
      * <p>Note: because the call blocks on the common pool, the experiment's {@code parallelism} bounds
      * how many invocations are launched, but the effective concurrency of the blocking HTTP call is
      * also limited by the common pool (~one less than the CPU count), which is shared process-wide.
-     * For higher, isolated concurrency, wrap the call in your own {@link AsyncTask} backed by a
-     * dedicated {@link java.util.concurrent.Executor}.
+     * For higher, isolated concurrency use {@link #asyncTask(ChatClient, java.util.concurrent.Executor)}
+     * (or the four-arg overload) to run calls on a pool you control.
      *
      * <p>Example:
      * <pre>{@code
@@ -276,6 +278,47 @@ public final class SpringAiSupport {
      * @throws IllegalArgumentException if any argument is null
      */
     public static AsyncTask asyncTask(ChatClient client, String inputKey, String outputKey) {
+        return asyncTask(client, inputKey, outputKey, null);
+    }
+
+    /**
+     * Creates an {@link AsyncTask} that calls a Spring AI {@link ChatClient} on the supplied
+     * {@link Executor}, with default input and output keys.
+     *
+     * <p>Use this when you want the blocking call to run on a pool you control (sized to your desired
+     * concurrency) rather than the shared common {@link java.util.concurrent.ForkJoinPool}. Pair the
+     * executor's size with the experiment's {@code parallelism} for predictable throughput.
+     *
+     * @param client   the ChatClient to call, never null
+     * @param executor the executor each blocking call runs on, never null
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code client} or {@code executor} is null
+     */
+    public static AsyncTask asyncTask(ChatClient client, Executor executor) {
+        if (executor == null) {
+            throw new IllegalArgumentException("executor cannot be null");
+        }
+        return asyncTask(client, INPUT_KEY, OUTPUT_KEY, executor);
+    }
+
+    /**
+     * Creates an {@link AsyncTask} that calls a Spring AI {@link ChatClient} using caller-chosen input
+     * and output keys, dispatching each blocking call on the supplied {@link Executor} (or the common
+     * {@link java.util.concurrent.ForkJoinPool} when {@code executor} is {@code null}).
+     *
+     * <p>Supplying an executor lets you control and isolate concurrency: the experiment's
+     * {@code parallelism} bounds in-flight invocations, and a pool sized to match gives true parallel
+     * blocking calls instead of the common pool's ~CPU-count, process-wide ceiling.
+     *
+     * @param client    the ChatClient to call, never null
+     * @param inputKey  the key to read the user message from the example inputs, never null
+     * @param outputKey the key the response is written under in the result, never null
+     * @param executor  the executor each blocking call runs on, or {@code null} for the common pool
+     * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
+     * @throws IllegalArgumentException if {@code client}, {@code inputKey}, or {@code outputKey} is null
+     */
+    public static AsyncTask asyncTask(
+            ChatClient client, String inputKey, String outputKey, Executor executor) {
         if (client == null) {
             throw new IllegalArgumentException("ChatClient cannot be null");
         }
@@ -285,12 +328,17 @@ public final class SpringAiSupport {
         if (outputKey == null) {
             throw new IllegalArgumentException("outputKey cannot be null");
         }
-        return example -> CompletableFuture.supplyAsync(() -> {
-            Object input = example.inputs().get(inputKey);
-            String content =
-                    client.prompt().user(String.valueOf(input)).call().content();
-            return TaskResult.of(Map.of(outputKey, content != null ? content : ""));
-        });
+        return example -> {
+            Supplier<TaskResult> call = () -> {
+                Object input = example.inputs().get(inputKey);
+                String content =
+                        client.prompt().user(String.valueOf(input)).call().content();
+                return TaskResult.of(Map.of(outputKey, content != null ? content : ""));
+            };
+            return executor == null
+                    ? CompletableFuture.supplyAsync(call)
+                    : CompletableFuture.supplyAsync(call, executor);
+        };
     }
 
     /**

--- a/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
+++ b/dokimos-spring-ai/src/main/java/dev/dokimos/springai/SpringAiSupport.java
@@ -317,8 +317,7 @@ public final class SpringAiSupport {
      * @return an AsyncTask suitable for {@code Experiment.builder().asyncTask(...)}
      * @throws IllegalArgumentException if {@code client}, {@code inputKey}, or {@code outputKey} is null
      */
-    public static AsyncTask asyncTask(
-            ChatClient client, String inputKey, String outputKey, Executor executor) {
+    public static AsyncTask asyncTask(ChatClient client, String inputKey, String outputKey, Executor executor) {
         if (client == null) {
             throw new IllegalArgumentException("ChatClient cannot be null");
         }
@@ -344,10 +343,9 @@ public final class SpringAiSupport {
     /**
      * Adapts a Reactor {@link Mono} of {@link TaskResult} to an {@link AsyncTask}.
      *
-     * <p>This is the bridge for reactive Spring AI pipelines: supply a function that produces a
-     * {@code Mono<TaskResult>} for an example, and the resulting task converts each Mono to a
-     * {@link CompletableFuture} via {@link Mono#toFuture()}. Reactor lives on the Spring AI classpath
-     * (provided scope), so dokimos-core stays free of any Reactor dependency.
+     * <p>For reactive Spring AI pipelines: supply a function that produces a {@code Mono<TaskResult>}
+     * for an example, and the resulting task converts each Mono to a {@link CompletableFuture} via
+     * {@link Mono#toFuture()}.
      *
      * <p>Example:
      * <pre>{@code

--- a/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
+++ b/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
@@ -35,6 +35,21 @@ class SpringAiAsyncTaskTest {
     }
 
     @Test
+    void asyncTask_shouldStoreEmptyStringWhenContentIsNull() throws Exception {
+        // A ChatResponse with no generations makes ChatClient.content() return null (the model
+        // produced an empty/tool-only completion). The null-guard in asyncTask must coerce that to ""
+        // rather than passing null to Map.of(...), which would NPE on the worker thread.
+        ChatModel mockModel = prompt -> new ChatResponse(List.of());
+        ChatClient client = ChatClient.builder(mockModel).build();
+
+        AsyncTask task = SpringAiSupport.asyncTask(client);
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "");
+    }
+
+    @Test
     void asyncTask_shouldSendInputAsUserMessage() throws Exception {
         final String[] captured = {null};
         ChatModel mockModel = prompt -> {

--- a/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
+++ b/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
@@ -80,8 +80,7 @@ class SpringAiAsyncTaskTest {
 
     @Test
     void asyncTask_shouldRejectNullClient() {
-        assertThatThrownBy(() -> SpringAiSupport.asyncTask(null))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SpringAiSupport.asyncTask(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -123,8 +122,8 @@ class SpringAiAsyncTaskTest {
 
     @Test
     void reactiveTask_shouldReceiveTheExample() throws Exception {
-        AsyncTask task = SpringAiSupport.reactiveTask(
-                example -> Mono.just(TaskResult.of(Map.of("output", example.input()))));
+        AsyncTask task =
+                SpringAiSupport.reactiveTask(example -> Mono.just(TaskResult.of(Map.of("output", example.input()))));
 
         TaskResult result = task.run(Example.of("echo me", "a")).get();
 
@@ -133,8 +132,7 @@ class SpringAiAsyncTaskTest {
 
     @Test
     void reactiveTask_shouldPropagateMonoError() {
-        AsyncTask task = SpringAiSupport.reactiveTask(
-                example -> Mono.error(new IllegalStateException("boom")));
+        AsyncTask task = SpringAiSupport.reactiveTask(example -> Mono.error(new IllegalStateException("boom")));
 
         assertThatThrownBy(() -> task.run(Example.of("q", "a")).get())
                 .isInstanceOf(ExecutionException.class)
@@ -144,8 +142,7 @@ class SpringAiAsyncTaskTest {
 
     @Test
     void reactiveTask_shouldRejectNullFunction() {
-        assertThatThrownBy(() -> SpringAiSupport.reactiveTask(null))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SpringAiSupport.reactiveTask(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -168,7 +165,6 @@ class SpringAiAsyncTaskTest {
 
     @Test
     void reactiveStringTask_shouldRejectNullFunction() {
-        assertThatThrownBy(() -> SpringAiSupport.reactiveStringTask(null))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SpringAiSupport.reactiveStringTask(null)).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
+++ b/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
@@ -85,6 +85,32 @@ class SpringAiAsyncTaskTest {
     }
 
     @Test
+    void asyncTask_shouldRunOnProvidedExecutor() throws Exception {
+        ChatModel mockModel = prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+        ChatClient client = ChatClient.builder(mockModel).build();
+        java.util.concurrent.atomic.AtomicInteger used = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.Executor executor = command -> {
+            used.incrementAndGet();
+            command.run();
+        };
+
+        AsyncTask task = SpringAiSupport.asyncTask(client, executor);
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(used.get()).isEqualTo(1);
+        assertThat(result.outputs()).containsEntry("output", "ok");
+    }
+
+    @Test
+    void asyncTask_shouldRejectNullExecutor() {
+        ChatModel mockModel = prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+        ChatClient client = ChatClient.builder(mockModel).build();
+
+        assertThatThrownBy(() -> SpringAiSupport.asyncTask(client, (java.util.concurrent.Executor) null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void reactiveTask_shouldAdaptMonoOfTaskResultToFuture() throws Exception {
         TaskResult expected = TaskResult.of(Map.of("output", "reactive value"));
 

--- a/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
+++ b/dokimos-spring-ai/src/test/java/dev/dokimos/springai/SpringAiAsyncTaskTest.java
@@ -1,0 +1,148 @@
+package dev.dokimos.springai;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.dokimos.core.AsyncTask;
+import dev.dokimos.core.Example;
+import dev.dokimos.core.TaskResult;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import reactor.core.publisher.Mono;
+
+/**
+ * Tests for the async and reactive {@link AsyncTask} factory methods on {@link SpringAiSupport}.
+ */
+class SpringAiAsyncTaskTest {
+
+    @Test
+    void asyncTask_shouldCompleteFutureWithChatClientResponse() throws Exception {
+        ChatModel mockModel =
+                prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("Async response"))));
+        ChatClient client = ChatClient.builder(mockModel).build();
+
+        AsyncTask task = SpringAiSupport.asyncTask(client);
+
+        TaskResult result = task.run(Example.of("What is 2+2?", "4")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "Async response");
+    }
+
+    @Test
+    void asyncTask_shouldSendInputAsUserMessage() throws Exception {
+        final String[] captured = {null};
+        ChatModel mockModel = prompt -> {
+            captured[0] = prompt.getInstructions().get(0).getText();
+            return new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+        };
+        ChatClient client = ChatClient.builder(mockModel).build();
+
+        AsyncTask task = SpringAiSupport.asyncTask(client);
+        task.run(Example.of("my question", "answer")).get();
+
+        assertThat(captured[0]).isEqualTo("my question");
+    }
+
+    @Test
+    void asyncTask_shouldSupportCustomKeys() throws Exception {
+        ChatModel mockModel = prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("response"))));
+        ChatClient client = ChatClient.builder(mockModel).build();
+
+        AsyncTask task = SpringAiSupport.asyncTask(client, "question", "answer");
+
+        var example = Example.builder().input("question", "What?").build();
+        TaskResult result = task.run(example).get();
+
+        assertThat(result.outputs()).containsEntry("answer", "response");
+        assertThat(result.outputs()).doesNotContainKey("output");
+    }
+
+    @Test
+    void asyncTask_shouldCompleteExceptionallyWhenClientThrows() {
+        ChatModel mockModel = prompt -> {
+            throw new IllegalStateException("model down");
+        };
+        ChatClient client = ChatClient.builder(mockModel).build();
+
+        AsyncTask task = SpringAiSupport.asyncTask(client);
+
+        assertThatThrownBy(() -> task.run(Example.of("q", "a")).get())
+                .isInstanceOf(ExecutionException.class)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("model down");
+    }
+
+    @Test
+    void asyncTask_shouldRejectNullClient() {
+        assertThatThrownBy(() -> SpringAiSupport.asyncTask(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void reactiveTask_shouldAdaptMonoOfTaskResultToFuture() throws Exception {
+        TaskResult expected = TaskResult.of(Map.of("output", "reactive value"));
+
+        AsyncTask task = SpringAiSupport.reactiveTask(example -> Mono.just(expected));
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "reactive value");
+    }
+
+    @Test
+    void reactiveTask_shouldReceiveTheExample() throws Exception {
+        AsyncTask task = SpringAiSupport.reactiveTask(
+                example -> Mono.just(TaskResult.of(Map.of("output", example.input()))));
+
+        TaskResult result = task.run(Example.of("echo me", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "echo me");
+    }
+
+    @Test
+    void reactiveTask_shouldPropagateMonoError() {
+        AsyncTask task = SpringAiSupport.reactiveTask(
+                example -> Mono.error(new IllegalStateException("boom")));
+
+        assertThatThrownBy(() -> task.run(Example.of("q", "a")).get())
+                .isInstanceOf(ExecutionException.class)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("boom");
+    }
+
+    @Test
+    void reactiveTask_shouldRejectNullFunction() {
+        assertThatThrownBy(() -> SpringAiSupport.reactiveTask(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void reactiveStringTask_shouldWrapEmittedStringUnderOutputKey() throws Exception {
+        AsyncTask task = SpringAiSupport.reactiveStringTask(example -> Mono.just("hello"));
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "hello");
+    }
+
+    @Test
+    void reactiveStringTask_shouldYieldEmptyStringForEmptyMono() throws Exception {
+        AsyncTask task = SpringAiSupport.reactiveStringTask(example -> Mono.empty());
+
+        TaskResult result = task.run(Example.of("q", "a")).get();
+
+        assertThat(result.outputs()).containsEntry("output", "");
+    }
+
+    @Test
+    void reactiveStringTask_shouldRejectNullFunction() {
+        assertThatThrownBy(() -> SpringAiSupport.reactiveStringTask(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
                 <artifactId>openai-java</artifactId>
                 <version>4.11.0</version>
             </dependency>
+            <!-- Kotlin-aware Jackson module, pinned to the same Jackson version dokimos-core uses. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-kotlin</artifactId>
+                <version>2.18.2</version>
+            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
         <spotless.version>3.2.1</spotless.version>
         <palantir.version>2.86.0</palantir.version>
         <ktlint.version>1.5.0</ktlint.version>
+        <!-- Matches the reactor-core managed by Spring Boot 3.5.10 (reactor-bom 2024.0.14). -->
+        <reactor.version>3.7.15</reactor.version>
     </properties>
 
     <dependencyManagement>
@@ -141,6 +143,12 @@
                 <groupId>io.opentelemetry.proto</groupId>
                 <artifactId>opentelemetry-proto</artifactId>
                 <version>1.7.0-alpha</version>
+            </dependency>
+            <!-- Reactor for the Spring AI reactive task adapter (provided scope in dokimos-spring-ai). -->
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${reactor.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Adds typed, structured output across the framework, plus non-blocking async tasks. All additive and non-breaking.

A task can now return a record, list, or POJO with `Task.typed(...)`, and you read it back type-safely with `actualOutputAs(...)` / `expectedOutputAs(...)` (and `inputAs`, `argumentsAs`, `metadataAs`), using `OutputType<T>` for generics like `List<Movie>`. `StructuralMatchEvaluator` compares structured output as JSON (numbers by value, with strict or lenient field and array handling) instead of brittle string matching, and `LLMJudgeEvaluator` now shows the judge structured output as JSON. Tool results round-trip through `ToolCall.resultJson(...)` and `resultAs(...)`. The Kotlin DSL gets reified `typedTask<T>` and `actualOutputAs<T>()` that work with plain data classes.

`AsyncTask` lets a task return a `CompletableFuture<TaskResult>`, so suspend or reactive callers (Koog, Reactor) can drive an experiment without a thread blocked per example; the async path caps in-flight work at `parallelism`. The Spring AI, LangChain4j, and Koog adapters get async and reactive task factories with caller-supplied `Executor` control.

Docs: a new Structured & typed data guide and a JUnit tutorial for evaluating model output in a Java or Kotlin test.