### PR TITLE
Resolve the eval-gate-report renderer from the action's own checkout

### DIFF
--- a/.github/actions/eval-gate-report/action.yml
+++ b/.github/actions/eval-gate-report/action.yml
@@ -42,7 +42,11 @@ runs:
           exit 1
         fi
 
-        renderer="$GITHUB_WORKSPACE/.github/actions/eval-gate/render-comment.sh"
+        # Resolve the renderer from the action's own checkout, not the consumer's workspace. When this
+        # action is used remotely (dokimos-dev/dokimos/.github/actions/eval-gate-report@v0), the whole
+        # repo is checked out under GITHUB_ACTION_PATH, so the sibling eval-gate script is reachable;
+        # GITHUB_WORKSPACE would point at the consumer's repo, which does not have the script.
+        renderer="$GITHUB_ACTION_PATH/../eval-gate/render-comment.sh"
         overall="NO_BASELINE"
         # gate-comment.md is CWD-relative; the comment step reads it from the same composite-step CWD.
         : > gate-comment.md


### PR DESCRIPTION
The `eval-gate-report` composite action resolved its renderer through `$GITHUB_WORKSPACE`:

```
renderer="$GITHUB_WORKSPACE/.github/actions/eval-gate/render-comment.sh"
```

`$GITHUB_WORKSPACE` is the consumer's checkout. When a downstream repo uses the action remotely (`dokimos-dev/dokimos/.github/actions/eval-gate-report@v0`), that path points into the consumer's tree, which does not contain `render-comment.sh`. Under `set -euo pipefail` with `if: always()`, the report step then fails on every pull request, including a clean PASS. The bug stayed invisible here because our own workflow invokes the action via a local path (`./.github/actions/eval-gate-report`), where `$GITHUB_WORKSPACE` is this checkout and the script exists.

The fix resolves the script from the action's own checkout, where the whole repo is present for a remote composite action, matching how the sibling `eval-gate` action already resolves its renderer (`${GITHUB_ACTION_PATH}/render-comment.sh`):

```
renderer="$GITHUB_ACTION_PATH/../eval-gate/render-comment.sh"
```

This keeps a single canonical `render-comment.sh` (still covered by `RenderCommentCompatTest`) rather than duplicating it into the report action.

Verified by simulating the remote resolution (`GITHUB_ACTION_PATH` set to the action directory) and piping a verdict through the resolved path: the comment renders and the script exits 0. `render-comment.sh` is unchanged.
