### PR TITLE
Put the framework-agnostic framing back in the docs

### DIFF
--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -19,6 +19,8 @@ It is an open-source evaluation framework. It works with Spring AI, LangChain4j,
 5. Run evals in a test-driven way with JUnit parameterized tests
 6. Track experiment results over time with an optional server and web UI
 
+Dokimos is framework agnostic. The core depends on no AI framework, so it works with any LLM client, or none at all. The Spring AI, LangChain4j, and Koog modules are thin, optional bridges that capture a run in one line. You never need them to use Dokimos.
+
 Dokimos brings the evaluation tooling that Python developers have to the Java ecosystem.
 
 ## See it run

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -30,12 +30,12 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: "Framework integration",
+    title: "Framework agnostic",
     glyph: "⌘",
     description: (
       <>
-        Works with JUnit, Spring AI, LangChain4j, and Koog, so evaluations run in the test suite and
-        CI you already have.
+        The core depends on no AI framework, so it works with any LLM client. Optional one-line
+        integrations cover Spring AI, LangChain4j, Koog, and JUnit.
       </>
     ),
   },

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -132,7 +132,8 @@ function HomepageHeader() {
           <p className={styles.heroSubtitle}>
             Evaluate responses and agent tool calls, track quality over time, and catch regressions
             before they ship. Runs in the JUnit suite and CI you already have, one dependency, no
-            new infrastructure. Works with Spring AI, LangChain4j, and Koog.
+            new infrastructure. Framework agnostic, with one-line integrations for Spring AI,
+            LangChain4j, and Koog.
           </p>
           <div className={styles.heroButtons}>
             <Link className="button button--primary button--lg" to="/overview">


### PR DESCRIPTION
The clarity rewrite dropped the word "framework agnostic" somehow.