### PR TITLE
Pin jackson-databind so the security advisories clear

### DIFF
--- a/dokimos-core/pom.xml
+++ b/dokimos-core/pom.xml
@@ -36,6 +36,9 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <!-- Kept explicit (and matched to the Spring Boot managed jackson-bom) so the resolved
+                 version is visible to dependency scanning; a bare BOM-managed version reads as absent. -->
+            <version>2.19.4</version>
         </dependency>
 
         <dependency>

--- a/dokimos-server-client/pom.xml
+++ b/dokimos-server-client/pom.xml
@@ -24,6 +24,9 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <!-- Explicit and matched to the Spring Boot managed jackson-bom, so the version stays
+                 visible to dependency scanning. -->
+            <version>2.19.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Follow-up to #154. That PR aligned Jackson correctly (Spring Boot's `jackson-bom` manages everything to 2.19.4) and fixed the build, but the `jackson-databind` alerts stayed open because GitHub's Maven dependency graph does not resolve BOM-managed versions. The SBOM shows `jackson-databind` with **no version**, so the scanner cannot confirm the fix.

Pinning it back to an explicit `2.19.4` (the exact version the BOM already resolves) makes the version visible to dependency scanning while keeping all Jackson artifacts aligned, so the advisories close. Verified: databind/core/annotations all resolve to 2.19.4 and the build is green.