### PR TITLE
Fix changelog Latest badge

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -64,15 +64,40 @@ knowledge disagree, the page is correct.
 
 Skill registry for agents: /.well-known/skills/index.json`;
 
+// Newest published release (v-prefixed tag) from GitHub, used for the changelog
+// "Latest" badge and the install snippet version. Falls back to the hardcoded
+// value if the API is unreachable (offline build, rate limit).
+async function latestReleaseVersion(fallback: string): Promise<string> {
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "dokimos-docs-build",
+    };
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    const res = await fetch("https://api.github.com/repos/dokimos-dev/dokimos/releases/latest", {
+      headers,
+    });
+    if (!res.ok) return fallback;
+    const data = (await res.json()) as { tag_name?: string };
+    const version = (data.tag_name ?? "").replace(/^v/, "");
+    return /^\d+\.\d+\.\d+/.test(version) ? version : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 const config: Config = {
   title: "Dokimos | LLM Evaluation Framework for Java",
   tagline: "An Evaluation Framework for LLM applications in Java.",
   favicon: "img/favicon.ico",
   staticDirectories: ["public", "static"],
 
-  // Latest released version, surfaced in the landing page install snippet.
+  // Surfaced in the install snippets and the changelog "Latest" badge. Overridden
+  // at build time from the newest GitHub release (see createConfig below); these
+  // are the offline fallback.
   customFields: {
     dokimosVersion: "0.20.0",
+    latestVersion: "0.20.0",
   },
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -206,4 +231,10 @@ const config: Config = {
   } satisfies Preset.ThemeConfig,
 };
 
-export default config;
+export default async function createConfig(): Promise<Config> {
+  const latestVersion = await latestReleaseVersion("0.20.0");
+  return {
+    ...config,
+    customFields: { ...config.customFields, dokimosVersion: latestVersion, latestVersion },
+  };
+}

--- a/docs/src/components/ReleaseTimeline/index.tsx
+++ b/docs/src/components/ReleaseTimeline/index.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import styles from "./styles.module.css";
 
 type Group = { label: "Added" | "Changed" | "Fixed"; items: { title: string; body: ReactNode }[] };
-type Release = { version: string; date: string; latest?: boolean; lead?: string; groups: Group[] };
+type Release = { version: string; date: string; lead?: string; groups: Group[] };
 
 const RELEASES: Release[] = [
   {
@@ -125,7 +126,6 @@ const RELEASES: Release[] = [
   {
     version: "0.19.0",
     date: "June 2, 2026",
-    latest: true,
     lead: "Hardens the core: per-item failure isolation, RFC 4180 CSV, prose-tolerant judges, retry and observability for the server reporter, and a run of correctness fixes.",
     groups: [
       {
@@ -348,19 +348,20 @@ function slug(v: string) {
 }
 
 export default function ReleaseTimeline() {
+  const { siteConfig } = useDocusaurusContext();
+  const latestVersion = siteConfig.customFields?.latestVersion as string | undefined;
   return (
     <div className={styles.timeline}>
-      {RELEASES.map((rel) => (
-        <section
-          key={rel.version}
-          className={`${styles.release} ${rel.latest ? styles.current : ""}`}
-        >
+      {RELEASES.map((rel) => {
+        const isLatest = rel.version === latestVersion;
+        return (
+        <section key={rel.version} className={`${styles.release} ${isLatest ? styles.current : ""}`}>
           <span className={styles.node} aria-hidden="true" />
           <div className={styles.head}>
             <h2 id={slug(rel.version)} className={styles.ver}>
               v{rel.version}
             </h2>
-            {rel.latest && <span className={styles.tag}>Latest</span>}
+            {isLatest && <span className={styles.tag}>Latest</span>}
             <span className={styles.date}>{rel.date}</span>
           </div>
           {rel.lead && <p className={styles.lead}>{rel.lead}</p>}
@@ -382,7 +383,8 @@ export default function ReleaseTimeline() {
             </div>
           ))}
         </section>
-      ))}
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
The changelog hardcoded the Latest badge on 0.19.0. It is now derived at build time from the newest GitHub release tag (v-prefixed), with an offline fallback, and the install-snippet version uses the same source.