### PR TITLE
Sync the README roadmap with the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,9 +526,10 @@ See the [server documentation](https://dokimos.dev/server/overview) for deployme
 
 ## Roadmap
 
-- More built in evaluators: misuse detection
-- CLI for running evaluations outside of tests
-- Server-side Dataset versioning and management
+- More built-in evaluators: misuse detection and more
+- Test data generation: LLM-generated synthetic datasets for evaluation
+- SPI (Service Provider Interface): plug in custom storage, metrics, and reporting
+- CLI for running experiments, managing datasets, and generating reports
 
 See the [full roadmap](https://dokimos.dev/overview/#whats-next) on the docs site.
 


### PR DESCRIPTION
The README roadmap still listed server-side dataset versioning as planned, but that shipped a while ago (ServerDatasetResolver, dataset://name@version, the server datasets page). Replaces the stale list with the What is next list from the docs overview: built-in evaluators, test data generation, SPI, and the CLI.