### PR TITLE
Add PlanQuality and PlanAdherence agent evaluators

### DIFF
--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluator.java
@@ -1,0 +1,241 @@
+package dev.dokimos.core.evaluators.agents;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.dokimos.core.BaseEvaluator;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.LlmResponseUtils;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Evaluates whether an agent's executed tool calls followed its stated plan using a rule-based check
+ * and an optional LLM check.
+ * <p>
+ * The plan is read from {@code actualOutputs[reasoningStepsKey]} (default {@code "reasoningSteps"})
+ * as a {@code List<String>} and the tool calls from {@code actualOutputs[toolCallsKey]}
+ * (default {@code "toolCalls"}), matching {@link dev.dokimos.core.agents.AgentTrace#toOutputMap()}.
+ * <p>
+ * Checks performed:
+ * <ul>
+ *   <li>{@code plan_present} (rule): a plan is present</li>
+ *   <li>{@code plan_followed} (LLM): the executed tool calls followed the stated plan</li>
+ * </ul>
+ * <p>
+ * Without a judge LLM, only the rule-based check runs. The score is the fraction of checks that
+ * passed. No tool calls short-circuits to a score of 1.0, and a missing tool calls key throws.
+ */
+public class PlanAdherenceEvaluator extends BaseEvaluator {
+
+    private static final ObjectMapper OBJECT_MAPPER = LlmResponseUtils.lenientMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final JudgeLM judge;
+    private final String reasoningStepsKey;
+    private final String toolCallsKey;
+
+    private PlanAdherenceEvaluator(Builder builder) {
+        super(builder.name, builder.threshold, builder.evaluationParams);
+        this.judge = builder.judge;
+        this.reasoningStepsKey = builder.reasoningStepsKey;
+        this.toolCallsKey = builder.toolCallsKey;
+    }
+
+    /**
+     * Creates a new builder for constructing the evaluator.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected EvalResult runEvaluation(EvalTestCase testCase) {
+        Object rawCalls = testCase.actualOutputs().get(toolCallsKey);
+        if (rawCalls == null) {
+            throw new EvaluationException(
+                    "PlanAdherenceEvaluator requires '%s' in actualOutputs".formatted(toolCallsKey));
+        }
+        List<ToolCall> toolCalls = AgentEvalCasts.toolCalls(rawCalls, toolCallsKey);
+
+        if (toolCalls.isEmpty()) {
+            return EvalResult.builder()
+                    .name(name)
+                    .score(1.0)
+                    .threshold(threshold)
+                    .reason("No tool calls to evaluate.")
+                    .build();
+        }
+
+        List<String> plan = readPlan(testCase.actualOutputs().get(reasoningStepsKey));
+
+        Map<String, Object> checks = new LinkedHashMap<>();
+        checks.put("plan_present", !plan.isEmpty());
+
+        if (judge != null) {
+            try {
+                Map<String, Object> parsed =
+                        LlmResponseUtils.parse(judge.generate(buildPrompt(plan, toolCalls)), MAP_TYPE);
+                checks.put("plan_followed", Boolean.TRUE.equals(parsed.get("plan_followed")));
+            } catch (Exception e) {
+                return EvalResult.builder()
+                        .name(name)
+                        .score(0.0)
+                        .threshold(threshold)
+                        .reason("Failed to parse judge response: " + e.getMessage())
+                        .build();
+            }
+        } else {
+            checks.put("plan_followed", "skipped");
+        }
+
+        long ran = checks.values().stream().filter(Boolean.class::isInstance).count();
+        long passed = checks.values().stream().filter(Boolean.TRUE::equals).count();
+        double score = ran > 0 ? (double) passed / ran : 1.0;
+
+        return EvalResult.builder()
+                .name(name)
+                .score(score)
+                .threshold(threshold)
+                .reason(String.format(
+                        "Plan adherence: %d/%d checks passed over %d tool calls.", passed, ran, toolCalls.size()))
+                .metadata(Map.of("checks", checks))
+                .build();
+    }
+
+    private String buildPrompt(List<String> plan, List<ToolCall> toolCalls) {
+        var sb = new StringBuilder();
+        sb.append("You are evaluating whether an AI agent's executed tool calls followed its stated plan.\n\n");
+        sb.append("PLAN (ordered reasoning steps):\n");
+        if (plan.isEmpty()) {
+            sb.append("(no plan provided)\n");
+        }
+        for (int i = 0; i < plan.size(); i++) {
+            sb.append(i + 1).append(". ").append(plan.get(i)).append("\n");
+        }
+        sb.append("\nEXECUTED TOOL CALLS (in order):\n");
+        for (int i = 0; i < toolCalls.size(); i++) {
+            ToolCall call = toolCalls.get(i);
+            String argsJson;
+            try {
+                argsJson = OBJECT_MAPPER.writeValueAsString(call.arguments());
+            } catch (Exception e) {
+                argsJson = call.arguments().toString();
+            }
+            sb.append(i + 1)
+                    .append(". ")
+                    .append(call.name())
+                    .append("(")
+                    .append(argsJson)
+                    .append(")\n");
+        }
+        sb.append("\nDid the executed tool calls carry out the stated plan? ");
+        sb.append("Some plan steps may be reasoning or decisions that need no tool call; ");
+        sb.append("judge whether the tool calls are consistent with the plan and advance it, ");
+        sb.append("not whether every step maps to a call. ");
+        sb.append("Respond ONLY as JSON (no markdown): {\"plan_followed\": true/false}\n");
+        return sb.toString();
+    }
+
+    private List<String> readPlan(Object raw) {
+        if (raw instanceof List<?> list) {
+            return list.stream().map(String::valueOf).toList();
+        }
+        return List.of();
+    }
+
+    /**
+     * Builder for constructing the evaluator.
+     */
+    public static class Builder {
+        private String name = "Plan Adherence";
+        private double threshold = 0.5;
+        private List<EvalTestCaseParam> evaluationParams = List.of();
+        private String reasoningStepsKey = "reasoningSteps";
+        private String toolCallsKey = "toolCalls";
+        private JudgeLM judge;
+
+        /**
+         * Sets the evaluator name.
+         *
+         * @param name the evaluator name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the minimum score threshold for success.
+         *
+         * @param threshold the threshold value
+         * @return this builder
+         */
+        public Builder threshold(double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets which test case parameters to validate.
+         *
+         * @param params the parameters
+         * @return this builder
+         */
+        public Builder evaluationParams(List<EvalTestCaseParam> params) {
+            this.evaluationParams = List.copyOf(params);
+            return this;
+        }
+
+        /**
+         * Sets the actualOutputs key for the plan (reasoning steps).
+         *
+         * @param reasoningStepsKey the key
+         * @return this builder
+         */
+        public Builder reasoningStepsKey(String reasoningStepsKey) {
+            this.reasoningStepsKey = reasoningStepsKey;
+            return this;
+        }
+
+        /**
+         * Sets the actualOutputs key for the tool calls.
+         *
+         * @param toolCallsKey the key
+         * @return this builder
+         */
+        public Builder toolCallsKey(String toolCallsKey) {
+            this.toolCallsKey = toolCallsKey;
+            return this;
+        }
+
+        /**
+         * Sets an optional judge LLM for the adherence check.
+         * Without a judge, only the rule-based {@code plan_present} check runs.
+         *
+         * @param judge the judge LLM
+         * @return this builder
+         */
+        public Builder judge(JudgeLM judge) {
+            this.judge = judge;
+            return this;
+        }
+
+        /**
+         * Builds the evaluator.
+         *
+         * @return a new evaluator
+         */
+        public PlanAdherenceEvaluator build() {
+            return new PlanAdherenceEvaluator(this);
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluator.java
@@ -145,10 +145,14 @@ public class PlanAdherenceEvaluator extends BaseEvaluator {
     }
 
     private List<String> readPlan(Object raw) {
+        if (raw == null) {
+            return List.of();
+        }
         if (raw instanceof List<?> list) {
             return list.stream().map(String::valueOf).toList();
         }
-        return List.of();
+        throw new EvaluationException("PlanAdherenceEvaluator requires a List for '%s' in actualOutputs, got %s"
+                .formatted(reasoningStepsKey, raw.getClass().getName()));
     }
 
     /**

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluator.java
@@ -1,0 +1,199 @@
+package dev.dokimos.core.evaluators.agents;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import dev.dokimos.core.BaseEvaluator;
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.EvalTestCaseParam;
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.LlmResponseUtils;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Evaluates whether an agent's plan is coherent and goal-directed using a rule-based check
+ * and an optional LLM check.
+ * <p>
+ * The plan is read from {@code actualOutputs[reasoningStepsKey]} (default {@code "reasoningSteps"})
+ * as a {@code List<String>}, matching {@link dev.dokimos.core.agents.AgentTrace#toOutputMap()}.
+ * <p>
+ * Checks performed:
+ * <ul>
+ *   <li>{@code non_empty_reasoning} (rule): a plan is present (non-empty reasoning)</li>
+ *   <li>{@code quality} (LLM): the plan is logical, coherent, and goal-directed given the input</li>
+ * </ul>
+ * <p>
+ * Without a judge LLM, only the rule-based check runs. The score is the fraction of checks that
+ * passed. An empty plan short-circuits to a score of 1.0, and a missing key throws.
+ */
+public class PlanQualityEvaluator extends BaseEvaluator {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final JudgeLM judge;
+    private final String reasoningStepsKey;
+
+    private PlanQualityEvaluator(Builder builder) {
+        super(builder.name, builder.threshold, builder.evaluationParams);
+        this.judge = builder.judge;
+        this.reasoningStepsKey = builder.reasoningStepsKey;
+    }
+
+    /**
+     * Creates a new builder for constructing the evaluator.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected EvalResult runEvaluation(EvalTestCase testCase) {
+        Object raw = testCase.actualOutputs().get(reasoningStepsKey);
+        if (raw == null) {
+            throw new EvaluationException(
+                    "PlanQualityEvaluator requires '%s' in actualOutputs".formatted(reasoningStepsKey));
+        }
+        List<String> plan = readPlan(raw);
+
+        if (plan.isEmpty()) {
+            return EvalResult.builder()
+                    .name(name)
+                    .score(1.0)
+                    .threshold(threshold)
+                    .reason("No reasoning steps to evaluate.")
+                    .build();
+        }
+
+        Map<String, Object> checks = new LinkedHashMap<>();
+        checks.put("non_empty_reasoning", true);
+
+        if (judge != null) {
+            try {
+                Map<String, Object> parsed =
+                        LlmResponseUtils.parse(judge.generate(buildPrompt(testCase.input(), plan)), MAP_TYPE);
+                checks.put("quality", Boolean.TRUE.equals(parsed.get("quality")));
+            } catch (Exception e) {
+                return EvalResult.builder()
+                        .name(name)
+                        .score(0.0)
+                        .threshold(threshold)
+                        .reason("Failed to parse judge response: " + e.getMessage())
+                        .build();
+            }
+        } else {
+            checks.put("quality", "skipped");
+        }
+
+        long ran = checks.values().stream().filter(Boolean.class::isInstance).count();
+        long passed = checks.values().stream().filter(Boolean.TRUE::equals).count();
+        double score = ran > 0 ? (double) passed / ran : 1.0;
+
+        return EvalResult.builder()
+                .name(name)
+                .score(score)
+                .threshold(threshold)
+                .reason(String.format("Plan quality: %d/%d checks passed across %d steps.", passed, ran, plan.size()))
+                .metadata(Map.of("checks", checks))
+                .build();
+    }
+
+    private String buildPrompt(String input, List<String> plan) {
+        var sb = new StringBuilder();
+        sb.append("You are evaluating whether an AI agent's plan is coherent and goal-directed.\n\n");
+        sb.append("TASK:\n").append(input != null ? input : "(none)").append("\n\n");
+        sb.append("PLAN (ordered reasoning steps):\n");
+        for (int i = 0; i < plan.size(); i++) {
+            sb.append(i + 1).append(". ").append(plan.get(i)).append("\n");
+        }
+        sb.append("\nIs the plan logical, coherent, and goal-directed for the task? ");
+        sb.append("Respond ONLY as JSON (no markdown): {\"quality\": true/false}\n");
+        return sb.toString();
+    }
+
+    private List<String> readPlan(Object raw) {
+        if (raw instanceof List<?> list) {
+            return list.stream().map(String::valueOf).toList();
+        }
+        return List.of();
+    }
+
+    /**
+     * Builder for constructing the evaluator.
+     */
+    public static class Builder {
+        private String name = "Plan Quality";
+        private double threshold = 0.5;
+        private List<EvalTestCaseParam> evaluationParams = List.of();
+        private String reasoningStepsKey = "reasoningSteps";
+        private JudgeLM judge;
+
+        /**
+         * Sets the evaluator name.
+         *
+         * @param name the evaluator name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the minimum score threshold for success.
+         *
+         * @param threshold the threshold value
+         * @return this builder
+         */
+        public Builder threshold(double threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        /**
+         * Sets which test case parameters to validate.
+         *
+         * @param params the parameters
+         * @return this builder
+         */
+        public Builder evaluationParams(List<EvalTestCaseParam> params) {
+            this.evaluationParams = List.copyOf(params);
+            return this;
+        }
+
+        /**
+         * Sets the actualOutputs key for the plan (reasoning steps).
+         *
+         * @param reasoningStepsKey the key
+         * @return this builder
+         */
+        public Builder reasoningStepsKey(String reasoningStepsKey) {
+            this.reasoningStepsKey = reasoningStepsKey;
+            return this;
+        }
+
+        /**
+         * Sets an optional judge LLM for the coherence check.
+         * Without a judge, only the rule-based {@code non_empty_reasoning} check runs.
+         *
+         * @param judge the judge LLM
+         * @return this builder
+         */
+        public Builder judge(JudgeLM judge) {
+            this.judge = judge;
+            return this;
+        }
+
+        /**
+         * Builds the evaluator.
+         *
+         * @return a new evaluator
+         */
+        public PlanQualityEvaluator build() {
+            return new PlanQualityEvaluator(this);
+        }
+    }
+}

--- a/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluator.java
+++ b/dokimos-core/src/main/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluator.java
@@ -118,7 +118,8 @@ public class PlanQualityEvaluator extends BaseEvaluator {
         if (raw instanceof List<?> list) {
             return list.stream().map(String::valueOf).toList();
         }
-        return List.of();
+        throw new EvaluationException("PlanQualityEvaluator requires a List for '%s' in actualOutputs, got %s"
+                .formatted(reasoningStepsKey, raw.getClass().getName()));
     }
 
     /**

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluatorTest.java
@@ -87,6 +87,21 @@ class PlanAdherenceEvaluatorTest {
     }
 
     @Test
+    void shouldThrowWhenReasoningStepsIsNotAList() {
+        var evaluator = PlanAdherenceEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", "not a list")
+                .actualOutput("toolCalls", CALLS)
+                .build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("reasoningSteps")
+                .hasMessageContaining("String");
+    }
+
+    @Test
     void shouldFlagMissingPlanInRuleMode() {
         var evaluator = PlanAdherenceEvaluator.builder().build();
 

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanAdherenceEvaluatorTest.java
@@ -1,0 +1,150 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PlanAdherenceEvaluatorTest {
+
+    private static final List<ToolCall> CALLS = List.of(
+            ToolCall.of("search_flights", Map.of("to", "Paris")), ToolCall.of("book_flight", Map.of("id", "1")));
+
+    @Test
+    void shouldRunRuleOnlyWithoutJudge() {
+        var evaluator = PlanAdherenceEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", List.of("Search flights", "Book the flight"))
+                .actualOutput("toolCalls", CALLS)
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Only plan_present runs; it passes.
+        assertThat(result.score()).isEqualTo(1.0);
+
+        @SuppressWarnings("unchecked")
+        var checks = (Map<String, Object>) result.metadata().get("checks");
+        assertThat(checks.get("plan_present")).isEqualTo(true);
+        assertThat(checks.get("plan_followed")).isEqualTo("skipped");
+    }
+
+    @Test
+    void shouldScoreHighWhenCallsFollowPlanWithJudge() {
+        var evaluator = PlanAdherenceEvaluator.builder()
+                .judge(prompt -> "{\"plan_followed\": true}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", List.of("Search flights", "Book the flight"))
+                .actualOutput("toolCalls", CALLS)
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // plan_present + plan_followed both pass.
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldScoreLowWhenCallsDivergeFromPlanWithJudge() {
+        var evaluator = PlanAdherenceEvaluator.builder()
+                .judge(prompt -> "{\"plan_followed\": false}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", List.of("Search flights", "Book the flight"))
+                .actualOutput("toolCalls", List.of(ToolCall.of("order_pizza", Map.of())))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // plan_present passes, plan_followed fails: 1/2.
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    void shouldReturnPerfectScoreForNoToolCalls() {
+        var evaluator = PlanAdherenceEvaluator.builder()
+                .judge(prompt -> "{\"plan_followed\": true}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", List.of("Search flights"))
+                .actualOutput("toolCalls", List.of())
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Nothing executed: short-circuits to 1.0. Judge is never called.
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.reason()).isEqualTo("No tool calls to evaluate.");
+    }
+
+    @Test
+    void shouldFlagMissingPlanInRuleMode() {
+        var evaluator = PlanAdherenceEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder().actualOutput("toolCalls", CALLS).build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // plan_present fails, plan_followed skipped: 0/1.
+        assertThat(result.score()).isEqualTo(0.0);
+
+        @SuppressWarnings("unchecked")
+        var checks = (Map<String, Object>) result.metadata().get("checks");
+        assertThat(checks.get("plan_present")).isEqualTo(false);
+    }
+
+    @Test
+    void shouldThrowWhenToolCallsKeyAbsent() {
+        var evaluator = PlanAdherenceEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", List.of("Search flights"))
+                .build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("toolCalls");
+    }
+
+    @Test
+    void shouldReturnZeroOnMalformedJudgeJson() {
+        var evaluator = PlanAdherenceEvaluator.builder().judge(prompt -> "{").build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("reasoningSteps", List.of("Search flights", "Book the flight"))
+                .actualOutput("toolCalls", CALLS)
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("Failed to parse judge response:");
+    }
+
+    @Test
+    void shouldHonorCustomKeys() {
+        var evaluator = PlanAdherenceEvaluator.builder()
+                .reasoningStepsKey("plan")
+                .toolCallsKey("calls")
+                .judge(prompt -> "{\"plan_followed\": true}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .actualOutput("plan", List.of("Search", "Book"))
+                .actualOutput("calls", CALLS)
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+}

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluatorTest.java
@@ -94,6 +94,21 @@ class PlanQualityEvaluatorTest {
     }
 
     @Test
+    void shouldThrowWhenReasoningStepsIsNotAList() {
+        var evaluator = PlanQualityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Do something")
+                .actualOutput("reasoningSteps", "not a list")
+                .build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("reasoningSteps")
+                .hasMessageContaining("String");
+    }
+
+    @Test
     void shouldReturnZeroOnMalformedJudgeJson() {
         var evaluator =
                 PlanQualityEvaluator.builder().judge(prompt -> "not json").build();

--- a/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluatorTest.java
+++ b/dokimos-core/src/test/java/dev/dokimos/core/evaluators/agents/PlanQualityEvaluatorTest.java
@@ -1,0 +1,125 @@
+package dev.dokimos.core.evaluators.agents;
+
+import static org.assertj.core.api.Assertions.*;
+
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.evaluators.EvaluationException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PlanQualityEvaluatorTest {
+
+    @Test
+    void shouldRunRuleOnlyWithoutJudge() {
+        var evaluator = PlanQualityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a flight to Paris")
+                .actualOutput("reasoningSteps", List.of("Search flights", "Pick the cheapest", "Book it"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Only non_empty_reasoning runs; it passes.
+        assertThat(result.score()).isEqualTo(1.0);
+
+        @SuppressWarnings("unchecked")
+        var checks = (Map<String, Object>) result.metadata().get("checks");
+        assertThat(checks.get("non_empty_reasoning")).isEqualTo(true);
+        assertThat(checks.get("quality")).isEqualTo("skipped");
+    }
+
+    @Test
+    void shouldScoreHighForCoherentPlanWithJudge() {
+        var evaluator = PlanQualityEvaluator.builder()
+                .judge(prompt -> "{\"quality\": true}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a flight to Paris")
+                .actualOutput("reasoningSteps", List.of("Search flights", "Pick the cheapest", "Book it"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // non_empty_reasoning + quality both pass.
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+
+    @Test
+    void shouldScoreLowForIncoherentPlanWithJudge() {
+        var evaluator = PlanQualityEvaluator.builder()
+                .judge(prompt -> "{\"quality\": false}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a flight to Paris")
+                .actualOutput("reasoningSteps", List.of("Order a pizza", "Water the plants"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // non_empty_reasoning passes, quality fails: 1/2.
+        assertThat(result.score()).isEqualTo(0.5);
+    }
+
+    @Test
+    void shouldReturnPerfectScoreForEmptyPlanWithoutThrowing() {
+        var evaluator = PlanQualityEvaluator.builder()
+                .judge(prompt -> "{\"quality\": true}")
+                .build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a flight to Paris")
+                .actualOutput("reasoningSteps", List.of())
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        // Nothing to evaluate: short-circuits to 1.0. Judge is never called.
+        assertThat(result.score()).isEqualTo(1.0);
+        assertThat(result.reason()).isEqualTo("No reasoning steps to evaluate.");
+    }
+
+    @Test
+    void shouldThrowWhenReasoningStepsKeyAbsent() {
+        var evaluator = PlanQualityEvaluator.builder().build();
+
+        var testCase = EvalTestCase.builder().input("Do something").build();
+
+        assertThatThrownBy(() -> evaluator.evaluate(testCase))
+                .isInstanceOf(EvaluationException.class)
+                .hasMessageContaining("reasoningSteps");
+    }
+
+    @Test
+    void shouldReturnZeroOnMalformedJudgeJson() {
+        var evaluator =
+                PlanQualityEvaluator.builder().judge(prompt -> "not json").build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a flight to Paris")
+                .actualOutput("reasoningSteps", List.of("Search flights", "Book it"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(0.0);
+        assertThat(result.reason()).contains("Failed to parse judge response:");
+    }
+
+    @Test
+    void shouldHonorCustomReasoningStepsKey() {
+        var evaluator = PlanQualityEvaluator.builder().reasoningStepsKey("plan").build();
+
+        var testCase = EvalTestCase.builder()
+                .input("Book a flight")
+                .actualOutput("plan", List.of("Search", "Book"))
+                .build();
+
+        var result = evaluator.evaluate(testCase);
+
+        assertThat(result.score()).isEqualTo(1.0);
+    }
+}

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
@@ -71,6 +71,12 @@ fun toolDescriptionReliability(
     },
 ): ToolDescriptionReliabilityEvaluator = ToolDescriptionReliabilityEvaluatorDsl().apply(block).build()
 
+fun planQuality(block: PlanQualityEvaluatorDsl.() -> Unit = {}): PlanQualityEvaluator =
+    PlanQualityEvaluatorDsl().apply(block).build()
+
+fun planAdherence(block: PlanAdherenceEvaluatorDsl.() -> Unit = {}): PlanAdherenceEvaluator =
+    PlanAdherenceEvaluatorDsl().apply(block).build()
+
 // Experiment, dataset, example, task DSLs remain in root for familiarity
 fun experiment(block: ExperimentDsl.() -> Unit): Experiment = ExperimentDsl().apply(block).build()
 

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDsl.kt
@@ -13,6 +13,8 @@ import dev.dokimos.core.evaluators.PrecisionEvaluator
 import dev.dokimos.core.evaluators.RecallEvaluator
 import dev.dokimos.core.evaluators.RegexEvaluator
 import dev.dokimos.core.evaluators.agents.ArgumentMatcher
+import dev.dokimos.core.evaluators.agents.PlanAdherenceEvaluator
+import dev.dokimos.core.evaluators.agents.PlanQualityEvaluator
 import dev.dokimos.core.evaluators.agents.TaskCompletionEvaluator
 import dev.dokimos.core.evaluators.agents.ToolArgumentHallucinationEvaluator
 import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator
@@ -95,6 +97,14 @@ class EvaluatorsDsl {
 
     fun toolEfficiency(block: ToolEfficiencyEvaluatorDsl.() -> Unit = {}) {
         evaluators += ToolEfficiencyEvaluatorDsl().apply(block).build()
+    }
+
+    fun planQuality(block: PlanQualityEvaluatorDsl.() -> Unit = {}) {
+        evaluators += PlanQualityEvaluatorDsl().apply(block).build()
+    }
+
+    fun planAdherence(block: PlanAdherenceEvaluatorDsl.() -> Unit = {}) {
+        evaluators += PlanAdherenceEvaluatorDsl().apply(block).build()
     }
 
     fun evaluator(evaluator: Evaluator) {
@@ -500,6 +510,54 @@ class ToolEfficiencyEvaluatorDsl {
             .threshold(threshold)
             .toolCallsKey(toolCallsKey)
         argumentMatcher?.let { builder.argumentMatcher(it) }
+        return builder.build()
+    }
+}
+
+@DokimosDsl
+class PlanQualityEvaluatorDsl {
+    var name: String = "Plan Quality"
+    var threshold: Double = 0.5
+    var reasoningStepsKey: String = "reasoningSteps"
+    var judge: JudgeLM? = null
+    var evaluationParams: List<EvalTestCaseParam> = listOf()
+
+    fun params(vararg params: EvalTestCaseParam) {
+        evaluationParams = params.toList()
+    }
+
+    fun build(): PlanQualityEvaluator {
+        val builder = PlanQualityEvaluator.builder()
+            .name(name)
+            .threshold(threshold)
+            .reasoningStepsKey(reasoningStepsKey)
+            .evaluationParams(evaluationParams)
+        judge?.let { builder.judge(it) }
+        return builder.build()
+    }
+}
+
+@DokimosDsl
+class PlanAdherenceEvaluatorDsl {
+    var name: String = "Plan Adherence"
+    var threshold: Double = 0.5
+    var reasoningStepsKey: String = "reasoningSteps"
+    var toolCallsKey: String = "toolCalls"
+    var judge: JudgeLM? = null
+    var evaluationParams: List<EvalTestCaseParam> = listOf()
+
+    fun params(vararg params: EvalTestCaseParam) {
+        evaluationParams = params.toList()
+    }
+
+    fun build(): PlanAdherenceEvaluator {
+        val builder = PlanAdherenceEvaluator.builder()
+            .name(name)
+            .threshold(threshold)
+            .reasoningStepsKey(reasoningStepsKey)
+            .toolCallsKey(toolCallsKey)
+            .evaluationParams(evaluationParams)
+        judge?.let { builder.judge(it) }
         return builder.build()
     }
 }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDslTest.kt
@@ -18,6 +18,8 @@ import dev.dokimos.kotlin.dsl.evaluators
 import dev.dokimos.kotlin.dsl.faithfulness
 import dev.dokimos.kotlin.dsl.hallucination
 import dev.dokimos.kotlin.dsl.llmJudge
+import dev.dokimos.kotlin.dsl.planAdherence
+import dev.dokimos.kotlin.dsl.planQuality
 import dev.dokimos.kotlin.dsl.precision
 import dev.dokimos.kotlin.dsl.recall
 import dev.dokimos.kotlin.dsl.toolCallValidity
@@ -258,10 +260,18 @@ class EvaluatorDslTest {
                 name = "DescReliab"
                 threshold = 0.8
             }
+            planQuality {
+                name = "PlanQual"
+                threshold = 0.5
+            }
+            planAdherence {
+                name = "PlanAdher"
+                threshold = 0.5
+            }
             evaluator(customEvaluator)
         }
 
-        assertThat(evaluators).hasSize(15)
+        assertThat(evaluators).hasSize(17)
         assertThat(evaluators.map { it.name() }).containsExactly(
             "Exact",
             "Regex",
@@ -277,6 +287,8 @@ class EvaluatorDslTest {
             "ArgHalluc",
             "NameReliab",
             "DescReliab",
+            "PlanQual",
+            "PlanAdher",
             "Custom Eval",
         )
     }
@@ -451,5 +463,46 @@ class EvaluatorDslTest {
         val result = evaluator.evaluate(testCase)
 
         assertThat(result.score()).isEqualTo(0.5)
+    }
+
+    @Test
+    fun `planQuality standalone DSL wires judge and reasoning steps key`() {
+        val coherentJudge = JudgeLM { _ -> """{"quality": true}""" }
+
+        val evaluator = planQuality {
+            reasoningStepsKey = "plan"
+            judge = coherentJudge
+        }
+
+        val testCase = EvalTestCase.builder()
+            .input("Book a flight")
+            .actualOutput("plan", listOf("Search flights", "Book the cheapest"))
+            .build()
+
+        val result = evaluator.evaluate(testCase)
+
+        assertThat(result.score()).isEqualTo(1.0)
+        assertThat(result.success()).isTrue()
+    }
+
+    @Test
+    fun `planAdherence standalone DSL wires judge and keys`() {
+        val followedJudge = JudgeLM { _ -> """{"plan_followed": true}""" }
+
+        val evaluator = planAdherence {
+            reasoningStepsKey = "plan"
+            toolCallsKey = "calls"
+            judge = followedJudge
+        }
+
+        val testCase = EvalTestCase.builder()
+            .actualOutput("plan", listOf("Search flights", "Book the flight"))
+            .actualOutput("calls", listOf(ToolCall.of("search_flights", mapOf("to" to "Paris"))))
+            .build()
+
+        val result = evaluator.evaluate(testCase)
+
+        assertThat(result.score()).isEqualTo(1.0)
+        assertThat(result.success()).isTrue()
     }
 }

--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/integration/LangChain4jPlanEvaluatorIT.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/integration/LangChain4jPlanEvaluatorIT.java
@@ -1,0 +1,126 @@
+package dev.dokimos.langchain4j.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.dokimos.core.EvalResult;
+import dev.dokimos.core.EvalTestCase;
+import dev.dokimos.core.JudgeLM;
+import dev.dokimos.core.agents.AgentTrace;
+import dev.dokimos.core.agents.ToolCall;
+import dev.dokimos.core.evaluators.agents.PlanAdherenceEvaluator;
+import dev.dokimos.core.evaluators.agents.PlanQualityEvaluator;
+import dev.dokimos.langchain4j.LangChain4jSupport;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModelName;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Scores realistic agent plans against a real OpenAI judge to confirm {@link PlanQualityEvaluator}
+ * and {@link PlanAdherenceEvaluator} discriminate: a coherent plan whose tool calls follow it scores
+ * high, while a contradictory plan (or tool calls that ignore the plan) scores strictly lower.
+ * Requires {@code OPENAI_API_KEY}.
+ */
+@Tag("integration")
+class LangChain4jPlanEvaluatorIT {
+
+    private static ChatModel model() {
+        return OpenAiChatModel.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .modelName(OpenAiChatModelName.GPT_5_MINI)
+                .build();
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    void planQualityScoresCoherentPlanAboveIncoherentPlan() {
+        JudgeLM judge = LangChain4jSupport.asJudge(model());
+        var evaluator = PlanQualityEvaluator.builder().judge(judge).build();
+
+        String task = "Find the cheapest flight from New York to Paris next Friday and book it.";
+
+        AgentTrace coherent = AgentTrace.builder()
+                .finalResponse("Booked the cheapest flight.")
+                .reasoningSteps(List.of(
+                        "Search available flights from New York to Paris for next Friday.",
+                        "Compare the results and pick the cheapest option.",
+                        "Book the selected flight and confirm the reservation."))
+                .build();
+        EvalTestCase coherentCase = EvalTestCase.builder()
+                .input(task)
+                .actualOutputs(coherent.toOutputMap())
+                .build();
+
+        AgentTrace incoherent = AgentTrace.builder()
+                .finalResponse("Done.")
+                .reasoningSteps(List.of(
+                        "Water the office plants.",
+                        "Reboot the coffee machine.",
+                        "Refactor an unrelated logging module."))
+                .build();
+        EvalTestCase incoherentCase = EvalTestCase.builder()
+                .input(task)
+                .actualOutputs(incoherent.toOutputMap())
+                .build();
+
+        EvalResult coherentResult = evaluator.evaluate(coherentCase);
+        EvalResult incoherentResult = evaluator.evaluate(incoherentCase);
+
+        assertThat(coherentResult.score())
+                .as("a coherent, goal-directed plan scores high. reason=%s", coherentResult.reason())
+                .isGreaterThanOrEqualTo(0.75);
+        assertThat(incoherentResult.score())
+                .as(
+                        "a plan unrelated to the task scores strictly lower. coherent=%s incoherent=%s",
+                        coherentResult.reason(), incoherentResult.reason())
+                .isLessThan(coherentResult.score());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    void planAdherenceScoresFollowedPlanAboveIgnoredPlan() {
+        JudgeLM judge = LangChain4jSupport.asJudge(model());
+        var evaluator = PlanAdherenceEvaluator.builder().judge(judge).build();
+
+        List<String> plan = List.of(
+                "Search for flights from New York to Paris.",
+                "Pick the cheapest matching flight.",
+                "Book the selected flight.");
+
+        AgentTrace followed = AgentTrace.builder()
+                .finalResponse("Booked.")
+                .reasoningSteps(plan)
+                .toolCalls(List.of(
+                        ToolCall.of("search_flights", Map.of("from", "New York", "to", "Paris")),
+                        ToolCall.of("book_flight", Map.of("flightId", "AF123"))))
+                .build();
+        EvalTestCase followedCase =
+                EvalTestCase.builder().actualOutputs(followed.toOutputMap()).build();
+
+        AgentTrace ignored = AgentTrace.builder()
+                .finalResponse("Done.")
+                .reasoningSteps(plan)
+                .toolCalls(List.of(
+                        ToolCall.of("order_pizza", Map.of("topping", "pepperoni")),
+                        ToolCall.of("send_email", Map.of("to", "someone@example.com"))))
+                .build();
+        EvalTestCase ignoredCase =
+                EvalTestCase.builder().actualOutputs(ignored.toOutputMap()).build();
+
+        EvalResult followedResult = evaluator.evaluate(followedCase);
+        EvalResult ignoredResult = evaluator.evaluate(ignoredCase);
+
+        assertThat(followedResult.score())
+                .as("tool calls that follow the plan score high. reason=%s", followedResult.reason())
+                .isGreaterThanOrEqualTo(0.75);
+        assertThat(ignoredResult.score())
+                .as(
+                        "tool calls that ignore the plan score strictly lower. followed=%s ignored=%s",
+                        followedResult.reason(), ignoredResult.reason())
+                .isLessThan(followedResult.score());
+    }
+}


### PR DESCRIPTION
Adds two judge-based agent evaluators in `dokimos-core`.

- **`PlanQualityEvaluator`** scores whether the agent's reasoning plan (`reasoningSteps`) is coherent and goal-directed for the task.
- **`PlanAdherenceEvaluator`** scores whether the executed tool calls carried out that plan.