### PR TITLE
Make the QA refund integration test tolerant of extra correct detail

### DIFF
--- a/dokimos-junit/src/test/java/dev/dokimos/junit/integration/QaEvaluationIT.java
+++ b/dokimos-junit/src/test/java/dev/dokimos/junit/integration/QaEvaluationIT.java
@@ -40,7 +40,9 @@ class QaEvaluationIT {
 
         evaluators = List.of(LLMJudgeEvaluator.builder()
                 .name("answer-correctness")
-                .criteria("is the answer correctly answering the question?")
+                .criteria("Does the answer correctly answer the question? Treat it as correct when it"
+                        + " conveys the expected answer's meaning, even if it adds further accurate detail"
+                        + " or uses different wording.")
                 .evaluationParams(List.of(
                         EvalTestCaseParam.INPUT, EvalTestCaseParam.ACTUAL_OUTPUT, EvalTestCaseParam.EXPECTED_OUTPUT))
                 .threshold(0.5)


### PR DESCRIPTION
The answer-correctness LLM judge intermittently failed a correct answer that volunteered an extra accurate sentence ("No return is allowed after 30 days"). The criteria now explicitly accepts extra correct detail and wording differences, so the test judges semantic correctness rather than near-exact match. Verified by running the integration test repeatedly against the live judge.