### PR TITLE
Grant contents: read to the eval gate workflow and docs example

### DIFF
--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -22,6 +22,7 @@ jobs:
     name: Eval Gate (server-free)
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/docs/docs/evaluation/regression-gate.md
+++ b/docs/docs/evaluation/regression-gate.md
@@ -245,6 +245,7 @@ eval-gate:
   runs-on: ubuntu-latest
   if: github.event_name == 'pull_request'
   permissions:
+    contents: read
     pull-requests: write
 
   steps:


### PR DESCRIPTION
The eval-gate workflow and its documented example declare `permissions: pull-requests: write`. Specifying a `permissions:` block sets every unlisted scope to `none`, including `contents`, so `actions/checkout` runs without `contents: read`. On a private repository that returns `fatal: repository '...' not found` (a 404 for the unauthorized token), and the gate never runs.

It works in this public repo because a public checkout does not require the token's `contents` scope, which is why it went unnoticed. Teams running the gate on a private repository (the common case for an internal eval gate) hit the failure as soon as they copy the documented workflow.

This grants `contents: read` alongside `pull-requests: write` in both our own `eval-gate.yml` and the `regression-gate.md` example, so the gate checks out on public and private repositories alike.
