### PR TITLE
Bump frontend and docs dependencies

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -30,13 +30,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.108",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.108.tgz",
-      "integrity": "sha512-86SG+gvko20aD6aM2Z4Mx8rEJYHpC2E2QrrEQzerXkEtruMWJCKwFfeaOKDLn8axN18Lln+HvYbS6cOiRA1J0g==",
+      "version": "2.0.117",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.117.tgz",
+      "integrity": "sha512-OubKzzPrWqodgrlZRsldskPno7MFvHnYZAxp+Sm7os1adQ2+VdfxEz4Kjowm6PJUmhHv8EyEAKM8NQX3YtDsig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.28",
+        "@ai-sdk/provider-utils": "3.0.30",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.28.tgz",
-      "integrity": "sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.30.tgz",
+      "integrity": "sha512-NCJ9JKow5ENAgEZxzvEvF20thwDiH+hutvzmrUDbloRX0azpJHNst8+7pZIVryYhLM9wgpT5/ShTSjPTFhkxEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
@@ -76,13 +76,13 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "2.0.211",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.211.tgz",
-      "integrity": "sha512-wAOKufjk1hxC20xAQCmXGJvhgy/9HESnVFeo6dcYf4ykNdATk6rfi4d+IpK8GKM0BrJ1bnDss12YfTDDtaT5rQ==",
+      "version": "2.0.220",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.220.tgz",
+      "integrity": "sha512-N9SVy3nHh3jqjpjKtbdgOUX5HnbWndRJI1UPod5bQcWbe6r8u1fW2Xmfwtff0WT6VNwSK9jxqk/KZNw0Yw0mwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.28",
-        "ai": "5.0.209",
+        "@ai-sdk/provider-utils": "3.0.30",
+        "ai": "5.0.218",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -6042,14 +6042,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.209",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.209.tgz",
-      "integrity": "sha512-M5iPINrFG/7fJamY4ibnuj+/1e8g3zMJj7f0EEoq25LTlgmqJqeVsRz2u7x7X4E+KvJuOWIJFAcwHVb6Nr9UfA==",
+      "version": "5.0.218",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.218.tgz",
+      "integrity": "sha512-h8rPBtp24iPybJpaadpu9/R6TyXqzxXYZj/r7HfMoCgNJn+0TxSBgDjSUjVVxDyS2wOyOtEJBdadsM19N59hYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.108",
+        "@ai-sdk/gateway": "2.0.117",
         "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.28",
+        "@ai-sdk/provider-utils": "3.0.30",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -6545,9 +6545,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8143,9 +8143,9 @@
       }
     },
     "node_modules/docusaurus-plugin-llms/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16869,9 +16869,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18408,9 +18408,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
@@ -18431,7 +18431,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/dokimos-server/frontend/package-lock.json
+++ b/dokimos-server/frontend/package-lock.json
@@ -1151,29 +1151,29 @@
       }
     },
     "node_modules/@orval/angular": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.18.0.tgz",
-      "integrity": "sha512-H8g9BLSwtKVa9vh43PGq/y3n9ATYPP6nm9or9j7zJ9GuTxVYxsu/eLET5tC1dkYNjr0urUgmOSm1QVNex5ALUQ==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.22.0.tgz",
+      "integrity": "sha512-lSvaNj+VHGIWBQOG104HfPNrk2xGjpArwy67u6ZBPzHo/OtDE5Tm1t+ARYseCOElFr4z3i3A62qjFLFy6zj00Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0"
+        "@orval/core": "8.22.0"
       }
     },
     "node_modules/@orval/axios": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.18.0.tgz",
-      "integrity": "sha512-MfZCrYJrOrzODBK8zGOAwBB/HtQhGJzwBHYn/Elz7qvwc1YfsIQdua1YuiA+YAPtOOdNcTn6tCrWQQQJf/JP6A==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.22.0.tgz",
+      "integrity": "sha512-fFu0UgTbpI9a1ayM7qCs55MMy6MlVgOpE3BBXGukCTBSwNwFLN47WdzQev/x0mAcs58pNKYT0KL4R9MXGnmgfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0"
+        "@orval/core": "8.22.0"
       }
     },
     "node_modules/@orval/core": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/core/-/core-8.18.0.tgz",
-      "integrity": "sha512-JkrJBvSj9XSKbptZ6XqD+Uf/gmcax9HlXhTkco+bzj3ukw68JBc4wKEzt2P8qEOx/SYqk/te9gePH2l0HUwE/w==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/core/-/core-8.22.0.tgz",
+      "integrity": "sha512-uKYi7+Smg6oQ2MxE0AS2FNI7bwssoxGLh391Uk0FU+DcTcSv9q2GmvoM8uwd827Hok29kD7AegHE8Mhmsa5uWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1185,6 +1185,7 @@
         "esutils": "2.0.3",
         "fs-extra": "^11.3.2",
         "jiti": "^2.6.1",
+        "jsesc": "^3.0.0",
         "remeda": "^2.33.6",
         "tinyglobby": "^0.2.16",
         "typedoc": "^0.28.19"
@@ -1199,38 +1200,36 @@
       }
     },
     "node_modules/@orval/effect": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/effect/-/effect-8.18.0.tgz",
-      "integrity": "sha512-z6DZDxgNHIqM8vmr5aOcRHs7BaLVJ+Gmsz1myGdYJQ0M7VmlqB6huhBw3NhFOJfQ4bbz3KRsySMvFCdTUhSiRw==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/effect/-/effect-8.22.0.tgz",
+      "integrity": "sha512-DACiw2+0ZsPJPKQbYlb9qFFFppaCBaT/HgIq2S1asH9ZCOOTZKm9VrRXpeCWINHC2w1BpdSATpytv+61UT5Y/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
+        "@orval/core": "8.22.0",
         "remeda": "^2.33.6"
       }
     },
     "node_modules/@orval/fetch": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.18.0.tgz",
-      "integrity": "sha512-1zM2cODgoTVIzHbSGHsrqehfTEv8vHXsPsg/unKoDjTcmIBt+JAKc/ZShBzgyvmcWDfJP0mapE16EJrAwQNf8w==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.22.0.tgz",
+      "integrity": "sha512-G0r6hOdZG963H/8S4Vk1kWfU/hkQC/cwpDZL+mzcXgzrdG9NDloshTqmge/jP5lPsFAwfcRUmmts10OmuIE4BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
-        "@scalar/openapi-types": "0.8.0"
+        "@orval/core": "8.22.0"
       }
     },
     "node_modules/@orval/hono": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.18.0.tgz",
-      "integrity": "sha512-sCxuctSy9vzG2MV0/tWCVL/buKoUYHg7pEntEeri0aOry5tlt52KDGPqIUk8WJN2TwOGrIxyA2olbsNgGjjErA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.22.0.tgz",
+      "integrity": "sha512-GMCpGZqCuGYSu10KTt2q3WYzCqEcTGxr18z3HgHv9dX22sv/V76dlLBh3SE72xp8Z7/jmoq3GKBdgU9k98ju0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
-        "@orval/zod": "8.18.0",
-        "fs-extra": "^11.3.2",
-        "remeda": "^2.33.6"
+        "@orval/core": "8.22.0",
+        "@orval/zod": "8.22.0",
+        "fs-extra": "^11.3.2"
       },
       "peerDependencies": {
         "typescript": ">=5"
@@ -1242,70 +1241,70 @@
       }
     },
     "node_modules/@orval/mcp": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.18.0.tgz",
-      "integrity": "sha512-sNjkAI6bUJ5Tv+KjItaSgUDvHpXST3KkEDnwp23lvc8Eh9PHrb4Uca4wj3qrKkL0f5Z2X8I2jELP56n7j7x48A==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.22.0.tgz",
+      "integrity": "sha512-ySa4EenAF8YMCpbmddJGO3lItTPC8Uf/iT+P2ezaowVgxOCPX/fjG7dd0fnVmrr0vaphi53yWx5o5DlT17FzLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
-        "@orval/fetch": "8.18.0",
-        "@orval/zod": "8.18.0"
+        "@orval/core": "8.22.0",
+        "@orval/fetch": "8.22.0",
+        "@orval/zod": "8.22.0"
       }
     },
     "node_modules/@orval/mock": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.18.0.tgz",
-      "integrity": "sha512-LB8zZS47oROAcyYCh7Jk5vWg9p/Nyr864TgH8FM2/+GZ2Hkw9IGVnAk+XV0KQODbAVt5t47BBfgKsOc/3gzVXg==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.22.0.tgz",
+      "integrity": "sha512-ZCEFpdi4z+YOCg0Tsgz6DO/M1TSfYxE5urDWJgYNUKeD8XDEHFb2IgTiiaAwJunqWnRQuiMfGp9G81+u10Kx6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
+        "@orval/core": "8.22.0",
         "remeda": "^2.33.6"
       }
     },
     "node_modules/@orval/query": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/query/-/query-8.18.0.tgz",
-      "integrity": "sha512-57awXfuTqWsrLfsyj9GOoNVzdjnqJ5zKDjhtm0nUrbxSec7olCLPoOQ9GVEOmQZyEuN0yFldjMNiVZxIlXsGnA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/query/-/query-8.22.0.tgz",
+      "integrity": "sha512-IH9049z860CLUeGEezGv+yOvUvcAyDnd9doDe1Ryi0WxsDul2Vh3LjCRUEQf4JZiyZezadWYYGzs0lwnCn/afA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
-        "@orval/fetch": "8.18.0",
+        "@orval/core": "8.22.0",
+        "@orval/fetch": "8.22.0",
         "remeda": "^2.33.6"
       }
     },
     "node_modules/@orval/solid-start": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.18.0.tgz",
-      "integrity": "sha512-bIZyjaUez50QV2hROg4H1GixWVe/wGk0Df3fU5mxcCnGPZA0k+z5VaavQmfk01WtfYiFZ4eUeb93IYMgpocBXA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.22.0.tgz",
+      "integrity": "sha512-Q1ZCWOrA6/VJnyj62XpPxXti9NpAA4lDZVqPL2uQ5gbxv+T+azEaazKqYIpSBJXbl1aEezujdcyg/DVUakWKEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
-        "@scalar/openapi-types": "0.8.0"
+        "@orval/core": "8.22.0"
       }
     },
     "node_modules/@orval/swr": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.18.0.tgz",
-      "integrity": "sha512-hxkw0ZqBUl0Xgk7Cs9nPkTEOO5j1CeVkI66KtBS3sjk3hapJinsrL0g8fjsEmb4dvJJINvsCGg3iJ/3ZMW3EqQ==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.22.0.tgz",
+      "integrity": "sha512-OSeWX3Af8ESapKIo3XpbOaTMaG8oeEtuucFyOUauqg6NyC6/9Ikcf2csBdF0AuIKA0QTcjcXxra/ccj1f7KnRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
-        "@orval/fetch": "8.18.0"
+        "@orval/core": "8.22.0",
+        "@orval/fetch": "8.22.0"
       }
     },
     "node_modules/@orval/zod": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.18.0.tgz",
-      "integrity": "sha512-fhcu4+JLE1dHlQQd5BMmwCAuVOyEo1z7lov0S3dzg4gb2UBRGbYdMkf6jf8CbUq12GT9Rn+/PEElHnYmaUZaAA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.22.0.tgz",
+      "integrity": "sha512-briHtUTz79fvCeIFfGW3IbmUIF9DOotUoWFa/sKUjRUG8PMGDWSjQzO8QdLzLoETVGo9g4TfGwp5Xjcs81GZTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@orval/core": "8.18.0",
+        "@orval/core": "8.22.0",
+        "jsesc": "^3.0.0",
         "remeda": "^2.33.6"
       }
     },
@@ -2933,9 +2932,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3070,9 +3069,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3127,26 +3126,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -3244,9 +3223,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3715,20 +3694,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -4254,9 +4219,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4635,9 +4600,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -5310,31 +5275,30 @@
       }
     },
     "node_modules/orval": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/orval/-/orval-8.18.0.tgz",
-      "integrity": "sha512-cbMBM4igqRpIXzWQRp1rReJHwI/fOBb5qWVeJmWCMedIQ3fX7ahiP7AvLOgtYfDoJfe61/bY2ZkOOFYIkB1njQ==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/orval/-/orval-8.22.0.tgz",
+      "integrity": "sha512-N8UmB4DOhW+Z2SzVq4oS/pN3DsRPq+msrRU8NyRldP1i0yiqT6qo8mUxHPk2umqYjyY0FlR2mvPbi/Jf5CiP7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^15.0.0",
-        "@orval/angular": "8.18.0",
-        "@orval/axios": "8.18.0",
-        "@orval/core": "8.18.0",
-        "@orval/effect": "8.18.0",
-        "@orval/fetch": "8.18.0",
-        "@orval/hono": "8.18.0",
-        "@orval/mcp": "8.18.0",
-        "@orval/mock": "8.18.0",
-        "@orval/query": "8.18.0",
-        "@orval/solid-start": "8.18.0",
-        "@orval/swr": "8.18.0",
-        "@orval/zod": "8.18.0",
+        "@orval/angular": "8.22.0",
+        "@orval/axios": "8.22.0",
+        "@orval/core": "8.22.0",
+        "@orval/effect": "8.22.0",
+        "@orval/fetch": "8.22.0",
+        "@orval/hono": "8.22.0",
+        "@orval/mcp": "8.22.0",
+        "@orval/mock": "8.22.0",
+        "@orval/query": "8.22.0",
+        "@orval/solid-start": "8.22.0",
+        "@orval/swr": "8.22.0",
+        "@orval/zod": "8.22.0",
         "@scalar/json-magic": "^0.12.16",
         "@scalar/openapi-parser": "^0.28.7",
         "@scalar/openapi-types": "0.8.0",
         "chokidar": "^5.0.0",
         "commander": "^15.0.0",
-        "enquirer": "^2.4.1",
         "execa": "^9.6.1",
         "find-up": "8.0.0",
         "fs-extra": "^11.3.2",
@@ -5964,19 +5928,6 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -6188,9 +6139,9 @@
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/dokimos-server/frontend/package.json
+++ b/dokimos-server/frontend/package.json
@@ -45,5 +45,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
     "vite": "^8.0.16"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
Clears the open npm Dependabot alerts in the two lockfiles. docs is bumped via npm audit fix (brace-expansion, shell-quote, webpack-dev-server, body-parser). The server frontend js-yaml alert is pinned to 4.3.0 with an overrides entry instead of npm audit fix --force, which would have downgraded orval a major version. Both the docs site and the frontend still build. The remaining @ai-sdk lows have no patched release yet.