### PR TITLE
Fix the flaky plan adherence integration test

### DIFF
--- a/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/integration/LangChain4jPlanEvaluatorIT.java
+++ b/dokimos-langchain4j/src/test/java/dev/dokimos/langchain4j/integration/LangChain4jPlanEvaluatorIT.java
@@ -91,11 +91,14 @@ class LangChain4jPlanEvaluatorIT {
                 "Pick the cheapest matching flight.",
                 "Book the selected flight.");
 
+        // One tool call per plan step. Leaving the "pick the cheapest" step without a matching call
+        // makes adherence a judgement call, and a strict judge reads it as not followed.
         AgentTrace followed = AgentTrace.builder()
                 .finalResponse("Booked.")
                 .reasoningSteps(plan)
                 .toolCalls(List.of(
                         ToolCall.of("search_flights", Map.of("from", "New York", "to", "Paris")),
+                        ToolCall.of("select_cheapest_flight", Map.of("flightId", "AF123", "price", "412.00")),
                         ToolCall.of("book_flight", Map.of("flightId", "AF123"))))
                 .build();
         EvalTestCase followedCase =


### PR DESCRIPTION
The "followed" fixture had a three-step plan but only two tool calls, with nothing matching "pick the cheapest matching flight", so whether the plan was followed was a judgement call. GPT-5-mini usually forgave it and occasionally did not, which is the intermittent failure on master.

Adds the missing `select_cheapest_flight` call. Checked against a deterministic judge (gpt-4o-mini, temperature 0): the old fixture scored not-followed 12/12, the new one scores followed 12/12.