### PR TITLE
Fix the release Docker builds for the dokimos-openai module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,25 @@ jobs:
 
       - name: Test ${{ matrix.module }} against ${{ matrix.property }}=${{ matrix.version }}
         run: mvn -B -U test -pl ${{ matrix.module }} -am -D${{ matrix.property }}=${{ matrix.version }} ${{ matrix.profiles }}
+
+  dockerfile-modules:
+    name: Dockerfile module list
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The release Docker builds copy every reactor module POM by hand. A module added to the
+      # parent <modules> without a matching COPY line breaks the image builds at release time.
+      - name: Check Dockerfiles copy every module POM
+        run: |
+          modules=$(awk '/<modules>/{f=1;next} /<\/modules>/{exit} f' pom.xml | sed -n 's/.*<module>\(.*\)<\/module>.*/\1/p')
+          status=0
+          for dockerfile in dokimos-server/Dockerfile dokimos-mcp-server/Dockerfile; do
+            for module in $modules; do
+              if ! grep -q "COPY $module/pom.xml" "$dockerfile"; then
+                echo "$dockerfile is missing: COPY $module/pom.xml"
+                status=1
+              fi
+            done
+          done
+          exit $status

--- a/dokimos-mcp-server/Dockerfile
+++ b/dokimos-mcp-server/Dockerfile
@@ -9,6 +9,7 @@ COPY dokimos-junit/pom.xml ./dokimos-junit/pom.xml
 COPY dokimos-langchain4j/pom.xml ./dokimos-langchain4j/pom.xml
 COPY dokimos-spring-ai/pom.xml ./dokimos-spring-ai/pom.xml
 COPY dokimos-spring-ai-alibaba/pom.xml ./dokimos-spring-ai-alibaba/pom.xml
+COPY dokimos-openai/pom.xml ./dokimos-openai/pom.xml
 COPY dokimos-koog/pom.xml ./dokimos-koog/pom.xml
 COPY dokimos-kotlin/pom.xml ./dokimos-kotlin/pom.xml
 COPY dokimos-server-client/pom.xml ./dokimos-server-client/pom.xml

--- a/dokimos-server/Dockerfile
+++ b/dokimos-server/Dockerfile
@@ -9,6 +9,7 @@ COPY dokimos-junit/pom.xml ./dokimos-junit/pom.xml
 COPY dokimos-langchain4j/pom.xml ./dokimos-langchain4j/pom.xml
 COPY dokimos-spring-ai/pom.xml ./dokimos-spring-ai/pom.xml
 COPY dokimos-spring-ai-alibaba/pom.xml ./dokimos-spring-ai-alibaba/pom.xml
+COPY dokimos-openai/pom.xml ./dokimos-openai/pom.xml
 COPY dokimos-koog/pom.xml ./dokimos-koog/pom.xml
 COPY dokimos-kotlin/pom.xml ./dokimos-kotlin/pom.xml
 COPY dokimos-server-client/pom.xml ./dokimos-server-client/pom.xml


### PR DESCRIPTION
The v0.24.0 Docker publish failed because both Dockerfiles copy every reactor module POM by hand and the new dokimos-openai module was missing, so Maven aborted on a nonexistent child module.