### PR TITLE
Align Jackson on the Spring Boot managed version

### DIFF
--- a/dokimos-core/pom.xml
+++ b/dokimos-core/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
         </dependency>
 
         <dependency>

--- a/dokimos-server-client/pom.xml
+++ b/dokimos-server-client/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,12 +124,6 @@
                 <artifactId>openai-java</artifactId>
                 <version>4.11.0</version>
             </dependency>
-            <!-- Kotlin-aware Jackson module, pinned to the same Jackson version dokimos-core uses. -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-kotlin</artifactId>
-                <version>2.18.2</version>
-            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>


### PR DESCRIPTION
Aligns all Jackson artifacts on the Spring Boot managed version (`jackson-bom` 2.19.4) and clears the open `jackson-databind` security alerts.

`jackson-databind` was hard-pinned to 2.18.2 in `dokimos-core` and `dokimos-server-client`, overriding the Spring Boot BOM that already manages `jackson-core`/`jackson-annotations` at 2.19.4. That left databind behind the patch line and split from core.

Dependabot #153 tried to fix the advisory by bumping databind alone to 2.22.0, which broke the whole build: databind 2.22 against core 2.19.4 fails `Json`'s static `ObjectMapper` init, cascading into ~337 test errors in `dokimos-core`.

This instead drops the hard-pins (and the parallel `jackson-module-kotlin` pin) so every Jackson artifact tracks Spring Boot's 2.19.4, which is past the patched version for the advisories. All Jackson artifacts now resolve to a single 2.19.4 and the reactor builds green. Supersedes #153.