### PR TITLE
Sync Kotlin DSL with 0.27.0 core: agents, structuralMatch, measuredTask, gate config

### DIFF
--- a/docs/docs/evaluation/agent-evaluation.md
+++ b/docs/docs/evaluation/agent-evaluation.md
@@ -63,26 +63,75 @@ var results = List.of(
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
+// 1. List the tools your agent can use — the schema is declared inline
+val tools = tools {
+    tool("search_flights") {
+        description = "Search for available flights"
+        parameters {
+            string("origin", "Origin airport IATA code", required = true)
+            string("destination", "Destination airport IATA code", required = true)
+            string("date", "Travel date in YYYY-MM-DD format")
+        }
+    }
+    tool("book_hotel") {
+        description = "Book a hotel room"
+        parameters {
+            string("city", "City name", required = true)
+            integer("nights", "Number of nights")
+        }
+    }
+}
+
+// 2. Set up a judge LLM (needed for task completion and hallucination checks)
 val judge = JudgeLM { prompt -> openAiClient.generate(prompt) }
 
-val result = experiment {
-    name = "Travel Agent Evaluation"
-    dataset(dataset)
-    task { example ->
-        val trace = travelAgent.run(example.input())
-        trace.toOutputMap()
+// 3. Run your agent and capture its trace
+val trace = agentTrace {
+    toolCall("search_flights", mapOf("origin" to "JFK", "destination" to "CDG"))
+    toolCall("book_hotel", mapOf("city" to "Paris", "nights" to 5))
+    finalResponse = "Found flights and booked your hotel in Paris."
+}
+
+// 4. Build a test case
+val testCase = agentTestCase {
+    input = "Find flights from NYC to Paris and book a hotel for 5 nights"
+    trace(trace)
+    tools(tools)
+    expectedToolCalls {
+        call("search_flights", mapOf())
+        call("book_hotel", mapOf())
     }
-    evaluators {
-        toolCallValidity { }
-        toolCorrectness { }
-        taskCompletion(judge) { }
-        toolArgumentHallucination(judge) { }
-    }
-}.run()
+    tasks("Search for flights", "Book a hotel")
+}
+
+// 5. Pick the evaluators you need and run them
+val results = listOf(
+    toolCallValidity().evaluate(testCase),
+    toolCorrectness().evaluate(testCase),
+    taskCompletion(judge).evaluate(testCase),
+    toolArgumentHallucination(judge).evaluate(testCase),
+)
 ```
 
   </TabItem>
 </Tabs>
+
+:::tip Kotlin DSL
+The agent builders live in `dev.dokimos.kotlin.dsl.agents`:
+
+| Entry point                                  | Builds                                                                                       |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `toolDefinition(name) { }` / `tools { }`     | `ToolDefinition`s, with a typed `parameters { }` JSON-schema builder                          |
+| `toolCall(name) { }` / `toolCalls { }`       | `ToolCall`s, including `resultJson(...)` for a serialized result                              |
+| `agentTrace { }`                             | an `AgentTrace` with tool calls, reasoning steps, and metadata                                 |
+| `agentTestCase { }`                          | an `EvalTestCase` wired for the agent evaluators                                              |
+
+`agentTestCase` delegates the shared slots to `AgentEvalCase` and adds the ones it does not cover:
+the final response, the `reasoningSteps` that `planQuality` and `planAdherence` read, and the
+`constraints` entry `taskCompletion` reads.
+
+> See [`AgentEvaluationKotlinExample.kt`](https://github.com/dokimos-dev/dokimos/blob/master/dokimos-examples/src/main/kotlin/dev/dokimos/examples/agents/AgentEvaluationKotlinExample.kt) for a runnable example.
+:::
 
 ## Evaluators
 

--- a/docs/docs/evaluation/evaluators.md
+++ b/docs/docs/evaluation/evaluators.md
@@ -267,10 +267,10 @@ EvalResult result = structural.evaluate(testCase);
 ```kotlin
 data class Invoice(val id: String, val total: Double, val items: List<String>)
 
-val structural: Evaluator = StructuralMatchEvaluator.builder()
-    .name("Invoice Match")
-    .threshold(1.0)
-    .build()  // STRICT mode, outputKey "output", partial scoring
+val structural: Evaluator = structuralMatch {
+    name = "Invoice Match"
+    threshold = 1.0
+}  // STRICT mode, outputKey "output", partial scoring
 
 val testCase = EvalTestCase.builder()
     .expectedOutput("output", Invoice("INV-1", 42.0, listOf("a", "b")))
@@ -306,11 +306,11 @@ Evaluator lenient = StructuralMatchEvaluator.builder()
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-val lenient: Evaluator = StructuralMatchEvaluator.builder()
-    .name("Extraction Match")
-    .mode(StructuralMatchMode.LENIENT)  // tolerate extra fields, ignore array order
-    .threshold(0.9)
-    .build()
+val lenient: Evaluator = structuralMatch {
+    name = "Extraction Match"
+    mode = StructuralMatchMode.LENIENT  // tolerate extra fields, ignore array order
+    threshold = 0.9
+}
 ```
 
   </TabItem>
@@ -337,11 +337,11 @@ Evaluator contract = StructuralMatchEvaluator.builder()
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-val contract: Evaluator = StructuralMatchEvaluator.builder()
-    .name("Schema Contract")
-    .binary()          // 1.0 if everything matches, 0.0 otherwise
-    .threshold(1.0)
-    .build()
+val contract: Evaluator = structuralMatch {
+    name = "Schema Contract"
+    binary = true      // 1.0 if everything matches, 0.0 otherwise
+    threshold = 1.0
+}
 ```
 
   </TabItem>

--- a/docs/docs/evaluation/experiments.md
+++ b/docs/docs/evaluation/experiments.md
@@ -307,6 +307,29 @@ ExperimentResult result = Experiment.builder()
 
 The plain `task(Task)` path still works the same. Use `measuredTask(MeasuredTask)` only when you want metrics on the results. The builder method has a separate name so a lambda passed to `task(...)` is never ambiguous between the two interfaces.
 
+In Kotlin, the DSL exposes the same path as `measuredTask { ... }`, either inside `experiment { }` or standalone:
+
+```kotlin
+val result = experiment {
+    name = "QA Evaluation"
+    dataset(dataset)
+    measuredTask { example ->
+        val start = System.currentTimeMillis()
+        val response = myLlmService.generate(example.input())
+        val metrics = CallMetrics(
+            response.promptTokens,
+            response.completionTokens,
+            response.costUsd,
+            System.currentTimeMillis() - start,
+        )
+        TaskResult(mapOf("output" to response.text), metrics)
+    }
+    evaluator(evaluators)
+}.run()
+```
+
+Setting both `task` and `measuredTask` on the same experiment fails fast, since they share one slot.
+
 ## Running against a dataset
 
 ### Load a dataset from a file

--- a/docs/docs/evaluation/regression-gate.md
+++ b/docs/docs/evaluation/regression-gate.md
@@ -194,17 +194,17 @@ Assertions.assertNoRegression(result, "rag", config);
   <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-import dev.dokimos.core.gate.GateConfig
-
-val config = GateConfig.builder()
-    .severityMargin(0.10)
-    .build()
-
-result.assertNoRegression("rag", config)
+result.assertNoRegression("rag") {
+    severityMargin = 0.10                              // stricter single-item drop guard
+    pairing = GateConfig.Pairing.DATASET_ITEM_ID       // pair strictly by id
+    bootstrapPasses = false                            // fail once until the baseline is reviewed
+}
 ```
 
   </TabItem>
 </Tabs>
+
+The block overload builds a `GateConfig` inline via the `dev.dokimos.kotlin.dsl.gate.gateConfig` DSL, starting from `GateConfig.defaults()` so unset properties keep their core defaults. Use `dev.dokimos.kotlin.dsl.gate.gateConfig { ... }` directly when you want a standalone `GateConfig` — for example to reuse across several `assertNoRegression` calls, or to pass to `RegressionGate.evaluate(...)`.
 
 | Option | Default | What it controls |
 | --- | --- | --- |

--- a/dokimos-examples/src/main/kotlin/dev/dokimos/examples/agents/AgentEvaluationKotlinExample.kt
+++ b/dokimos-examples/src/main/kotlin/dev/dokimos/examples/agents/AgentEvaluationKotlinExample.kt
@@ -1,0 +1,131 @@
+package dev.dokimos.examples.agents
+
+import dev.dokimos.core.EvalResult
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.kotlin.dsl.agents.agentTestCase
+import dev.dokimos.kotlin.dsl.agents.agentTrace
+import dev.dokimos.kotlin.dsl.agents.tools
+import dev.dokimos.kotlin.dsl.toolCallValidity
+import dev.dokimos.kotlin.dsl.toolCorrectness
+import dev.dokimos.kotlin.dsl.toolDescriptionReliability
+import dev.dokimos.kotlin.dsl.toolEfficiency
+import dev.dokimos.kotlin.dsl.toolError
+import dev.dokimos.kotlin.dsl.toolNameReliability
+
+/**
+ * Kotlin counterpart of [dev.dokimos.examples.basic.AgentEvaluationExample].
+ *
+ * Shows the Kotlin agent DSL:
+ * - declaring tools with a typed JSON schema builder instead of nested maps
+ * - building an agent trace with tool calls, results, and reasoning steps
+ * - turning that trace into an `EvalTestCase` the agent evaluators understand
+ */
+object AgentEvaluationKotlinExample {
+
+    private val availableTools = tools {
+        tool("search_flights") {
+            description = "Search for available flights between airports"
+            parameters {
+                string("origin", "Origin airport IATA code", required = true)
+                string("destination", "Destination airport IATA code", required = true)
+                string("date", "Travel date in YYYY-MM-DD format")
+            }
+        }
+        tool("book_hotel") {
+            description = "Book a hotel room in a specific city"
+            parameters {
+                string("city", "City name", required = true)
+                string("checkIn", "Check-in date")
+                integer("nights", "Number of nights")
+            }
+        }
+        tool("get_weather") {
+            description = "Get weather forecast for a city"
+            parameters {
+                string("city", "City name", required = true)
+            }
+        }
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        println("=== Dokimos Agent Evaluation Example (Kotlin DSL) ===\n")
+
+        // Simulate an agent trace
+        val trace = agentTrace {
+            reasoning("User wants to travel to Paris. I need to search for flights and book a hotel.")
+            toolCall("search_flights") {
+                argument("origin", "NYC")
+                argument("destination", "CDG")
+                argument("date", "2026-03-15")
+                result = "Found 5 flights from NYC to CDG on 2026-03-15"
+            }
+            reasoning("Found flights. Now booking a hotel.")
+            toolCall("book_hotel") {
+                argument("city", "Paris")
+                argument("checkIn", "2026-03-15")
+                argument("nights", 3)
+                resultJson(mapOf("hotel" to "Hotel Le Marais", "nights" to 3))
+            }
+            finalResponse =
+                "I've found flights from NYC to Paris and booked Hotel Le Marais for 3 nights starting March 15."
+            metadata("totalLatencyMs" to 2500)
+        }
+
+        println("Agent trace:")
+        println("  Final response: ${trace.finalResponse()}")
+        println("  Tool calls: ${trace.toolNames()}")
+        println("  Reasoning steps: ${trace.reasoningSteps().size}")
+        println()
+
+        // The trace plus the tools and expectations become a test case in one block
+        val testCase = agentTestCase {
+            input = "Find flights from NYC to Paris and book a hotel for 3 nights"
+            trace(trace)
+            tools(availableTools)
+            expectedToolCalls {
+                call("search_flights", mapOf())
+                call("book_hotel", mapOf())
+            }
+            tasks("Search for flights", "Book a hotel")
+        }
+
+        println("--- Tool Call Validity ---")
+        printResult(toolCallValidity().evaluate(testCase))
+
+        println("--- Tool Correctness ---")
+        printResult(toolCorrectness().evaluate(testCase))
+
+        println("--- Tool Error ---")
+        printResult(toolError().evaluate(testCase))
+
+        println("--- Tool Efficiency ---")
+        printResult(toolEfficiency().evaluate(testCase))
+
+        // Tool reliability only needs the definitions, not a run
+        val toolsOnlyTestCase: EvalTestCase = agentTestCase { tools(availableTools) }
+
+        println("--- Tool Name Reliability ---")
+        printResult(toolNameReliability().evaluate(toolsOnlyTestCase))
+
+        println("--- Tool Description Reliability ---")
+        printResult(toolDescriptionReliability().evaluate(toolsOnlyTestCase))
+
+        println("=== Done ===")
+        println("\nNote: taskCompletion and toolArgumentHallucination require a JudgeLM (real LLM)")
+        println("and are not shown in this offline example.")
+    }
+
+    private fun printResult(result: EvalResult) {
+        println(
+            "  %s: %s (score: %.2f, threshold: %.2f)".format(
+                result.name(),
+                if (result.success()) "PASS" else "FAIL",
+                result.score(),
+                result.threshold() ?: 0.0,
+            ),
+        )
+        println("  Reason: ${result.reason()}")
+        println()
+    }
+}

--- a/dokimos-kotlin/README.md
+++ b/dokimos-kotlin/README.md
@@ -39,7 +39,39 @@ val experiment = experiment {
 
 Key helpers:
 - `experiment { ... }`, `dataset { ... }`, `example { ... }`
-- `task { example -> mapOf("output" to ...) }`
-- Evaluators: `exactMatch {}`, `regex {}`, `llmJudge(judge) {}`
+- Tasks: `task { example -> mapOf("output" to ...) }`, `typedTask<T> { ... }`, `measuredTask { ... }` (adds `CallMetrics`), `suspendTask { ... }` (coroutines)
+- Evaluators: `exactMatch {}`, `regex {}`, `structuralMatch {}`, `llmJudge(judge) {}`, and the agent evaluators (`toolCallValidity {}`, `toolCorrectness {}`, `toolTrajectory {}`, `toolError {}`, `toolEfficiency {}`, `planQuality {}`, `planAdherence {}`, ...)
+- Conversations (`dev.dokimos.kotlin.dsl.conversation`): `trajectory {}`, `simulator {}`, `llmUser(judge) {}`, `trajectoryEvaluator(judge) {}`, `criterion(name, description, weight)`, `goldenGenerator {}`
+- Agents (`dev.dokimos.kotlin.dsl.agents`): `tools {}`, `toolDefinition(name) {}`, `toolCall(name) {}`, `toolCalls {}`, `agentTrace {}`, `agentTestCase {}`
+- Regression gate (`dev.dokimos.kotlin.dsl.gate` / `dev.dokimos.kotlin.core`): `gateConfig {}` builds a `GateConfig`; `ExperimentResult.assertNoRegression(baseline) { ... }` takes the config inline
+
+Agent evaluation without hand-written JSON schemas or output-map keys:
+
+```kotlin
+import dev.dokimos.kotlin.dsl.agents.*
+
+val tools = tools {
+    tool("search_flights") {
+        description = "Search for available flights"
+        parameters {
+            string("origin", "Origin airport IATA code", required = true)
+            string("destination", "Destination airport IATA code", required = true)
+        }
+    }
+}
+
+val testCase = agentTestCase {
+    input = "Find flights from NYC to Paris"
+    trace {
+        toolCall("search_flights", mapOf("origin" to "JFK", "destination" to "CDG"))
+        finalResponse = "Found your flights."
+    }
+    tools(tools)
+    expectedToolCall("search_flights", mapOf())
+    tasks("Search for flights")
+}
+
+val result = toolCallValidity().evaluate(testCase)
+```
 
 For advanced cases you can still pass fully constructed `Task`, `Dataset`, or `Evaluator` instances into the DSL blocks.

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/GateExt.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/core/GateExt.kt
@@ -3,6 +3,8 @@ package dev.dokimos.kotlin.core
 import dev.dokimos.core.Assertions
 import dev.dokimos.core.ExperimentResult
 import dev.dokimos.core.gate.GateConfig
+import dev.dokimos.kotlin.dsl.gate.GateConfigDsl
+import dev.dokimos.kotlin.dsl.gate.gateConfig
 import java.nio.file.Path
 
 /**
@@ -22,3 +24,17 @@ fun ExperimentResult.assertNoRegression(baseline: String = name, config: GateCon
  */
 fun ExperimentResult.assertNoRegression(baseline: Path, config: GateConfig = GateConfig.defaults()) =
     Assertions.assertNoRegression(this, baseline, config)
+
+/**
+ * Asserts this result has not regressed against the baseline named [baseline], configuring the gate
+ * inline with the [gateConfig] DSL.
+ */
+fun ExperimentResult.assertNoRegression(baseline: String = name, config: GateConfigDsl.() -> Unit) =
+    Assertions.assertNoRegression(this, baseline, gateConfig(config))
+
+/**
+ * Asserts this result has not regressed against the baseline at [baseline], configuring the gate
+ * inline with the [gateConfig] DSL.
+ */
+fun ExperimentResult.assertNoRegression(baseline: Path, config: GateConfigDsl.() -> Unit) =
+    Assertions.assertNoRegression(this, baseline, gateConfig(config))

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/CoreDsl.kt
@@ -39,6 +39,9 @@ fun precision(block: PrecisionEvaluatorDsl.() -> Unit = {}): PrecisionEvaluator 
 
 fun recall(block: RecallEvaluatorDsl.() -> Unit = {}): RecallEvaluator = RecallEvaluatorDsl().apply(block).build()
 
+fun structuralMatch(block: StructuralMatchEvaluatorDsl.() -> Unit = {}): StructuralMatchEvaluator =
+    StructuralMatchEvaluatorDsl().apply(block).build()
+
 fun taskCompletion(judge: JudgeLM, block: TaskCompletionEvaluatorDsl.() -> Unit = {}): TaskCompletionEvaluator =
     TaskCompletionEvaluatorDsl(judge).apply(block).build()
 
@@ -85,6 +88,15 @@ fun dataset(block: DatasetDsl.() -> Unit): Dataset = DatasetDsl().apply(block).b
 fun example(block: ExampleDsl.() -> Unit): Example = ExampleDsl().apply(block).build()
 
 fun task(block: (Example) -> Map<String, Any>): Task = Task(block)
+
+/**
+ * Builds a [MeasuredTask] from a lambda returning a [TaskResult], so each item can carry
+ * [CallMetrics] (tokens, cost, latency) alongside its outputs.
+ *
+ * @param fn produces the [TaskResult] for an [Example]
+ * @return a [MeasuredTask] suitable for [Experiment.Builder.measuredTask]
+ */
+fun measuredTask(fn: (Example) -> TaskResult): MeasuredTask = MeasuredTask { example -> fn(example) }
 
 /**
  * Builds a [Task] that produces a single typed value and stores it under the conventional
@@ -139,10 +151,12 @@ class ExperimentDsl {
     var parallelism: Int = 1
     var runs: Int = 1
     var reporter: Reporter = NoOpReporter.INSTANCE
+    var autoCloseReporter: Boolean = false
 
     private var dataset: Dataset? = null
     private var task: Task? = null
     private var asyncTask: AsyncTask? = null
+    private var measuredTask: MeasuredTask? = null
     private val evaluators: MutableList<Evaluator> = mutableListOf()
     private val metadata: MutableMap<String, Any> = mutableMapOf()
 
@@ -168,6 +182,22 @@ class ExperimentDsl {
      */
     inline fun <reified T> typedTask(crossinline block: (Example) -> T) {
         task(Task.typed { example -> block(example) })
+    }
+
+    /**
+     * Sets a [MeasuredTask] that returns a [TaskResult] carrying optional [CallMetrics]
+     * (tokens, cost, latency) alongside the outputs.
+     */
+    fun measuredTask(value: MeasuredTask) {
+        measuredTask = value
+    }
+
+    /**
+     * Sets a measured task from a lambda returning a [TaskResult]. Use it when the task
+     * should report token counts, cost, or latency for each item.
+     */
+    fun measuredTask(block: (Example) -> TaskResult) {
+        measuredTask = MeasuredTask { example -> block(example) }
     }
 
     /**
@@ -219,14 +249,20 @@ class ExperimentDsl {
             .evaluators(evaluators)
             .metadata(metadata)
             .reporter(reporter)
+            .autoCloseReporter(autoCloseReporter)
             .parallelism(parallelism)
             .runs(runs)
 
+        if (task != null && measuredTask != null) {
+            error("set either task or measuredTask, not both")
+        }
+
         asyncTask?.let { builder.asyncTask(it) }
+        measuredTask?.let { builder.measuredTask(it) }
         task?.let { builder.task(it) }
 
-        if (task == null && asyncTask == null) {
-            error("task or asyncTask must be set")
+        if (task == null && asyncTask == null && measuredTask == null) {
+            error("task, measuredTask or asyncTask must be set")
         }
 
         return builder.build()

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/agents/AgentDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/agents/AgentDsl.kt
@@ -1,0 +1,433 @@
+package dev.dokimos.kotlin.dsl.agents
+
+import dev.dokimos.core.EvalTestCase
+import dev.dokimos.core.agents.AgentTrace
+import dev.dokimos.core.agents.ToolCall
+import dev.dokimos.core.agents.ToolDefinition
+import dev.dokimos.core.evaluators.agents.AgentEvalCase
+import dev.dokimos.kotlin.dsl.DokimosDsl
+
+/**
+ * Top-level DSL entrypoints for the agent primitives in `dev.dokimos.core.agents`.
+ */
+
+/** Builds a single [ToolCall]. */
+fun toolCall(name: String, block: ToolCallDsl.() -> Unit = {}): ToolCall = ToolCallDsl(name).apply(block).build()
+
+/** Builds a [ToolCall] from a name and arguments, delegating to [ToolCall.of]. */
+fun toolCall(name: String, arguments: Map<String, Any>): ToolCall = ToolCall.of(name, arguments)
+
+/** Builds a list of [ToolCall]s. */
+fun toolCalls(block: ToolCallsDsl.() -> Unit): List<ToolCall> = ToolCallsDsl().apply(block).build()
+
+/** Builds a single [ToolDefinition]. */
+fun toolDefinition(name: String, block: ToolDefinitionDsl.() -> Unit = {}): ToolDefinition =
+    ToolDefinitionDsl(name).apply(block).build()
+
+/** Builds a list of [ToolDefinition]s. */
+fun tools(block: ToolDefinitionsDsl.() -> Unit): List<ToolDefinition> = ToolDefinitionsDsl().apply(block).build()
+
+/** Builds an [AgentTrace]. */
+fun agentTrace(block: AgentTraceDsl.() -> Unit): AgentTrace = AgentTraceDsl().apply(block).build()
+
+/**
+ * Builds an [EvalTestCase] carrying the keys the agent evaluators read.
+ *
+ * Delegates the shared slots to [AgentEvalCase] and adds the ones it does not cover:
+ * the final response, the reasoning steps that `planQuality` and `planAdherence` read,
+ * and the `constraints` entry `taskCompletion` reads.
+ */
+fun agentTestCase(block: AgentTestCaseDsl.() -> Unit): EvalTestCase = AgentTestCaseDsl().apply(block).build()
+
+@DokimosDsl
+class ToolCallDsl(var name: String) {
+    /** The raw tool result. Use [resultJson] to serialize an object instead. */
+    var result: String? = null
+
+    private val arguments: MutableMap<String, Any> = linkedMapOf()
+    private val metadata: MutableMap<String, Any> = mutableMapOf()
+    private var resultValue: Any? = null
+
+    fun argument(key: String, value: Any) {
+        arguments[key] = value
+    }
+
+    fun arguments(vararg values: Pair<String, Any>) {
+        arguments.putAll(values)
+    }
+
+    fun arguments(values: Map<String, Any>) {
+        arguments.putAll(values)
+    }
+
+    /** Sets the result by serializing [value] to JSON, delegating to `ToolCall.Builder.resultJson`. */
+    fun resultJson(value: Any) {
+        resultValue = value
+    }
+
+    fun metadata(key: String, value: Any) {
+        metadata[key] = value
+    }
+
+    fun metadata(vararg values: Pair<String, Any>) {
+        metadata.putAll(values)
+    }
+
+    fun metadata(values: Map<String, Any>) {
+        metadata.putAll(values)
+    }
+
+    fun build(): ToolCall {
+        val builder = ToolCall.builder()
+            .name(name)
+            .arguments(arguments)
+            .metadata(metadata)
+        result?.let { builder.result(it) }
+        resultValue?.let { builder.resultJson(it) }
+        return builder.build()
+    }
+}
+
+@DokimosDsl
+class ToolCallsDsl {
+    private val calls: MutableList<ToolCall> = mutableListOf()
+
+    fun call(name: String, block: ToolCallDsl.() -> Unit = {}) {
+        calls += ToolCallDsl(name).apply(block).build()
+    }
+
+    fun call(name: String, arguments: Map<String, Any>) {
+        calls += ToolCall.of(name, arguments)
+    }
+
+    fun call(value: ToolCall) {
+        calls += value
+    }
+
+    fun calls(values: List<ToolCall>) {
+        calls += values
+    }
+
+    fun build(): List<ToolCall> = calls.toList()
+}
+
+@DokimosDsl
+class ToolDefinitionDsl(var name: String) {
+    var description: String = ""
+
+    private val inputSchema: MutableMap<String, Any> = linkedMapOf()
+
+    /** Sets the raw JSON schema for the tool's arguments. */
+    fun inputSchema(values: Map<String, Any>) {
+        inputSchema.putAll(values)
+    }
+
+    /** Builds the tool's JSON schema from typed parameter declarations. */
+    fun parameters(block: JsonSchemaDsl.() -> Unit) {
+        inputSchema.putAll(JsonSchemaDsl().apply(block).build())
+    }
+
+    fun build(): ToolDefinition = ToolDefinition(name, description, inputSchema)
+}
+
+@DokimosDsl
+class ToolDefinitionsDsl {
+    private val definitions: MutableList<ToolDefinition> = mutableListOf()
+
+    fun tool(name: String, block: ToolDefinitionDsl.() -> Unit = {}) {
+        definitions += ToolDefinitionDsl(name).apply(block).build()
+    }
+
+    fun tool(value: ToolDefinition) {
+        definitions += value
+    }
+
+    fun tools(values: List<ToolDefinition>) {
+        definitions += values
+    }
+
+    fun build(): List<ToolDefinition> = definitions.toList()
+}
+
+/**
+ * Builds an object-typed JSON schema (`type`, `properties`, `required`) for a tool's arguments.
+ *
+ * The declared types are the ones `ToolCallValidityEvaluator` validates against:
+ * `string`, `number`, `integer`, `boolean`, `array`, and `object`.
+ */
+@DokimosDsl
+class JsonSchemaDsl {
+    /** When set to `false`, arguments outside the declared properties are reported as unexpected. */
+    var additionalProperties: Boolean? = null
+
+    private val properties: MutableMap<String, Map<String, Any>> = linkedMapOf()
+    private val requiredNames: MutableList<String> = mutableListOf()
+
+    fun string(name: String, description: String = "", required: Boolean = false, enum: List<String> = emptyList()) {
+        val schema = typed("string", description).toMutableMap()
+        if (enum.isNotEmpty()) schema["enum"] = enum
+        property(name, schema, required)
+    }
+
+    fun integer(name: String, description: String = "", required: Boolean = false) {
+        property(name, typed("integer", description), required)
+    }
+
+    fun number(name: String, description: String = "", required: Boolean = false) {
+        property(name, typed("number", description), required)
+    }
+
+    fun boolean(name: String, description: String = "", required: Boolean = false) {
+        property(name, typed("boolean", description), required)
+    }
+
+    fun array(name: String, description: String = "", itemType: String = "string", required: Boolean = false) {
+        val schema = typed("array", description).toMutableMap()
+        schema["items"] = mapOf("type" to itemType)
+        property(name, schema, required)
+    }
+
+    fun `object`(name: String, description: String = "", required: Boolean = false) {
+        property(name, typed("object", description), required)
+    }
+
+    /** Declares a property with a raw JSON schema. */
+    fun property(name: String, schema: Map<String, Any>, required: Boolean = false) {
+        properties[name] = schema.toMap()
+        if (required) required(name)
+    }
+
+    /** Marks already declared properties as required. */
+    fun required(vararg names: String) {
+        names.forEach { if (it !in requiredNames) requiredNames += it }
+    }
+
+    fun build(): Map<String, Any> = buildMap {
+        put("type", "object")
+        put("properties", properties.toMap())
+        if (requiredNames.isNotEmpty()) put("required", requiredNames.toList())
+        additionalProperties?.let { put("additionalProperties", it) }
+    }
+
+    private fun typed(type: String, description: String): Map<String, Any> = buildMap {
+        put("type", type)
+        if (description.isNotEmpty()) put("description", description)
+    }
+}
+
+@DokimosDsl
+class AgentTraceDsl {
+    var finalResponse: String? = null
+
+    private val toolCalls: MutableList<ToolCall> = mutableListOf()
+    private val reasoningSteps: MutableList<String> = mutableListOf()
+    private val metadata: MutableMap<String, Any> = mutableMapOf()
+
+    fun toolCall(name: String, block: ToolCallDsl.() -> Unit = {}) {
+        toolCalls += ToolCallDsl(name).apply(block).build()
+    }
+
+    fun toolCall(name: String, arguments: Map<String, Any>) {
+        toolCalls += ToolCall.of(name, arguments)
+    }
+
+    fun toolCall(value: ToolCall) {
+        toolCalls += value
+    }
+
+    fun toolCalls(values: List<ToolCall>) {
+        toolCalls += values
+    }
+
+    fun toolCalls(block: ToolCallsDsl.() -> Unit) {
+        toolCalls += ToolCallsDsl().apply(block).build()
+    }
+
+    fun reasoning(step: String) {
+        reasoningSteps += step
+    }
+
+    fun reasoning(values: List<String>) {
+        reasoningSteps += values
+    }
+
+    fun metadata(key: String, value: Any) {
+        metadata[key] = value
+    }
+
+    fun metadata(vararg values: Pair<String, Any>) {
+        metadata.putAll(values)
+    }
+
+    fun metadata(values: Map<String, Any>) {
+        metadata.putAll(values)
+    }
+
+    fun build(): AgentTrace = AgentTrace(finalResponse, toolCalls, reasoningSteps, metadata)
+}
+
+/**
+ * Builds an [EvalTestCase] using the keys the agent evaluators read: `toolCalls` in actual and
+ * expected outputs, `output` and `reasoningSteps` in actual outputs, and `tools`, `tasks` and
+ * `constraints` in metadata.
+ */
+@DokimosDsl
+class AgentTestCaseDsl {
+    var input: String? = null
+
+    /** The agent's final text response, stored under the `output` key. */
+    var output: String? = null
+
+    /** Optional constraints read by `taskCompletion`. */
+    var constraints: String? = null
+
+    private val toolCalls: MutableList<ToolCall> = mutableListOf()
+    private val expectedToolCalls: MutableList<ToolCall> = mutableListOf()
+    private val toolDefinitions: MutableList<ToolDefinition> = mutableListOf()
+    private val tasks: MutableList<String> = mutableListOf()
+    private val reasoningSteps: MutableList<String> = mutableListOf()
+    private val inputs: MutableMap<String, Any> = mutableMapOf()
+    private val actualOutputs: MutableMap<String, Any> = mutableMapOf()
+    private val expectedOutputs: MutableMap<String, Any> = mutableMapOf()
+    private val metadata: MutableMap<String, Any> = mutableMapOf()
+
+    /** Takes the final response, tool calls and reasoning steps from an existing trace. */
+    fun trace(value: AgentTrace) {
+        value.finalResponse()?.let { output = it }
+        toolCalls += value.toolCalls()
+        reasoningSteps += value.reasoningSteps()
+    }
+
+    /** Builds a trace inline and takes its outputs. */
+    fun trace(block: AgentTraceDsl.() -> Unit) {
+        trace(AgentTraceDsl().apply(block).build())
+    }
+
+    fun toolCall(name: String, block: ToolCallDsl.() -> Unit = {}) {
+        toolCalls += ToolCallDsl(name).apply(block).build()
+    }
+
+    fun toolCall(name: String, arguments: Map<String, Any>) {
+        toolCalls += ToolCall.of(name, arguments)
+    }
+
+    fun toolCall(value: ToolCall) {
+        toolCalls += value
+    }
+
+    fun toolCalls(values: List<ToolCall>) {
+        toolCalls += values
+    }
+
+    fun toolCalls(block: ToolCallsDsl.() -> Unit) {
+        toolCalls += ToolCallsDsl().apply(block).build()
+    }
+
+    fun expectedToolCall(name: String, block: ToolCallDsl.() -> Unit = {}) {
+        expectedToolCalls += ToolCallDsl(name).apply(block).build()
+    }
+
+    fun expectedToolCall(name: String, arguments: Map<String, Any>) {
+        expectedToolCalls += ToolCall.of(name, arguments)
+    }
+
+    fun expectedToolCall(value: ToolCall) {
+        expectedToolCalls += value
+    }
+
+    fun expectedToolCalls(values: List<ToolCall>) {
+        expectedToolCalls += values
+    }
+
+    fun expectedToolCalls(block: ToolCallsDsl.() -> Unit) {
+        expectedToolCalls += ToolCallsDsl().apply(block).build()
+    }
+
+    fun tool(name: String, block: ToolDefinitionDsl.() -> Unit = {}) {
+        toolDefinitions += ToolDefinitionDsl(name).apply(block).build()
+    }
+
+    fun tool(value: ToolDefinition) {
+        toolDefinitions += value
+    }
+
+    fun tools(values: List<ToolDefinition>) {
+        toolDefinitions += values
+    }
+
+    fun tools(block: ToolDefinitionsDsl.() -> Unit) {
+        toolDefinitions += ToolDefinitionsDsl().apply(block).build()
+    }
+
+    fun task(value: String) {
+        tasks += value
+    }
+
+    fun tasks(vararg values: String) {
+        tasks += values
+    }
+
+    fun tasks(values: List<String>) {
+        tasks += values
+    }
+
+    fun reasoning(step: String) {
+        reasoningSteps += step
+    }
+
+    fun reasoning(values: List<String>) {
+        reasoningSteps += values
+    }
+
+    fun input(key: String, value: Any) {
+        inputs[key] = value
+    }
+
+    fun actualOutput(key: String, value: Any) {
+        actualOutputs[key] = value
+    }
+
+    fun expectedOutput(key: String, value: Any) {
+        expectedOutputs[key] = value
+    }
+
+    fun metadata(key: String, value: Any) {
+        metadata[key] = value
+    }
+
+    fun metadata(vararg values: Pair<String, Any>) {
+        metadata.putAll(values)
+    }
+
+    fun metadata(values: Map<String, Any>) {
+        metadata.putAll(values)
+    }
+
+    fun build(): EvalTestCase {
+        // The shared slots come from AgentEvalCase so the key names stay owned by core.
+        val agentCase = AgentEvalCase.builder()
+        input?.let { agentCase.input(it) }
+        if (toolCalls.isNotEmpty()) agentCase.toolCalls(toolCalls)
+        if (toolDefinitions.isNotEmpty()) agentCase.tools(toolDefinitions)
+        if (expectedToolCalls.isNotEmpty()) agentCase.expectedToolCalls(expectedToolCalls)
+        if (tasks.isNotEmpty()) agentCase.tasks(tasks)
+        val base = agentCase.build()
+
+        val builder = EvalTestCase.builder()
+            .inputs(base.inputs())
+            .actualOutputs(base.actualOutputs())
+            .expectedOutputs(base.expectedOutputs())
+            .metadata(base.metadata())
+
+        output?.let { builder.actualOutput("output", it) }
+        if (reasoningSteps.isNotEmpty()) builder.actualOutput("reasoningSteps", reasoningSteps.toList())
+        constraints?.let { builder.metadata("constraints", it) }
+
+        inputs.forEach { (k, v) -> builder.input(k, v) }
+        actualOutputs.forEach { (k, v) -> builder.actualOutput(k, v) }
+        expectedOutputs.forEach { (k, v) -> builder.expectedOutput(k, v) }
+        metadata.forEach { (k, v) -> builder.metadata(k, v) }
+
+        return builder.build()
+    }
+}

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/conversation/ConversationDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/conversation/ConversationDsl.kt
@@ -36,6 +36,10 @@ fun scenarioSeed(block: ScenarioSeedDsl.() -> Unit): ScenarioSeed = ScenarioSeed
 
 fun goldenGenerator(block: GoldenGeneratorDsl.() -> Unit): GoldenGenerator = GoldenGeneratorDsl().apply(block).build()
 
+/** Builds an [EvaluationCriterion]; [weight] defaults to the same 1.0 as [EvaluationCriterion.of]. */
+fun criterion(name: String, description: String, weight: Double = 1.0): EvaluationCriterion =
+    EvaluationCriterion(name, description, weight)
+
 /** Convenience builders outside DSL blocks. */
 fun message(role: Message.Role, content: String, metadata: Map<String, Any> = emptyMap()): Message =
     Message(role, content, metadata)
@@ -181,6 +185,10 @@ class TrajectoryEvaluatorDsl(private val judge: JudgeLM) {
 
     fun criterion(criterion: EvaluationCriterion) {
         criteria += criterion
+    }
+
+    fun criterion(name: String, description: String, weight: Double = 1.0) {
+        criteria += EvaluationCriterion(name, description, weight)
     }
 
     fun criteria(values: List<EvaluationCriterion>) {

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDsl.kt
@@ -12,6 +12,8 @@ import dev.dokimos.core.evaluators.LLMJudgeEvaluator
 import dev.dokimos.core.evaluators.PrecisionEvaluator
 import dev.dokimos.core.evaluators.RecallEvaluator
 import dev.dokimos.core.evaluators.RegexEvaluator
+import dev.dokimos.core.evaluators.StructuralMatchEvaluator
+import dev.dokimos.core.evaluators.StructuralMatchMode
 import dev.dokimos.core.evaluators.agents.ArgumentMatcher
 import dev.dokimos.core.evaluators.agents.PlanAdherenceEvaluator
 import dev.dokimos.core.evaluators.agents.PlanQualityEvaluator
@@ -57,6 +59,10 @@ class EvaluatorsDsl {
 
     fun precision(block: PrecisionEvaluatorDsl.() -> Unit = {}) {
         evaluators += PrecisionEvaluatorDsl().apply(block).build()
+    }
+
+    fun structuralMatch(block: StructuralMatchEvaluatorDsl.() -> Unit = {}) {
+        evaluators += StructuralMatchEvaluatorDsl().apply(block).build()
     }
 
     fun recall(block: RecallEvaluatorDsl.() -> Unit = {}) {
@@ -132,6 +138,33 @@ class ExactMatchEvaluatorDsl {
         .threshold(threshold)
         .evaluationParams(evaluationParams)
         .build()
+}
+
+@DokimosDsl
+class StructuralMatchEvaluatorDsl {
+    var name: String = "Structural Match"
+    var threshold: Double = 1.0
+    var outputKey: String = "output"
+    var mode: StructuralMatchMode = StructuralMatchMode.STRICT
+
+    /** Scores 1.0 or 0.0 instead of the fraction of matching fields. */
+    var binary: Boolean = false
+    var evaluationParams: List<EvalTestCaseParam> = listOf()
+
+    fun params(vararg params: EvalTestCaseParam) {
+        evaluationParams = params.toList()
+    }
+
+    fun build(): StructuralMatchEvaluator {
+        val builder = StructuralMatchEvaluator.builder()
+            .name(name)
+            .threshold(threshold)
+            .outputKey(outputKey)
+            .mode(mode)
+            .evaluationParams(evaluationParams)
+        if (binary) builder.binary()
+        return builder.build()
+    }
 }
 
 @DokimosDsl

--- a/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/gate/GateDsl.kt
+++ b/dokimos-kotlin/src/main/kotlin/dev/dokimos/kotlin/dsl/gate/GateDsl.kt
@@ -1,0 +1,54 @@
+package dev.dokimos.kotlin.dsl.gate
+
+import dev.dokimos.core.gate.GateConfig
+import dev.dokimos.kotlin.dsl.DokimosDsl
+
+/**
+ * Builds a [GateConfig] for the regression gate.
+ *
+ * Every property starts at the value [GateConfig.defaults] carries, so the defaults stay owned by
+ * core rather than being restated here.
+ */
+fun gateConfig(block: GateConfigDsl.() -> Unit = {}): GateConfig = GateConfigDsl().apply(block).build()
+
+@DokimosDsl
+class GateConfigDsl {
+    private val defaults: GateConfig = GateConfig.defaults()
+
+    /** Significance level for the permutation test. */
+    var alpha: Double = defaults.alpha()
+
+    /** Seed for the permutation and bootstrap resampling. */
+    var seed: Long = defaults.seed()
+    var permutationIterations: Int = defaults.permutationIterations()
+    var bootstrapIterations: Int = defaults.bootstrapIterations()
+
+    /** How large a drop must be, beyond significance, to count as a regression. */
+    var severityMargin: Double = defaults.severityMargin()
+
+    /** How baseline and candidate items are paired. */
+    var pairing: GateConfig.Pairing = defaults.pairing()
+    var failOnRegression: Boolean = defaults.failOnRegression()
+    var failOnRemovedItems: Boolean = defaults.failOnRemovedItems()
+
+    /** What to do when an evaluator in the baseline is missing from the candidate. */
+    var onRemovedEvaluator: GateConfig.RemovedEvaluatorPolicy = defaults.onRemovedEvaluator()
+
+    /** Whether the first run, which writes the baseline, passes instead of failing once for review. */
+    var bootstrapPasses: Boolean = defaults.bootstrapPasses()
+    var updateBaseline: Boolean = defaults.updateBaseline()
+
+    fun build(): GateConfig = GateConfig.builder()
+        .alpha(alpha)
+        .seed(seed)
+        .permutationIterations(permutationIterations)
+        .bootstrapIterations(bootstrapIterations)
+        .severityMargin(severityMargin)
+        .pairing(pairing)
+        .failOnRegression(failOnRegression)
+        .failOnRemovedItems(failOnRemovedItems)
+        .onRemovedEvaluator(onRemovedEvaluator)
+        .bootstrapPasses(bootstrapPasses)
+        .updateBaseline(updateBaseline)
+        .build()
+}

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/GateExtTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/core/GateExtTest.kt
@@ -7,6 +7,7 @@ import dev.dokimos.core.ItemResult
 import dev.dokimos.core.RunResult
 import dev.dokimos.core.gate.BaselineStore
 import dev.dokimos.core.gate.GateConfig
+import dev.dokimos.kotlin.dsl.gate.gateConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
@@ -53,5 +54,62 @@ class GateExtTest {
         val unnamed = ExperimentResult("unnamed", "", emptyMap(), emptyList())
 
         assertThrows<IllegalArgumentException> { unnamed.assertNoRegression() }
+    }
+
+    @Test
+    fun `gateConfig DSL starts from the core defaults and overrides only what is set`() {
+        val defaults = GateConfig.defaults()
+
+        val config = gateConfig {
+            alpha = 0.01
+            severityMargin = 0.25
+            pairing = GateConfig.Pairing.DATASET_ITEM_ID
+            onRemovedEvaluator = GateConfig.RemovedEvaluatorPolicy.WARN
+            bootstrapPasses = false
+        }
+
+        assertThat(config.alpha()).isEqualTo(0.01)
+        assertThat(config.severityMargin()).isEqualTo(0.25)
+        assertThat(config.pairing()).isEqualTo(GateConfig.Pairing.DATASET_ITEM_ID)
+        assertThat(config.onRemovedEvaluator()).isEqualTo(GateConfig.RemovedEvaluatorPolicy.WARN)
+        assertThat(config.bootstrapPasses()).isFalse()
+
+        // untouched knobs keep the core defaults
+        assertThat(config.seed()).isEqualTo(defaults.seed())
+        assertThat(config.permutationIterations()).isEqualTo(defaults.permutationIterations())
+        assertThat(config.bootstrapIterations()).isEqualTo(defaults.bootstrapIterations())
+        assertThat(config.failOnRegression()).isEqualTo(defaults.failOnRegression())
+        assertThat(config.failOnRemovedItems()).isEqualTo(defaults.failOnRemovedItems())
+        assertThat(config.updateBaseline()).isEqualTo(defaults.updateBaseline())
+    }
+
+    @Test
+    fun `empty gateConfig equals the core defaults`() {
+        val defaults = GateConfig.defaults()
+        val config = gateConfig()
+
+        assertThat(config.alpha()).isEqualTo(defaults.alpha())
+        assertThat(config.seed()).isEqualTo(defaults.seed())
+        assertThat(config.severityMargin()).isEqualTo(defaults.severityMargin())
+        assertThat(config.pairing()).isEqualTo(defaults.pairing())
+        assertThat(config.bootstrapPasses()).isEqualTo(defaults.bootstrapPasses())
+    }
+
+    @Test
+    fun `path overload takes an inline gate config block`(@TempDir dir: Path) {
+        val path = dir.resolve("baseline.json")
+        BaselineStore.write(path, resultWithScore(1.0), GateConfig.defaults())
+
+        val regressed = resultWithScore(0.0)
+
+        // failOnRegression=false downgrades the compare-path failure to a pass
+        assertThatCode {
+            regressed.assertNoRegression(path) { failOnRegression = false }
+        }.doesNotThrowAnyException()
+
+        val error = assertThrows<AssertionError> {
+            regressed.assertNoRegression(path) { failOnRegression = true }
+        }
+        assertThat(error).hasMessageContaining("Eval gate FAILED")
     }
 }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/TaskDslTest.kt
@@ -217,4 +217,53 @@ class TaskDslTest {
 
         assertThat(output.outputs()).containsEntry("output", "cba")
     }
+
+    @Test
+    fun `measuredTask carries call metrics through to the item result`() {
+        val result = experiment {
+            name = "measured"
+            dataset {
+                example {
+                    input = "hello"
+                    expected = "hello"
+                }
+            }
+            measuredTask { example ->
+                TaskResult(mapOf("output" to example.input()), CallMetrics(12, 34, 0.001, 250L))
+            }
+            evaluators {
+                exactMatch { }
+            }
+        }.run()
+
+        assertThat(result.passRate()).isEqualTo(1.0)
+        val metrics = result.itemResults().single().metrics()
+        assertThat(metrics.tokensIn()).isEqualTo(12)
+        assertThat(metrics.tokensOut()).isEqualTo(34)
+        assertThat(metrics.costUsd()).isEqualTo(0.001)
+        assertThat(metrics.latencyMs()).isEqualTo(250L)
+    }
+
+    @Test
+    fun `top-level measuredTask builds a MeasuredTask`() {
+        val task = measuredTask { example -> TaskResult(mapOf("output" to example.input()), null) }
+
+        val taskResult = task.run(exampleWith("abc"))
+
+        assertThat(taskResult.outputs()).containsEntry("output", "abc")
+        assertThat(taskResult.metrics()).isNull()
+    }
+
+    @Test
+    fun `experiment DSL rejects setting both task and measuredTask`() {
+        assertThatThrownBy {
+            experiment {
+                name = "conflict"
+                dataset { example { input = "hello" } }
+                task { mapOf("output" to "hello") }
+                measuredTask { TaskResult(mapOf("output" to "hello"), null) }
+                evaluators { exactMatch { } }
+            }
+        }.hasMessageContaining("not both")
+    }
 }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/agents/AgentDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/agents/AgentDslTest.kt
@@ -1,0 +1,272 @@
+package dev.dokimos.kotlin.dsl.agents
+
+import dev.dokimos.core.agents.ToolCall
+import dev.dokimos.core.agents.ToolDefinition
+import dev.dokimos.core.evaluators.agents.PlanQualityEvaluator
+import dev.dokimos.core.evaluators.agents.ToolCallValidityEvaluator
+import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator
+import dev.dokimos.core.evaluators.agents.ToolEfficiencyEvaluator
+import dev.dokimos.core.evaluators.agents.ToolErrorEvaluator
+import dev.dokimos.core.evaluators.agents.ToolNameReliabilityEvaluator
+import dev.dokimos.kotlin.dsl.experiment
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AgentDslTest {
+
+    @Test
+    fun `toolCall DSL builds arguments, result and metadata`() {
+        val call = toolCall("search_flights") {
+            argument("origin", "JFK")
+            arguments("destination" to "CDG", "date" to "2026-03-15")
+            result = "Found 5 flights"
+            metadata("latencyMs" to 120)
+        }
+
+        assertThat(call.name()).isEqualTo("search_flights")
+        assertThat(call.arguments())
+            .containsEntry("origin", "JFK")
+            .containsEntry("destination", "CDG")
+            .containsEntry("date", "2026-03-15")
+        assertThat(call.result()).isEqualTo("Found 5 flights")
+        assertThat(call.metadata()).containsEntry("latencyMs", 120)
+    }
+
+    @Test
+    fun `toolCall DSL serializes a result object with resultJson`() {
+        val call = toolCall("search_flights") {
+            resultJson(mapOf("flights" to 5))
+        }
+
+        assertThat(call.result()).isEqualTo("""{"flights":5}""")
+    }
+
+    @Test
+    fun `toolCall shorthand takes a plain argument map`() {
+        val call = toolCall("book_hotel", mapOf("city" to "Paris"))
+
+        assertThat(call.name()).isEqualTo("book_hotel")
+        assertThat(call.arguments()).containsEntry("city", "Paris")
+        assertThat(call.result()).isNull()
+    }
+
+    @Test
+    fun `toolDefinition DSL builds a JSON schema from typed parameters`() {
+        val definition = toolDefinition("search_flights") {
+            description = "Search for available flights between airports"
+            parameters {
+                string("origin", "Origin airport IATA code", required = true)
+                string("destination", "Destination airport IATA code", required = true)
+                string("date", "Travel date in YYYY-MM-DD format")
+                integer("passengers", "Number of passengers")
+                string("cabin", enum = listOf("economy", "business"))
+                additionalProperties = false
+            }
+        }
+
+        assertThat(definition.name()).isEqualTo("search_flights")
+        assertThat(definition.description()).isEqualTo("Search for available flights between airports")
+        assertThat(definition.requiredParameters()).containsExactly("origin", "destination")
+        assertThat(definition.parameterNames())
+            .containsExactly("origin", "destination", "date", "passengers", "cabin")
+        assertThat(definition.parameterSchema("passengers")).containsEntry("type", "integer")
+        assertThat(definition.parameterSchema("cabin")).containsEntry("enum", listOf("economy", "business"))
+        assertThat(definition.inputSchema()).containsEntry("additionalProperties", false)
+    }
+
+    @Test
+    fun `schema DSL drives the validity evaluator`() {
+        val testCase = agentTestCase {
+            toolCall("search_flights", mapOf("origin" to "JFK", "passengers" to "two"))
+            tool("search_flights") {
+                parameters {
+                    string("origin", required = true)
+                    string("destination", required = true)
+                    integer("passengers")
+                }
+            }
+        }
+
+        val result = ToolCallValidityEvaluator.builder().build().evaluate(testCase)
+
+        assertThat(result.success()).isFalse()
+        // missing required 'destination' and 'passengers' typed as string instead of integer
+        assertThat(result.reason()).contains("0/1")
+    }
+
+    @Test
+    fun `tools DSL builds a list of definitions`() {
+        val definitions = tools {
+            tool("search_flights") { description = "Search flights" }
+            tool("book_hotel") { description = "Book a hotel" }
+            tool(ToolDefinition.of("get_weather", "Weather forecast", mapOf()))
+        }
+
+        assertThat(definitions).hasSize(3)
+        assertThat(definitions.map { it.name() }).containsExactly("search_flights", "book_hotel", "get_weather")
+    }
+
+    @Test
+    fun `toolCalls DSL builds a list of calls`() {
+        val calls = toolCalls {
+            call("search_flights") { argument("origin", "JFK") }
+            call("book_hotel", mapOf("city" to "Paris"))
+            call(ToolCall.of("get_weather", mapOf("city" to "Paris")))
+        }
+
+        assertThat(calls.map { it.name() }).containsExactly("search_flights", "book_hotel", "get_weather")
+    }
+
+    @Test
+    fun `agentTrace DSL builds a trace`() {
+        val trace = agentTrace {
+            reasoning("User wants to travel to Paris")
+            toolCall("search_flights") {
+                argument("origin", "JFK")
+                argument("destination", "CDG")
+            }
+            reasoning("Now booking a hotel")
+            toolCall("book_hotel", mapOf("city" to "Paris", "nights" to 3))
+            finalResponse = "Booked your trip to Paris."
+            metadata("totalLatencyMs" to 2500)
+        }
+
+        assertThat(trace.finalResponse()).isEqualTo("Booked your trip to Paris.")
+        assertThat(trace.toolNames()).containsExactly("search_flights", "book_hotel")
+        assertThat(trace.reasoningSteps()).hasSize(2)
+        assertThat(trace.metadata()).containsEntry("totalLatencyMs", 2500)
+        assertThat(trace.toOutputMap()).containsKeys("output", "toolCalls", "reasoningSteps")
+    }
+
+    @Test
+    fun `agentTestCase DSL wires the keys the agent evaluators expect`() {
+        val testCase = agentTestCase {
+            input = "Find flights from NYC to Paris and book a hotel"
+            output = "Booked your trip to Paris."
+            toolCall("search_flights") {
+                argument("origin", "JFK")
+                argument("destination", "CDG")
+            }
+            toolCall("book_hotel", mapOf("city" to "Paris"))
+            expectedToolCalls {
+                call("search_flights", mapOf())
+                call("book_hotel", mapOf())
+            }
+            tools {
+                tool("search_flights") {
+                    description = "Search flights"
+                    parameters {
+                        string("origin", required = true)
+                        string("destination", required = true)
+                    }
+                }
+                tool("book_hotel") {
+                    description = "Book a hotel"
+                    parameters { string("city", required = true) }
+                }
+            }
+            tasks("Search for flights", "Book a hotel")
+            constraints = "Budget under 500"
+            metadata("traceId" to "abc")
+        }
+
+        assertThat(testCase.inputs()).containsEntry("input", "Find flights from NYC to Paris and book a hotel")
+        assertThat(testCase.actualOutputs()).containsEntry("output", "Booked your trip to Paris.")
+        assertThat(testCase.actualOutputs()["toolCalls"] as List<*>).hasSize(2)
+        assertThat(testCase.expectedOutputs()["toolCalls"] as List<*>).hasSize(2)
+        assertThat(testCase.metadata()["tools"] as List<*>).hasSize(2)
+        assertThat(testCase.metadata()).containsEntry("tasks", listOf("Search for flights", "Book a hotel"))
+        assertThat(testCase.metadata()).containsEntry("constraints", "Budget under 500")
+        assertThat(testCase.metadata()).containsEntry("traceId", "abc")
+
+        assertThat(ToolCallValidityEvaluator.builder().build().evaluate(testCase).success()).isTrue()
+        assertThat(ToolCorrectnessEvaluator.builder().build().evaluate(testCase).success()).isTrue()
+        assertThat(ToolEfficiencyEvaluator.builder().build().evaluate(testCase).success()).isTrue()
+        assertThat(ToolNameReliabilityEvaluator.builder().build().evaluate(testCase).score()).isGreaterThan(0.0)
+    }
+
+    @Test
+    fun `agentTestCase takes outputs from a trace`() {
+        val testCase = agentTestCase {
+            input = "Find flights from NYC to Paris"
+            trace {
+                reasoning("Search for flights from JFK to CDG")
+                toolCall("search_flights") {
+                    argument("origin", "JFK")
+                    argument("destination", "CDG")
+                    result = "Found 5 flights"
+                }
+                finalResponse = "Found your flights."
+            }
+            tools {
+                tool("search_flights") {
+                    description = "Search flights"
+                    parameters {
+                        string("origin", required = true)
+                        string("destination", required = true)
+                    }
+                }
+            }
+            expectedToolCall("search_flights", mapOf())
+        }
+
+        assertThat(testCase.actualOutputs()).containsEntry("output", "Found your flights.")
+        assertThat(testCase.actualOutputs()["reasoningSteps"] as List<*>)
+            .containsExactly("Search for flights from JFK to CDG")
+
+        assertThat(ToolCallValidityEvaluator.builder().build().evaluate(testCase).success()).isTrue()
+        assertThat(ToolCorrectnessEvaluator.builder().build().evaluate(testCase).success()).isTrue()
+        // reasoningSteps is the key planQuality reads — AgentEvalCase alone does not write it
+        assertThat(PlanQualityEvaluator.builder().build().evaluate(testCase).score()).isGreaterThan(0.0)
+    }
+
+    @Test
+    fun `tool results feed the error evaluator`() {
+        val testCase = agentTestCase {
+            toolCall("search_flights") { result = "Found 5 flights" }
+            toolCall("book_hotel") { resultJson(mapOf("error" to "no availability")) }
+        }
+
+        val result = ToolErrorEvaluator.builder().build().evaluate(testCase)
+
+        assertThat(result.score()).isEqualTo(0.5)
+    }
+
+    @Test
+    fun `agent DSL composes with the experiment DSL`() {
+        val availableTools = tools {
+            tool("search_flights") {
+                description = "Search for flights"
+                parameters {
+                    string("origin", required = true)
+                    string("destination", required = true)
+                }
+            }
+        }
+
+        val result = experiment {
+            name = "Travel Agent Evaluation"
+            dataset {
+                name = "Travel Agent"
+                example {
+                    input = "Find flights to Paris"
+                    expected("toolCalls", toolCalls { call("search_flights", mapOf()) })
+                    metadata("tools", availableTools)
+                    metadata("tasks", listOf("Search flights"))
+                }
+            }
+            task { example ->
+                agentTrace {
+                    toolCall("search_flights", mapOf("origin" to "JFK", "destination" to "CDG"))
+                    finalResponse = "Found flights for ${example.input()}"
+                }.toOutputMap()
+            }
+            evaluators {
+                toolCallValidity { }
+                toolCorrectness { }
+            }
+        }.run()
+
+        assertThat(result.passRate()).isEqualTo(1.0)
+    }
+}

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/conversation/ConversationDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/conversation/ConversationDslTest.kt
@@ -244,4 +244,30 @@ class ConversationDslTest {
         assertThat(dataset.examples()[0].input()).contains("hi there").contains("persona reply")
         assertThat(dataset.examples()[0].expectedOutputs()).doesNotContainKey("output")
     }
+
+    @Test
+    fun `criterion helpers build criteria inline`() {
+        val standalone = criterion("Helpfulness", "Was the assistant helpful?", weight = 2.0)
+
+        assertThat(standalone.name()).isEqualTo("Helpfulness")
+        assertThat(standalone.description()).isEqualTo("Was the assistant helpful?")
+        assertThat(standalone.weight()).isEqualTo(2.0)
+
+        val prompts = mutableListOf<String>()
+        val judge = JudgeLM { prompt ->
+            prompts += prompt
+            """{"score":0.9,"reason":"good"}"""
+        }
+        val evaluator = trajectoryEvaluator(judge) {
+            criterion("Helpfulness", "Was the assistant helpful?")
+            criterion("Tone", "Was the tone appropriate?", weight = 0.5)
+        }
+
+        val trajectory = conversation(userMessage("hi"), assistantMessage("hello"))
+        evaluator.evaluate(EvalTestCase(input = "q", actualOutputs = mapOf("trajectory" to trajectory)))
+
+        assertThat(prompts).hasSize(2)
+        assertThat(prompts[0]).contains("Helpfulness", "Was the assistant helpful?")
+        assertThat(prompts[1]).contains("Tone", "Was the tone appropriate?")
+    }
 }

--- a/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDslTest.kt
+++ b/dokimos-kotlin/src/test/kotlin/dev/dokimos/kotlin/dsl/evaluators/EvaluatorDslTest.kt
@@ -8,6 +8,7 @@ import dev.dokimos.core.JudgeLM
 import dev.dokimos.core.MatchingStrategy
 import dev.dokimos.core.agents.ToolCall
 import dev.dokimos.core.agents.ToolDefinition
+import dev.dokimos.core.evaluators.StructuralMatchMode
 import dev.dokimos.core.evaluators.agents.ArgMatchMode
 import dev.dokimos.core.evaluators.agents.ArgumentMatcher
 import dev.dokimos.core.evaluators.agents.ToolCorrectnessEvaluator
@@ -22,6 +23,7 @@ import dev.dokimos.kotlin.dsl.planAdherence
 import dev.dokimos.kotlin.dsl.planQuality
 import dev.dokimos.kotlin.dsl.precision
 import dev.dokimos.kotlin.dsl.recall
+import dev.dokimos.kotlin.dsl.structuralMatch
 import dev.dokimos.kotlin.dsl.toolCallValidity
 import dev.dokimos.kotlin.dsl.toolCorrectness
 import dev.dokimos.kotlin.dsl.toolDescriptionReliability
@@ -504,5 +506,46 @@ class EvaluatorDslTest {
 
         assertThat(result.score()).isEqualTo(1.0)
         assertThat(result.success()).isTrue()
+    }
+
+    @Test
+    fun `structuralMatch DSL compares JSON structures`() {
+        val strict = structuralMatch {
+            outputKey = "payload"
+            mode = StructuralMatchMode.STRICT
+        }
+        val lenient = structuralMatch {
+            outputKey = "payload"
+            mode = StructuralMatchMode.LENIENT
+        }
+
+        val testCase = EvalTestCase.builder()
+            .actualOutput("payload", """{"name":"Lagavulin","age":16,"region":"Islay"}""")
+            .expectedOutput("payload", """{"name":"Lagavulin","age":16.0}""")
+            .build()
+
+        // LENIENT ignores the extra "region" field; STRICT penalizes it
+        assertThat(lenient.evaluate(testCase).score()).isEqualTo(1.0)
+        assertThat(strict.evaluate(testCase).score()).isLessThan(1.0)
+    }
+
+    @Test
+    fun `structuralMatch DSL supports binary scoring inside evaluators block`() {
+        val built = evaluators {
+            structuralMatch {
+                name = "Contract"
+                binary = true
+            }
+        }
+
+        val testCase = EvalTestCase.builder()
+            .actualOutput("output", """{"a":1,"b":2}""")
+            .expectedOutput("output", """{"a":1,"b":3}""")
+            .build()
+
+        val result = built.single().evaluate(testCase)
+
+        assertThat(result.name()).isEqualTo("Contract")
+        assertThat(result.score()).isEqualTo(0.0)
     }
 }


### PR DESCRIPTION
## Summary

The Kotlin DSL (`dokimos-kotlin`) had fallen behind `dokimos-core`'s agent, structural-match, measured-task, and regression-gate additions, forcing Kotlin callers back to Java builders for those areas. This closes the gaps:

- **`dev.dokimos.kotlin.dsl.agents`** (new): `tools { }` / `toolDefinition(name) { }` with a typed `parameters { }` JSON-schema builder (`string`/`integer`/`number`/`boolean`/`array`/`object`, `required`, `enum`, `additionalProperties`), `toolCall(name) { }` / `toolCalls { }` (including `resultJson(...)`), `agentTrace { }`, and `agentTestCase { }`. `agentTestCase` delegates the shared slots to `AgentEvalCase` and adds what it doesn't cover: the final response, `reasoningSteps` (read by `planQuality`/`planAdherence`), and `constraints` (read by `taskCompletion`).
- **`structuralMatch { }`** for `StructuralMatchEvaluator`, standalone and inside `evaluators { }`.
- **`measuredTask { }`** and `autoCloseReporter` on `ExperimentDsl`, plus a top-level `measuredTask { }`. Setting both `task` and `measuredTask` now fails fast, matching the single underlying slot on `Experiment.Builder`.
- **`criterion(name, description, weight)`** helper for `trajectoryEvaluator { }`.
- **`dev.dokimos.kotlin.dsl.gate`** (new): `gateConfig { }` builds a `GateConfig` starting from `GateConfig.defaults()`, plus an inline-block `ExperimentResult.assertNoRegression(baseline) { ... }` overload.
- Docs updated (`agent-evaluation.md`, `evaluators.md`, `experiments.md`, `regression-gate.md`, `dokimos-kotlin/README.md`) and a new runnable `AgentEvaluationKotlinExample.kt` mirroring the existing Java example.

## Test plan

- [x] `mvn -pl dokimos-kotlin test` — 89 tests pass (18 new: 12 agent DSL, 2 structural match, 3 measured-task, 1 criterion helper, plus 6 in `GateExtTest` for the gate DSL)
- [x] `mvn -pl dokimos-core,dokimos-kotlin,dokimos-examples -am install` — reactor build succeeds, no failures
- [x] `mvn spotless:check` — clean
- [x] Ran `AgentEvaluationKotlinExample` directly; all six offline agent evaluators PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)