### PR TITLE
Make the Koog dependency provided-scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,10 @@ jobs:
             property: koog.version
             version: '1.0.0'
             profiles: '-P!koog-live-it'
+          - module: dokimos-koog
+            property: koog.version
+            version: '1.1.1'
+            profiles: '-P!koog-live-it'
           # spring-ai-alibaba is not source-compatible across releases (1.0.0.4 added a checked
           # exception on CompiledGraph.invoke; 1.1.x relocated the agent types and changed the
           # ReactAgent builder), so we track the one supported version on the current 1.1.x line.

--- a/dokimos-koog/pom.xml
+++ b/dokimos-koog/pom.xml
@@ -53,6 +53,7 @@
             <groupId>ai.koog</groupId>
             <artifactId>koog-agents-jvm</artifactId>
             <version>${koog.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
`dokimos-koog` was the only adapter shipping its framework at compile scope, so consumers pulled Koog into their dependency tree instead of bringing their own. Matches langchain4j, spring-ai, openai and embabel now.

Also adds a Koog 1.1.1 row to the adapter compat matrix, which was topping out at 1.0.0.